### PR TITLE
Monorepo updates to main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,39 @@
-# PowerSync React Native SDK
+<p align="center">
+  <a href="https://www.powersync.com" target="_blank"><img src="https://github.com/powersync-ja/.github/assets/19345049/602bafa0-41ce-4cee-a432-56848c278722"/></a>
+</p>
 
-Monorepo for all things React Native and PowerSync.
+PowerSync is a service and set of SDKs that keeps Postgres databases in sync with on-device SQLite databases.
 
-## Monorepo Structure
+# PowerSync JavaScript SDKs
 
-- [packages/powersync-sdk-common](./packages/powersync-sdk-common/README.md)
-  - A TypeScript implementation of a PowerSync database connector and streaming sync bucket implementation.
+`powersync-js` is the monorepo for PowerSync JavaScript SDKs.
+
+## Monorepo Structure: Packages
 
 - [packages/powersync-sdk-react-native](./packages/powersync-sdk-react-native/README.md)
-  - An extension of `packages/powersync-sdk-common` which provides React Native specific implementations of abstracted features.
+  - React Native SDK implementation (extension of `packages/powersync-sdk-common`)
+ 
+- [packages/powersync-sdk-web](./packages/powersync-sdk-web/README.md)
+  - JS Web SDK implementation (extension of `packages/powersync-sdk-common`)
+ 
+- [packages/powersync-react](./packages/powersync-react/README.md)
+  - React integration for PowerSync.
 
-- [apps/supabase-todolist](https://github.com/powersync-ja/powersync-supabase-react-native-todolist-demo)
-  - An Expo React Native demo app using Supabase.
+- [packages/powersync-attachments](./packages/powersync-attachments/README.md)
+  - Attachments helper package for React Native.
+ 
+- [packages/powersync-sdk-common](./packages/powersync-sdk-common/README.md)
+  - Shared package: TypeScript implementation of a PowerSync database connector and streaming sync bucket implementation.
+
+## Demo Apps / Example Projects
+
+Demo applications are located in the [`demos/`](./demos/) directory.
+
+ - [demos/nextjs-supabase-todolist](./demos/nextjs-supabase-todolist/): A Next.js to-do list example app using the PowerSync Web SDK and a Supabase backend.
+ - [demos/yjs-nextjs-supabase-text-collab](./demos/yjs-nextjs-supabase-text-collab/README.md): A Next.js real-time text editing collaboration example app powered by [Yjs]((https://github.com/yjs/yjs)) CRDTs and [Tiptap](https://tiptap.dev/), using the PowerSync Web SDK and a Supabase backend.
+ - [demos/react-native-supabase-todolist](./demos/react-native-supabase-todolist) A React Native to-do list example app using a Supabase backend.
+ - [demos/example-webpack](./demos/example-webpack/README.md) contains a minimal example demonstrating bundling with Webpack.
+ - [demos/example-vite](./demos/example-vite/README.md) contains a minimal example demonstrating bundling with Vite.
 
 # Development
 
@@ -57,6 +79,8 @@ Merging a PR with Changesets will automatically create a PR with version bumps. 
 
 ## React Native Quick SQLite Development
 
+The PowerSync React Native SDK uses [a fork of react-native-quick-sqlite](https://github.com/powersync-ja/react-native-quick-sqlite)
+
 Testing live development changes to `@journeyapps/react-native-quick-sqlite` will not work with standard `yarn link` commands. Metro does not work well with symlinks <https://github.com/facebook/metro/issues/286>.
 
 The process of releasing development packages for `@journeyapps/react-native-quick-sqlite` for each change can be tedious and slow. A faster (and hackier) method is to use [mtsl](https://www.npmjs.com/package/mtsl) which will watch and copy the package into this workspace's `node_modules`.
@@ -71,16 +95,4 @@ mtsl add -s "[source path to your react-native-quick-sqlite repo folder]" -d "[t
 
 ```bash
 mtsl start "[the id returned from step above]"
-```
-
-## Testing Supabase example app
-
-``` bash
-cd apps/supabase-todolist
-```
-
-Test on either Android or iOS
-
-```bash
-pnpm ios
 ```


### PR DESCRIPTION
Rename the main README of powersync-js to be no longer describe the repo as being for React Native only