### PR TITLE
OpenJDK 21

### DIFF
--- a/demos/react-native-supabase-todolist/android/build.gradle
+++ b/demos/react-native-supabase-todolist/android/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle')
+        classpath('com.android.tools.build:gradle:8.2.2')
         classpath('com.facebook.react:react-native-gradle-plugin')
     }
 }

--- a/demos/react-native-supabase-todolist/android/gradle/wrapper/gradle-wrapper.properties
+++ b/demos/react-native-supabase-todolist/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
`com.facebook.react:react-native-gradle-plugin` currently depends on `com.android.tools.build:gradle:8.1.1`. This updates it to 8.2.2, to support OpenJDK 21. (OpenJDK 22+ is not supported by the current Gradle release yet).

This version bump should be included in react-native 0.74 when released: https://github.com/facebook/react-native/commit/a7586947d719a9cd2344ad346d271e7ca900de87

Upstream issue fixed by the update: https://issuetracker.google.com/issues/294137077

Fixes #55.


