### PR TITLE
[Fix] Shared sync

### DIFF
--- a/.changeset/pink-rings-retire.md
+++ b/.changeset/pink-rings-retire.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-sdk-web': patch
+---
+
+Fixed issue on NextJS 14.1.0 where shared sync web worker would fail to initialize.

--- a/.changeset/sharp-meals-join.md
+++ b/.changeset/sharp-meals-join.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-sdk-common': patch
+---
+
+Improve `AbstractPowerSyncDatabase.getCrudBatch` should use a `readLock` instead of using `database.execute`.

--- a/.changeset/sharp-meals-join.md
+++ b/.changeset/sharp-meals-join.md
@@ -2,4 +2,4 @@
 '@journeyapps/powersync-sdk-common': patch
 ---
 
-Improve `AbstractPowerSyncDatabase.getCrudBatch` should use a `readLock` instead of using `database.execute`.
+Improve `AbstractPowerSyncDatabase.getCrudBatch` should use a `getAll` instead of using `database.execute`.

--- a/.changeset/small-pianos-clap.md
+++ b/.changeset/small-pianos-clap.md
@@ -1,0 +1,6 @@
+---
+'@journeyapps/powersync-sdk-common': patch
+---
+
+Removed `object-hash` package as a dependency as this caused issues with NextJs 14.1.0.
+Added `equals` method on `CrudEntry` class to better align comparison operations with Javascript.

--- a/packages/powersync-sdk-common/package.json
+++ b/packages/powersync-sdk-common/package.json
@@ -31,13 +31,11 @@
     "event-iterator": "^2.0.0",
     "js-logger": "^1.6.1",
     "lodash": "^4.17.21",
-    "object-hash": "^3.0.0",
     "uuid": "^3.0.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.197",
     "@types/node": "^20.5.9",
-    "@types/object-hash": "^3.0.4",
     "@types/uuid": "^3.0.0",
     "typescript": "^5.1.3"
   }

--- a/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
@@ -352,28 +352,26 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
    * and a single transaction may be split over multiple batches.
    */
   async getCrudBatch(limit: number): Promise<CrudBatch | null> {
-    return this.readLock(async (db) => {
-      const result = await db.getAll<CrudEntryJSON>(
-        `SELECT id, tx_id, data FROM ${PSInternalTable.CRUD} ORDER BY id ASC LIMIT ?`,
-        [limit + 1]
-      );
+    const result = await this.getAll<CrudEntryJSON>(
+      `SELECT id, tx_id, data FROM ${PSInternalTable.CRUD} ORDER BY id ASC LIMIT ?`,
+      [limit + 1]
+    );
 
-      const all: CrudEntry[] = result.map((row) => CrudEntry.fromRow(row)) ?? [];
+    const all: CrudEntry[] = result.map((row) => CrudEntry.fromRow(row)) ?? [];
 
-      let haveMore = false;
-      if (all.length > limit) {
-        all.pop();
-        haveMore = true;
-      }
-      if (all.length == 0) {
-        return null;
-      }
+    let haveMore = false;
+    if (all.length > limit) {
+      all.pop();
+      haveMore = true;
+    }
+    if (all.length == 0) {
+      return null;
+    }
 
-      const last = all[all.length - 1];
-      return new CrudBatch(all, haveMore, async (writeCheckpoint?: string) =>
-        this.handleCrudCheckpoint(last.clientId, writeCheckpoint)
-      );
-    });
+    const last = all[all.length - 1];
+    return new CrudBatch(all, haveMore, async (writeCheckpoint?: string) =>
+      this.handleCrudCheckpoint(last.clientId, writeCheckpoint)
+    );
   }
 
   /**

--- a/packages/powersync-sdk-common/src/client/sync/bucket/CrudEntry.ts
+++ b/packages/powersync-sdk-common/src/client/sync/bucket/CrudEntry.ts
@@ -1,4 +1,4 @@
-import hash from 'object-hash';
+import _ from 'lodash';
 
 /**
  * 64-bit unsigned integer stored as a string in base-10.
@@ -108,10 +108,24 @@ export class CrudEntry {
     };
   }
 
+  equals(entry: CrudEntry) {
+    return _.isEqual(this.toComparisonArray(), entry.toComparisonArray());
+  }
+
   /**
    * The hash code for this object.
+   * @deprecated This should not be necessary in the JS SDK.
+   * Use the  @see CrudEntry#equals method instead.
+   * TODO remove in the next major release.
    */
   hashCode() {
-    return hash([this.transactionId, this.clientId, this.op, this.table, this.id, this.opData]);
+    return JSON.stringify(this.toComparisonArray());
+  }
+
+  /**
+   * Generates an array for use in deep comparison operations
+   */
+  toComparisonArray() {
+    return [this.transactionId, this.clientId, this.op, this.table, this.id, this.opData];
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -806,9 +806,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      object-hash:
-        specifier: ^3.0.0
-        version: 3.0.0
       uuid:
         specifier: ^3.0.0
         version: 3.4.0
@@ -819,9 +816,6 @@ importers:
       '@types/node':
         specifier: ^20.5.9
         version: 20.11.17
-      '@types/object-hash':
-        specifier: ^3.0.4
-        version: 3.0.6
       '@types/uuid':
         specifier: ^3.0.0
         version: 3.4.11
@@ -10723,10 +10717,6 @@ packages:
 
   /@types/normalize-package-data@2.4.4:
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
-    dev: true
-
-  /@types/object-hash@3.0.6:
-    resolution: {integrity: sha512-fOBV8C1FIu2ELinoILQ+ApxcUKz4ngq+IWUYrxSGjXzzjUALijilampwkMgEtJ+h2njAW3pi853QpzNVCHB73w==}
     dev: true
 
   /@types/object.omit@3.0.3:


### PR DESCRIPTION
# Description
It was recently discovered in the YJS NextJS demo app that watched uploads would take long to trigger if multiple Powersync instances were created for the same DB. This was due to the sync status not being correctly shared between the (multiple) instances. The second instance would not trigger uploads since it did not know a connection to the PowerSync instance was established by the first instance. 

This same issue would manifest itself in regular apps (with a single instance per tab). Sync statuses between multiple tabs would not be shared. Subsequently opened tabs would remain in `connected: false` mode. 

The root cause of this issue was that the `SharedSyncImplementation.worker.ts` shared worker failed to run and share syncing information between tabs and instances. The worker thew an exception when trying to access the `window` object in the global worker scope. The `window` object is not directly used in this worker codebase, but it is tested against in the `object-hash` library. The issue seems to be cause from bumping the NextJS version to `14.1.0`. [This](https://github.com/vercel/next.js/issues/60644) issue mentioned that versions after `14.0.0` can incorrectly compile checks on `window` objects. This issue seems to be resolved here https://github.com/vercel/next.js/commit/cfedc529c713e66fefd51df9c8e226b2ddfd95ad. For better compatibility the `object-hash` library is removed since it's not actually needed. This fixes the shared worker from trying to access `window`. 

# Testing

Functionality was confirmed for the YJS demo app and React Native Todolist apps.


https://github.com/powersync-ja/powersync-js/assets/51082125/534d2237-fb43-42a6-a9ad-764a733a17e5



