### PR TITLE
 Remove lodash (mostly)

### DIFF
--- a/packages/powersync-sdk-common/src/client/sync/bucket/CrudEntry.ts
+++ b/packages/powersync-sdk-common/src/client/sync/bucket/CrudEntry.ts
@@ -1,5 +1,3 @@
-import isEqual from 'lodash/isEqual';
-
 /**
  * 64-bit unsigned integer stored as a string in base-10.
  *
@@ -109,7 +107,7 @@ export class CrudEntry {
   }
 
   equals(entry: CrudEntry) {
-    return isEqual(this.toComparisonArray(), entry.toComparisonArray());
+    return JSON.stringify(this.toComparisonArray()) == JSON.stringify(entry.toComparisonArray());
   }
 
   /**

--- a/packages/powersync-sdk-common/src/client/sync/bucket/CrudEntry.ts
+++ b/packages/powersync-sdk-common/src/client/sync/bucket/CrudEntry.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 /**
  * 64-bit unsigned integer stored as a string in base-10.
@@ -109,7 +109,7 @@ export class CrudEntry {
   }
 
   equals(entry: CrudEntry) {
-    return _.isEqual(this.toComparisonArray(), entry.toComparisonArray());
+    return isEqual(this.toComparisonArray(), entry.toComparisonArray());
   }
 
   /**

--- a/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/powersync-sdk-common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -1,5 +1,4 @@
 import throttle from 'lodash/throttle';
-import defer from 'lodash/defer';
 
 import Logger, { ILogger } from 'js-logger';
 
@@ -226,7 +225,7 @@ export abstract class AbstractStreamingSyncImplementation extends BaseObserver<S
           // A connection is active and messages are being received
           if (!this.syncStatus.connected) {
             // There is a connection now
-            defer(() => this.triggerCrudUpload());
+            Promise.resolve().then(() => this.triggerCrudUpload());
             this.updateSyncStatus({
               connected: true
             });

--- a/packages/powersync-sdk-common/src/db/crud/SyncStatus.ts
+++ b/packages/powersync-sdk-common/src/db/crud/SyncStatus.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 export type SyncDataFlowStatus = Partial<{
   downloading: boolean;
@@ -49,7 +49,7 @@ export class SyncStatus {
   }
 
   isEqual(status: SyncStatus) {
-    return _.isEqual(this.options, status.options);
+    return isEqual(this.options, status.options);
   }
 
   getMessage() {

--- a/packages/powersync-sdk-common/src/db/crud/SyncStatus.ts
+++ b/packages/powersync-sdk-common/src/db/crud/SyncStatus.ts
@@ -1,5 +1,3 @@
-import isEqual from 'lodash/isEqual';
-
 export type SyncDataFlowStatus = Partial<{
   downloading: boolean;
   uploading: boolean;
@@ -49,7 +47,7 @@ export class SyncStatus {
   }
 
   isEqual(status: SyncStatus) {
-    return isEqual(this.options, status.options);
+    return JSON.stringify(this.options) == JSON.stringify(status.options);
   }
 
   getMessage() {

--- a/packages/powersync-sdk-common/src/db/schema/Table.ts
+++ b/packages/powersync-sdk-common/src/db/schema/Table.ts
@@ -1,4 +1,3 @@
-import _, { indexOf } from 'lodash';
 import { Column } from '../Column';
 import type { Index } from './Index';
 import { TableV2 } from './TableV2';
@@ -86,10 +85,13 @@ export class Table {
   }
 
   get validName() {
-    return _.chain([this.name, this.viewNameOverride])
-      .compact()
-      .every((name) => !InvalidSQLCharacters.test(name))
-      .value();
+    if (InvalidSQLCharacters.test(this.name)) {
+      return false;
+    }
+    if (this.viewNameOverride != null && InvalidSQLCharacters.test(this.viewNameOverride)) {
+      return false;
+    }
+    return true;
   }
 
   validate() {

--- a/packages/powersync-sdk-web/src/db/adapters/AbstractWebPowerSyncDatabaseOpenFactory.ts
+++ b/packages/powersync-sdk-web/src/db/adapters/AbstractWebPowerSyncDatabaseOpenFactory.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import {
   AbstractPowerSyncDatabase,
   AbstractPowerSyncDatabaseOpenFactory,
@@ -73,10 +72,14 @@ export abstract class AbstractWebPowerSyncDatabaseOpenFactory extends AbstractPo
   }
 
   protected resolveDBFlags(): WebPowerSyncFlags {
-    return _.merge(_.clone(DEFAULT_POWERSYNC_FLAGS), {
-      ssrMode: this.isServerSide(),
-      enableMultiTabs: this.options.flags?.enableMultiTabs
-    });
+    let flags = {
+      ...DEFAULT_POWERSYNC_FLAGS,
+      ssrMode: this.isServerSide()
+    };
+    if (typeof this.options.flags?.enableMultiTabs != 'undefined') {
+      flags.enableMultiTabs = this.options.flags.enableMultiTabs;
+    }
+    return flags;
   }
 
   generateInstance(options: PowerSyncDatabaseOptions): AbstractPowerSyncDatabase {

--- a/packages/powersync-sdk-web/src/db/sync/SSRWebStreamingSyncImplementation.ts
+++ b/packages/powersync-sdk-web/src/db/sync/SSRWebStreamingSyncImplementation.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import {
   AbstractStreamingSyncImplementation,
   AbstractStreamingSyncImplementationOptions,

--- a/packages/powersync-sdk-web/src/db/sync/SharedWebStreamingSyncImplementation.ts
+++ b/packages/powersync-sdk-web/src/db/sync/SharedWebStreamingSyncImplementation.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { v4 as uuid } from 'uuid';
 import * as Comlink from 'comlink';
 import {

--- a/packages/powersync-sdk-web/src/db/sync/WebStreamingSyncImplementation.ts
+++ b/packages/powersync-sdk-web/src/db/sync/WebStreamingSyncImplementation.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import {
   AbstractStreamingSyncImplementation,
   AbstractStreamingSyncImplementationOptions,

--- a/packages/powersync-sdk-web/src/worker/db/open-db.ts
+++ b/packages/powersync-sdk-web/src/worker/db/open-db.ts
@@ -1,6 +1,5 @@
 import * as SQLite from '@journeyapps/wa-sqlite';
 import '@journeyapps/wa-sqlite';
-import _ from 'lodash';
 import * as Comlink from 'comlink';
 import { v4 as uuid } from 'uuid';
 import { QueryResult } from '@journeyapps/powersync-sdk-common';
@@ -93,21 +92,16 @@ export async function _openDB(dbFileName: string): Promise<DBWorkerInterface> {
         }
       }
 
-      const rows = _.chain(results)
-        .filter(({ rows }) => !!rows.length)
-        .flatMap(({ columns, rows }) =>
-          _.map(rows, (row) =>
-            _.reduce(
-              columns,
-              (out: Record<string, any>, key: string, index) => {
-                out[key] = row[index];
-                return out;
-              },
-              {}
-            )
-          )
-        )
-        .value();
+      let rows: Record<string, any>[] = [];
+      for (let resultset of results) {
+        for (let row of resultset.rows) {
+          let outRow: Record<string, any> = {};
+          resultset.columns.forEach((key, index) => {
+            outRow[key] = row[index];
+          });
+          rows.push(outRow);
+        }
+      }
 
       const result = {
         insertId: sqlite3.last_insert_id(db),

--- a/packages/powersync-sdk-web/src/worker/sync/SharedSyncImplementation.ts
+++ b/packages/powersync-sdk-web/src/worker/sync/SharedSyncImplementation.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { BaseListener, BaseObserver, SyncStatusOptions } from '@journeyapps/powersync-sdk-common';
 
 export enum SharedSyncMessageType {
@@ -38,7 +37,10 @@ export class SharedSyncImplementation extends BaseObserver<SharedSyncImplementat
   }
 
   updateState(status: SharedSyncStatus) {
-    this.status = _.merge(this.status, status);
+    this.status = {
+      ...this.status,
+      ...status
+    };
     this.iterateListeners((cb) => cb.statusChanged?.(status));
   }
 }

--- a/packages/powersync-sdk-web/tests/crud.test.ts
+++ b/packages/powersync-sdk-web/tests/crud.test.ts
@@ -163,8 +163,8 @@ describe('CRUD Tests', () => {
     const tx = (await powersync.getNextCrudTransaction())!;
     expect(tx.transactionId).equals(1);
     const expectedCrudEntry = new CrudEntry(1, UpdateType.PUT, 'logs', testId, 1, {
-      level: 'INFO',
-      content: 'test log'
+      content: 'test log',
+      level: 'INFO'
     });
     expect(tx.crud[0].equals(expectedCrudEntry)).true;
   });


### PR DESCRIPTION
Remove lodash imports to decrease bundle size. Changes the bundle size of example-vite from 127kB -> 56kB. (This excludes the web workers and SQLite WASM build, but those can be loaded asynchronously).

The only remaining import in the core SDKs is `lodash/throttle`.

The updated code is not quite equivalent to the previous lodash version, so it needs some testing.
