### PR TITLE
POC: Suspense for usePowerSyncWatchedQuery

### DIFF
--- a/demos/react-supabase-todolist/package.json
+++ b/demos/react-supabase-todolist/package.json
@@ -19,6 +19,7 @@
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.13",
     "react-router-dom": "^6.22.3"
   },
   "devDependencies": {

--- a/demos/react-supabase-todolist/src/app/index.tsx
+++ b/demos/react-supabase-todolist/src/app/index.tsx
@@ -8,9 +8,11 @@ const root = createRoot(document.getElementById('app')!);
 root.render(<App />);
 
 export function App() {
-  return <ThemeProviderContainer>
-    <SystemProvider>
-      <RouterProvider router={router} />
-    </SystemProvider>
-  </ThemeProviderContainer>;
+  return (
+    <ThemeProviderContainer>
+      <SystemProvider>
+        <RouterProvider router={router} future={{ v7_startTransition: true }} />
+      </SystemProvider>
+    </ThemeProviderContainer>
+  );
 }

--- a/demos/react-supabase-todolist/src/app/router.tsx
+++ b/demos/react-supabase-todolist/src/app/router.tsx
@@ -2,10 +2,10 @@ import { Outlet, createBrowserRouter } from "react-router-dom";
 import LoginPage from "./auth/login/page";
 import RegisterPage from "./auth/register/page";
 import EntryPage from "./page";
-import TodoEditPage from "./views/todo-lists/edit/page";
-import TodoListsPage from "./views/todo-lists/page";
 import ViewsLayout from "./views/layout";
 import SQLConsolePage from "./views/sql-console/page";
+import TodoEditPage from "./views/todo-lists/edit/page";
+import TodoListsPage from "./views/todo-lists/page";
 
 export const TODO_LISTS_ROUTE = '/views/todo-lists';
 export const TODO_EDIT_ROUTE = '/views/todo-lists/:id';

--- a/demos/react-supabase-todolist/src/app/views/layout.tsx
+++ b/demos/react-supabase-todolist/src/app/views/layout.tsx
@@ -21,7 +21,7 @@ import {
   Typography,
   styled
 } from '@mui/material';
-import React from 'react';
+import React, { Suspense } from 'react';
 
 import { useNavigationPanel } from '@/components/navigation/NavigationPanelContext';
 import { useSupabase } from '@/components/providers/SystemProvider';
@@ -118,7 +118,9 @@ export default function ViewsLayout({ children }: { children: React.ReactNode })
         </List>
       </Drawer>
       <S.MainBox>
-        {children}
+        <Suspense>
+          {children}
+        </Suspense>
       </S.MainBox>
     </S.MainBox>
   );

--- a/demos/react-supabase-todolist/src/app/views/sql-console/page.tsx
+++ b/demos/react-supabase-todolist/src/app/views/sql-console/page.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { usePowerSyncWatchedQuery } from '@journeyapps/powersync-react';
-import { Box, Button, Grid, TextField, styled } from '@mui/material';
+import { Box, Button, CircularProgress, Grid, TextField, styled } from '@mui/material';
 import { DataGrid } from '@mui/x-data-grid';
 import { NavigationPage } from '@/components/navigation/NavigationPage';
+
+import { ErrorBoundary } from "react-error-boundary";
 
 export type LoginFormParams = {
   email: string;
@@ -14,21 +16,6 @@ const DEFAULT_QUERY = 'SELECT * FROM lists';
 export default function SQLConsolePage() {
   const inputRef = React.useRef<HTMLInputElement>();
   const [query, setQuery] = React.useState(DEFAULT_QUERY);
-  const querySQLResult = usePowerSyncWatchedQuery(query);
-
-  const queryDataGridResult = React.useMemo(() => {
-    const firstItem = querySQLResult?.[0];
-
-    return {
-      columns: firstItem
-        ? Object.keys(firstItem).map((field) => ({
-          field,
-          flex: 1
-        }))
-        : [],
-      rows: querySQLResult
-    };
-  }, [querySQLResult]);
 
   return (
     <NavigationPage title="SQL Console">
@@ -64,30 +51,66 @@ export default function SQLConsolePage() {
           </S.CenteredGrid>
         </S.CenteredGrid>
 
-        {queryDataGridResult ? (
-          <S.QueryResultContainer>
-            {queryDataGridResult.columns ? (
-              <DataGrid
-                autoHeight={true}
-                rows={queryDataGridResult.rows?.map((r, index) => ({ ...r, id: r.id ?? index })) ?? []}
-                columns={queryDataGridResult.columns}
-                initialState={{
-                  pagination: {
-                    paginationModel: {
-                      pageSize: 20
-                    }
-                  }
-                }}
-                pageSizeOptions={[20]}
-                disableRowSelectionOnClick
-              />
-            ) : null}
-          </S.QueryResultContainer>
-        ) : null}
+        <Suspense fallback={<CircularProgress />}>
+          {/* Use resetKeys to dismiss the error when changing the query. */}
+          <ErrorBoundary
+            fallbackRender={fallbackRender} resetKeys={[query]}>
+            <SqlConsoleResults query={query} />
+          </ErrorBoundary>
+        </Suspense>
+
       </S.MainContainer>
     </NavigationPage>
   );
 }
+
+function SqlConsoleResults(props: { query: string }) {
+  const querySQLResult = usePowerSyncWatchedQuery(props.query);
+
+  const queryDataGridResult = React.useMemo(() => {
+    const firstItem = querySQLResult?.[0];
+
+    return {
+      columns: firstItem
+        ? Object.keys(firstItem).map((field) => ({
+          field,
+          flex: 1
+        }))
+        : [],
+      rows: querySQLResult
+    };
+  }, [querySQLResult]);
+
+  return queryDataGridResult ? (
+    <S.QueryResultContainer>
+      {queryDataGridResult.columns ? (
+        <DataGrid
+          autoHeight={true}
+          rows={queryDataGridResult.rows?.map((r, index) => ({ ...r, id: r.id ?? index })) ?? []}
+          columns={queryDataGridResult.columns}
+          initialState={{
+            pagination: {
+              paginationModel: {
+                pageSize: 20
+              }
+            }
+          }}
+          pageSizeOptions={[20]}
+          disableRowSelectionOnClick
+        />
+      ) : null}
+    </S.QueryResultContainer>
+  ) : null
+}
+
+function fallbackRender(options: { error: any }) {
+  return (
+    <div role="alert">
+      <pre style={{ color: "red" }}>{options.error.message}</pre>
+    </div>
+  );
+}
+
 
 namespace S {
   export const MainContainer = styled(Box)`

--- a/demos/react-supabase-todolist/src/app/views/todo-lists/edit/page.tsx
+++ b/demos/react-supabase-todolist/src/app/views/todo-lists/edit/page.tsx
@@ -1,26 +1,27 @@
+import { NavigationPage } from '@/components/navigation/NavigationPage';
 import { useSupabase } from '@/components/providers/SystemProvider';
 import { TodoItemWidget } from '@/components/widgets/TodoItemWidget';
+import { TodoListsWidget } from '@/components/widgets/TodoListsWidget';
 import { LISTS_TABLE, TODOS_TABLE, TodoRecord } from '@/library/powersync/AppSchema';
 import { usePowerSync, usePowerSyncWatchedQuery } from '@journeyapps/powersync-react';
 import AddIcon from '@mui/icons-material/Add';
 import {
   Box,
   Button,
-  CircularProgress,
   Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
   DialogTitle,
+  Grid,
   List,
   TextField,
   Typography,
   styled
 } from '@mui/material';
 import Fab from '@mui/material/Fab';
-import React, { Suspense } from 'react';
+import React from 'react';
 import { useParams } from 'react-router-dom';
-import { NavigationPage } from '@/components/navigation/NavigationPage';
 
 /**
  * useSearchParams causes the entire element to fall back to client side rendering
@@ -35,7 +36,6 @@ const TodoEditSection = () => {
   const [listRecord] = usePowerSyncWatchedQuery<{ name: string }>(`SELECT name FROM ${LISTS_TABLE} WHERE id = ?`, [
     listID
   ]);
-
   const todos = usePowerSyncWatchedQuery<TodoRecord>(
     `SELECT * FROM ${TODOS_TABLE} WHERE list_id=? ORDER BY created_at DESC, id`,
     [listID]
@@ -104,17 +104,24 @@ const TodoEditSection = () => {
           <AddIcon />
         </S.FloatingActionButton>
         <Box>
-          <List dense={false}>
-            {todos.map((r) => (
-              <TodoItemWidget
-                key={r.id}
-                description={r.description}
-                onDelete={() => deleteTodo(r.id)}
-                isComplete={r.completed == 1}
-                toggleCompletion={() => toggleCompletion(r, !r.completed)}
-              />
-            ))}
-          </List>
+          <Grid container spacing={2}>
+            <Grid item xs={4}>
+              <TodoListsWidget selectedId={listID} />
+            </Grid>
+            <Grid item xs={8}>
+              <List dense={false}>
+                {todos.map((r) => (
+                  <TodoItemWidget
+                    key={r.id}
+                    description={r.description}
+                    onDelete={() => deleteTodo(r.id)}
+                    isComplete={r.completed == 1}
+                    toggleCompletion={() => toggleCompletion(r, !r.completed)}
+                  />
+                ))}
+              </List>
+            </Grid>
+          </Grid>
         </Box>
         {/* TODO use a dialog service in future, this is just a simple example app */}
         <Dialog
@@ -152,9 +159,7 @@ const TodoEditSection = () => {
 export default function TodoEditPage() {
   return (
     <Box>
-      <Suspense fallback={<CircularProgress />}>
-        <TodoEditSection />
-      </Suspense>
+      <TodoEditSection />
     </Box>
   );
 }

--- a/demos/react-supabase-todolist/src/app/views/todo-lists/page.tsx
+++ b/demos/react-supabase-todolist/src/app/views/todo-lists/page.tsx
@@ -1,3 +1,7 @@
+import { NavigationPage } from '@/components/navigation/NavigationPage';
+import { useSupabase } from '@/components/providers/SystemProvider';
+import { TodoListsWidget } from '@/components/widgets/TodoListsWidget';
+import { LISTS_TABLE } from '@/library/powersync/AppSchema';
 import { usePowerSync } from '@journeyapps/powersync-react';
 import AddIcon from '@mui/icons-material/Add';
 import {
@@ -13,10 +17,7 @@ import {
 } from '@mui/material';
 import Fab from '@mui/material/Fab';
 import React from 'react';
-import { NavigationPage } from '@/components/navigation/NavigationPage';
-import { useSupabase } from '@/components/providers/SystemProvider';
-import { TodoListsWidget } from '@/components/widgets/TodoListsWidget';
-import { LISTS_TABLE } from '@/library/powersync/AppSchema';
+
 
 export default function TodoListsPage() {
   const powerSync = usePowerSync();

--- a/demos/react-supabase-todolist/src/components/providers/SystemProvider.tsx
+++ b/demos/react-supabase-todolist/src/components/providers/SystemProvider.tsx
@@ -42,7 +42,7 @@ export const SystemProvider = ({ children }: { children: React.ReactNode }) => {
   }, [powerSync, connector]);
 
   return (
-    <Suspense fallback={<CircularProgress />}>
+    <Suspense fallback={<Fallback />}>
       <PowerSyncContext.Provider value={powerSync}>
         <SupabaseContext.Provider value={connector}>
           <NavigationPanelContextProvider>
@@ -53,5 +53,9 @@ export const SystemProvider = ({ children }: { children: React.ReactNode }) => {
     </Suspense>
   );
 };
+
+function Fallback() {
+  return <CircularProgress />;
+}
 
 export default SystemProvider;

--- a/demos/react-supabase-todolist/src/components/providers/SystemProvider.tsx
+++ b/demos/react-supabase-todolist/src/components/providers/SystemProvider.tsx
@@ -42,7 +42,7 @@ export const SystemProvider = ({ children }: { children: React.ReactNode }) => {
   }, [powerSync, connector]);
 
   return (
-    <Suspense fallback={<Fallback />}>
+    <Suspense fallback={<CircularProgress />}>
       <PowerSyncContext.Provider value={powerSync}>
         <SupabaseContext.Provider value={connector}>
           <NavigationPanelContextProvider>
@@ -53,9 +53,5 @@ export const SystemProvider = ({ children }: { children: React.ReactNode }) => {
     </Suspense>
   );
 };
-
-function Fallback() {
-  return <CircularProgress />;
-}
 
 export default SystemProvider;

--- a/demos/react-supabase-todolist/src/components/widgets/TodoListsWidget.tsx
+++ b/demos/react-supabase-todolist/src/components/widgets/TodoListsWidget.tsx
@@ -49,11 +49,7 @@ export function TodoListsWidget(props: TodoListsWidgetProps) {
           selected={r.id == props.selectedId}
           onDelete={() => deleteList(r.id)}
           onPress={() => {
-            // startTransition avoids showing the loader for an instant
-            // when navigating.
-            startTransition(() => {
-              navigate(TODO_LISTS_ROUTE + '/' + r.id);
-            });
+            navigate(TODO_LISTS_ROUTE + '/' + r.id);
           }}
         />
       ))}

--- a/demos/react-supabase-todolist/src/components/widgets/TodoListsWidget.tsx
+++ b/demos/react-supabase-todolist/src/components/widgets/TodoListsWidget.tsx
@@ -1,13 +1,14 @@
 import { TODO_LISTS_ROUTE } from '@/app/router';
 import { LISTS_TABLE, ListRecord, TODOS_TABLE } from '@/library/powersync/AppSchema';
-import { usePowerSync, usePowerSyncWatchedQuery } from "@journeyapps/powersync-react";
-import { List } from "@mui/material";
+import { usePowerSync, usePowerSyncWatchedQuery } from '@journeyapps/powersync-react';
+import { List } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
-import { ListItemWidget } from "./ListItemWidget";
+import { ListItemWidget } from './ListItemWidget';
+import React from 'react';
 
 export type TodoListsWidgetProps = {
   selectedId?: string;
-}
+};
 
 const description = (total: number, completed: number = 0) => {
   return `${total - completed} pending, ${completed} completed`;
@@ -16,6 +17,7 @@ const description = (total: number, completed: number = 0) => {
 export function TodoListsWidget(props: TodoListsWidgetProps) {
   const powerSync = usePowerSync();
   const navigate = useNavigate();
+  const [isPending, startTransition] = React.useTransition();
 
   const listRecords = usePowerSyncWatchedQuery<ListRecord & { total_tasks: number; completed_tasks: number }>(`
       SELECT
@@ -47,7 +49,11 @@ export function TodoListsWidget(props: TodoListsWidgetProps) {
           selected={r.id == props.selectedId}
           onDelete={() => deleteList(r.id)}
           onPress={() => {
-            navigate(TODO_LISTS_ROUTE + '/' + r.id)
+            // startTransition avoids showing the loader for an instant
+            // when navigating.
+            startTransition(() => {
+              navigate(TODO_LISTS_ROUTE + '/' + r.id);
+            });
           }}
         />
       ))}

--- a/demos/react-supabase-todolist/src/components/widgets/TodoListsWidget.tsx
+++ b/demos/react-supabase-todolist/src/components/widgets/TodoListsWidget.tsx
@@ -18,15 +18,15 @@ export function TodoListsWidget(props: TodoListsWidgetProps) {
   const navigate = useNavigate();
 
   const listRecords = usePowerSyncWatchedQuery<ListRecord & { total_tasks: number; completed_tasks: number }>(`
-      SELECT 
+      SELECT
         ${LISTS_TABLE}.*, COUNT(${TODOS_TABLE}.id) AS total_tasks, SUM(CASE WHEN ${TODOS_TABLE}.completed = true THEN 1 ELSE 0 END) as completed_tasks
-      FROM 
+      FROM
         ${LISTS_TABLE}
-      LEFT JOIN ${TODOS_TABLE} 
+      LEFT JOIN ${TODOS_TABLE}
         ON  ${LISTS_TABLE}.id = ${TODOS_TABLE}.list_id
-      GROUP BY 
+      GROUP BY
         ${LISTS_TABLE}.id;
-      `);
+  `);
 
   const deleteList = async (id: string) => {
     await powerSync.writeTransaction(async (tx) => {

--- a/packages/powersync-react/src/QueryStore.ts
+++ b/packages/powersync-react/src/QueryStore.ts
@@ -1,0 +1,35 @@
+import { AbstractPowerSyncDatabase, SQLWatchOptions } from '@journeyapps/powersync-sdk-common';
+import { WatchedQuery } from './WatchedQuery';
+
+export class QueryStore {
+  cache = new Map<string, WatchedQuery>();
+
+  constructor(private db: AbstractPowerSyncDatabase) {}
+
+  getQuery(query: string, parameters: any[], options: SQLWatchOptions) {
+    const key = `${query} -- ${JSON.stringify(parameters)} -- ${JSON.stringify(options)}`;
+    if (this.cache.has(key)) {
+      return this.cache.get(key);
+    }
+    const disposer = () => {
+      this.cache.delete(key);
+    };
+    const q = new WatchedQuery(this.db, query, parameters, options, disposer);
+    this.cache.set(key, q);
+
+    return q;
+  }
+}
+
+let queryStores: WeakMap<AbstractPowerSyncDatabase, QueryStore> | undefined = undefined;
+
+export function getQueryStore(db: AbstractPowerSyncDatabase): QueryStore {
+  queryStores ||= new WeakMap();
+  const existing = queryStores.get(db);
+  if (existing) {
+    return existing;
+  }
+  const store = new QueryStore(db);
+  queryStores.set(db, store);
+  return store;
+}

--- a/packages/powersync-react/src/WatchedQuery.ts
+++ b/packages/powersync-react/src/WatchedQuery.ts
@@ -1,0 +1,140 @@
+import { AbstractPowerSyncDatabase, SQLWatchOptions } from '@journeyapps/powersync-sdk-common';
+
+export class WatchedQuery {
+  listeners = new Set<() => void>();
+
+  readyPromise: Promise<void>;
+  isReady: boolean = false;
+  currentData: any[] | undefined;
+  currentError: any;
+
+  private temporaryHolds = new Set();
+  private controller: AbortController | undefined;
+  private db: AbstractPowerSyncDatabase;
+
+  private resolveReady: undefined | (() => void);
+
+  readonly query: string;
+  readonly parameters: any[];
+  readonly options: SQLWatchOptions;
+  private disposer: () => void;
+
+  constructor(
+    db: AbstractPowerSyncDatabase,
+    query: string,
+    parameters: any[],
+    options: SQLWatchOptions,
+    disposer: () => void
+  ) {
+    this.db = db;
+    this.query = query;
+    this.parameters = parameters;
+    this.options = options;
+    this.disposer = disposer;
+
+    this.readyPromise = new Promise((resolve) => {
+      this.resolveReady = resolve;
+    });
+  }
+
+  addTemporaryHold() {
+    const ref = new Object();
+    this.temporaryHolds.add(ref);
+    this.maybeListen();
+
+    let timeout: any;
+    const release = () => {
+      this.temporaryHolds.delete(ref);
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      this.maybeDispose();
+    };
+
+    timeout = setTimeout(release, 5_000);
+
+    return release;
+  }
+
+  addListener(l: () => void) {
+    this.listeners.add(l);
+
+    this.maybeListen();
+    return () => {
+      this.listeners.delete(l);
+      this.maybeDispose();
+    };
+  }
+
+  private maybeListen() {
+    if (this.controller != null) {
+      return;
+    }
+    if (this.listeners.size == 0 && this.temporaryHolds.size == 0) {
+      return;
+    }
+
+    const controller = new AbortController();
+    this.controller = controller;
+
+    (async () => {
+      try {
+        for await (const result of this.db.watch(this.query, this.parameters, {
+          ...this.options,
+          signal: this.controller.signal
+        })) {
+          const data = result.rows?._array ?? [];
+          this.setData(data);
+        }
+      } catch (e) {
+        console.log('got error', e);
+        this.setError(e);
+      } finally {
+        if (this.controller === controller) {
+          this.controller = undefined;
+        }
+      }
+    })();
+  }
+
+  private setData(results: any[]) {
+    this.isReady = true;
+    this.currentData = results;
+    this.currentError = undefined;
+    this.resolveReady?.();
+
+    for (let listener of this.listeners) {
+      listener();
+    }
+  }
+
+  private setError(error: any) {
+    this.isReady = true;
+    this.currentData = undefined;
+    this.currentError = error;
+    this.resolveReady?.();
+
+    console.log('notify error', error, this.listeners.size);
+
+    for (let listener of this.listeners) {
+      listener();
+    }
+  }
+
+  private maybeDispose() {
+    if (this.listeners.size == 0 && this.temporaryHolds.size == 0) {
+      this.controller?.abort();
+      this.controller = undefined;
+      this.isReady = false;
+      this.currentData = undefined;
+      this.currentError = undefined;
+      this.disposer?.();
+
+      this.readyPromise = new Promise((resolve, reject) => {
+        this.resolveReady = resolve;
+      });
+
+      console.log('disposed', this.query);
+    }
+  }
+}

--- a/packages/powersync-react/src/WatchedQuery.ts
+++ b/packages/powersync-react/src/WatchedQuery.ts
@@ -87,7 +87,6 @@ export class WatchedQuery {
           this.setData(data);
         }
       } catch (e) {
-        console.log('got error', e);
         this.setError(e);
       } finally {
         if (this.controller === controller) {
@@ -114,8 +113,6 @@ export class WatchedQuery {
     this.currentError = error;
     this.resolveReady?.();
 
-    console.log('notify error', error, this.listeners.size);
-
     for (let listener of this.listeners) {
       listener();
     }
@@ -133,8 +130,6 @@ export class WatchedQuery {
       this.readyPromise = new Promise((resolve, reject) => {
         this.resolveReady = resolve;
       });
-
-      console.log('disposed', this.query);
     }
   }
 }

--- a/packages/powersync-react/src/hooks/usePowerSyncWatchedQuery.ts
+++ b/packages/powersync-react/src/hooks/usePowerSyncWatchedQuery.ts
@@ -1,42 +1,59 @@
 import { SQLWatchOptions } from '@journeyapps/powersync-sdk-common';
 import React from 'react';
+import { getQueryStore } from '../QueryStore';
+import { WatchedQuery } from '../WatchedQuery';
 import { usePowerSync } from './PowerSyncContext';
 
 /**
  * A hook to access the results of a watched query.
  */
 export const usePowerSyncWatchedQuery = <T = any>(
-  sqlStatement: string,
+  query: string,
   parameters: any[] = [],
   options: Omit<SQLWatchOptions, 'signal'> = {}
 ): T[] => {
+  let initialResults = [];
+
   const powerSync = usePowerSync();
   if (!powerSync) {
-    return [];
+    return initialResults;
   }
 
-  const memoizedParams = React.useMemo(() => parameters, [...parameters]);
-  const memoizedOptions = React.useMemo(() => options, [JSON.stringify(options)]);
-  const [data, setData] = React.useState<T[]>([]);
-  const abortController = React.useRef(new AbortController());
+  // When the component is suspended, all state is discarded. We don't get
+  // any notification of that. So checkoutQuery reserves a temporary hold
+  // on the query.
+  // Once the component "commits", we exchange that for a permanent hold.
+  const store = getQueryStore(powerSync);
+  const q = store.getQuery(query, parameters, options);
+  const addedHoldTo = React.useRef<WatchedQuery | undefined>(undefined);
+  const releaseTemporaryHold = React.useRef<(() => void) | undefined>(undefined);
+
+  if (addedHoldTo.current !== q) {
+    releaseTemporaryHold.current?.();
+    releaseTemporaryHold.current = q.addTemporaryHold();
+    addedHoldTo.current = q;
+  }
+
+  const [_counter, setUpdateCounter] = React.useState(0);
 
   React.useEffect(() => {
-    // Abort any previous watches
-    abortController.current?.abort();
-    abortController.current = new AbortController();
-    (async () => {
-      for await (const result of powerSync.watch(sqlStatement, parameters, {
-        ...options,
-        signal: abortController.current.signal
-      })) {
-        setData(result.rows?._array ?? []);
-      }
-    })();
+    const dispose = q.addListener(() => {
+      setUpdateCounter((counter) => {
+        return counter + 1;
+      });
+    });
 
-    return () => {
-      abortController.current?.abort();
-    };
-  }, [powerSync, sqlStatement, memoizedParams, memoizedOptions]);
+    releaseTemporaryHold.current?.();
+    releaseTemporaryHold.current = undefined;
 
-  return data;
+    return dispose;
+  }, []);
+
+  if (q.currentError != null) {
+    throw q.currentError;
+  } else if (q.currentData != null) {
+    return q.currentData;
+  } else {
+    throw q.readyPromise;
+  }
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -614,6 +614,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      react-error-boundary:
+        specifier: ^4.0.13
+        version: 4.0.13(react@18.2.0)
       react-router-dom:
         specifier: ^6.22.3
         version: 6.22.3(react-dom@18.2.0)(react@18.2.0)
@@ -9649,8 +9652,8 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.0
       '@emotion/cache': 11.11.0
-      '@emotion/react': 11.11.4(@types/react@18.2.65)(react@18.2.0)
-      '@emotion/styled': 11.11.0(@emotion/react@11.11.4)(@types/react@18.2.65)(react@18.2.0)
+      '@emotion/react': 11.11.4(@types/react@18.2.64)(react@18.2.0)
+      '@emotion/styled': 11.11.0(@emotion/react@11.11.4)(@types/react@18.2.64)(react@18.2.0)
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.2.0
@@ -26912,6 +26915,15 @@ packages:
       react: '>=16.13.1'
     dependencies:
       '@babel/runtime': 7.23.9
+      react: 18.2.0
+    dev: false
+
+  /react-error-boundary@4.0.13(react@18.2.0):
+    resolution: {integrity: sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==}
+    peerDependencies:
+      react: '>=16.13.1'
+    dependencies:
+      '@babel/runtime': 7.24.0
       react: 18.2.0
     dev: false
 


### PR DESCRIPTION
This is an alternative approach to #84 - see the PR for the problem statement.

This uses React [`<Suspense>`](https://react.dev/reference/react/Suspense) to wait until the initial query results have loaded before rendering the component. This makes the `usePowerSyncWatchedQuery` API practically unchanged: Just use `const results = usePowerSyncWatchedQuery(...)` - but without ever getting "loading" results. Instead, you use Suspense and error boundaries to handle loading states and errors, respectively.

The changes to the demo app are primarily:
1. Refactor sql-console page to handle loading and error states.
2. Refactor todo list page to display the list of todos to the left and todos on the right (same as #84).
3. Place `<Suspense/>` in the layout.

~One caveat is that, by default, you now get a loading spinner (the Suspense fallback) for an instant when navigating. [useTransition](https://react.dev/reference/react/useTransition) avoids this, but it's tedious to add to every navigation, and that doesn't handle browser back/forward. Ideally this would be handled by the router, but integrating this with react-router seems tricky.~ Update: react-router has an experimental option `v7_startTransition` that does exactly this.

The implementation is based on Relay's [useLazyLoadQuery](https://relay.dev/docs/api-reference/use-lazy-load-query/) implementation. This approach is called "fetch-on-render", which is typically not recommended for fetching data from a server, since it often causes "waterfall" loading. However, loading from a local database is very fast despite it being asynchronous, so that's not really an issue.

React does make it difficult to implement this pattern. When "suspending" a render, all state is discarded, so you can't keep track of a loading query in the component state. Instead, a "QueryStore" is used here to keep track of watched queries. It uses some workarounds to track queries between the initial suspend and the first actual render. One additional advantage of this approach is that watched queries can now be shared between different components, instead of each re-evaluating the same queries.

