### PR TITLE
[Fix] concurrent connections issue

### DIFF
--- a/.changeset/lemon-zoos-sort.md
+++ b/.changeset/lemon-zoos-sort.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-sdk-web': patch
+---
+
+Added some serialization checks for broadcasted logs from shared web worker. Unserializable items will return a warning.

--- a/.changeset/lucky-planes-prove.md
+++ b/.changeset/lucky-planes-prove.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-sdk-common': patch
+---
+
+Fixed issue where sync stream exceptions would not close previous streaming connections.

--- a/.changeset/modern-terms-admire.md
+++ b/.changeset/modern-terms-admire.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-sdk-web': patch
+---
+
+Fixed issue where SyncBucketStorage logs would not be broadcasted from the shared sync worker to individual tabs.

--- a/packages/powersync-sdk-web/src/db/sync/SharedWebStreamingSyncImplementation.ts
+++ b/packages/powersync-sdk-web/src/db/sync/SharedWebStreamingSyncImplementation.ts
@@ -165,8 +165,6 @@ export class SharedWebStreamingSyncImplementation extends WebStreamingSyncImplem
       data: {}
     };
 
-    (localStorage as any).setItem('posting close' + Math.random(), `$}`);
-
     this.messagePort.postMessage(closeMessagePayload);
 
     // Release the proxy

--- a/packages/powersync-sdk-web/src/worker/sync/BroadcastLogger.ts
+++ b/packages/powersync-sdk-web/src/worker/sync/BroadcastLogger.ts
@@ -79,7 +79,7 @@ export class BroadcastLogger implements ILogger {
 
   /**
    * Guards against any logging errors.
-   * We don't want a logging exception to cause thurther issues upstream
+   * We don't want a logging exception to cause further issues upstream
    */
   private sanitizeArgs(x: any[], handler: (...params: any[]) => void) {
     const sanitizedParams = x.map((param) => {

--- a/packages/powersync-sdk-web/src/worker/sync/BroadcastLogger.ts
+++ b/packages/powersync-sdk-web/src/worker/sync/BroadcastLogger.ts
@@ -40,17 +40,17 @@ export class BroadcastLogger implements ILogger {
 
   log(...x: any[]): void {
     console.log(...x);
-    this.clients.forEach((p) => p.clientProvider.log(...x));
+    this.sanitizeArgs(x, (params) => this.clients.forEach((p) => p.clientProvider.log(...params)));
   }
 
   warn(...x: any[]): void {
     console.warn(...x);
-    this.clients.forEach((p) => p.clientProvider.warn(...x));
+    this.sanitizeArgs(x, (params) => this.clients.forEach((p) => p.clientProvider.warn(...params)));
   }
 
   error(...x: any[]): void {
     console.error(...x);
-    this.clients.forEach((p) => p.clientProvider.error(...x));
+    this.sanitizeArgs(x, (params) => this.clients.forEach((p) => p.clientProvider.error(...params)));
   }
 
   time(label: string): void {
@@ -75,5 +75,23 @@ export class BroadcastLogger implements ILogger {
   enabledFor(level: ILogLevel): boolean {
     // Levels are not adjustable on this level.
     return true;
+  }
+
+  /**
+   * Guards against any logging errors.
+   * We don't want a logging exception to cause thurther issues upstream
+   */
+  private sanitizeArgs(x: any[], handler: (...params: any[]) => void) {
+    const sanitizedParams = x.map((param) => {
+      try {
+        // Try and clone here first. If it fails it won't be passable over a MessagePort
+        return structuredClone(x);
+      } catch (ex) {
+        console.error(ex);
+        return 'Could not serialize log params. Check shared worker logs for more details.';
+      }
+    });
+
+    return handler(...sanitizedParams);
   }
 }

--- a/packages/powersync-sdk-web/src/worker/sync/SharedSyncImplementation.ts
+++ b/packages/powersync-sdk-web/src/worker/sync/SharedSyncImplementation.ts
@@ -125,7 +125,8 @@ export class SharedSyncImplementation
           flags: { enableMultiTabs: true },
           logger: this.broadCastLogger
         }),
-        new Mutex()
+        new Mutex(),
+        this.broadCastLogger
       ),
       remote: new WebRemote({
         fetchCredentials: async () => {


### PR DESCRIPTION
This fixes an issue where sync stream connections would not be closed if any exceptions were thrown while handling events from the backend instance.

Previous connections are now closed before new connections are established. 

This PR also includes some fixes for the shared sync worker's broadcast logger.

Testing:
The network graph below shows how connections are closed on error.
<img width="1728" alt="Screenshot 2024-03-21 at 09 56 59" src="https://github.com/powersync-ja/powersync-js/assets/51082125/a6e27de6-cf49-4f77-a9c7-f9741fee327c">
