### PR TITLE
[Fix] Watched queries retriggers

### DIFF
--- a/.changeset/metal-vans-grin.md
+++ b/.changeset/metal-vans-grin.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-sdk-common': patch
+---
+
+Fixed regression where watched queries would update for table changes in external (not in query) tables.

--- a/.changeset/shaggy-apples-lick.md
+++ b/.changeset/shaggy-apples-lick.md
@@ -1,0 +1,5 @@
+---
+'@journeyapps/powersync-sdk-web': patch
+---
+
+Minor code cleanup for shared sync worker.

--- a/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
@@ -595,7 +595,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
             const intersection = Array.from(changedTables.values()).filter((change) => watchedTables.has(change));
             if (intersection.length) {
               eventOptions.push({
-                changedTables: [...changedTables]
+                changedTables: intersection
               });
             }
           }

--- a/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
@@ -592,9 +592,12 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
       const flushTableUpdates = throttle(
         () => {
           if (changedTables.size > 0) {
-            eventOptions.push({
-              changedTables: [...changedTables]
-            });
+            const intersection = Array.from(changedTables.values()).filter((change) => watchedTables.has(change));
+            if (intersection.length) {
+              eventOptions.push({
+                changedTables: [...changedTables]
+              });
+            }
           }
           changedTables.clear();
         },

--- a/packages/powersync-sdk-web/src/db/sync/SharedWebStreamingSyncImplementation.ts
+++ b/packages/powersync-sdk-web/src/db/sync/SharedWebStreamingSyncImplementation.ts
@@ -42,8 +42,12 @@ class SharedSyncClientProvider extends AbstractSharedSyncClientProvider {
     };
   }
 
-  uploadCrud(): Promise<void> {
-    return this.options.uploadCrud();
+  async uploadCrud(): Promise<void> {
+    /**
+     * Don't return anything here, just incase something which is not
+     * serializable is returned from the `uploadCrud` function.
+     */
+    await this.options.uploadCrud();
   }
 
   get logger() {

--- a/packages/powersync-sdk-web/src/worker/sync/SharedSyncImplementation.ts
+++ b/packages/powersync-sdk-web/src/worker/sync/SharedSyncImplementation.ts
@@ -204,7 +204,7 @@ export class SharedSyncImplementation
 
   async disconnect() {
     this.abortController?.abort('Disconnected');
-    this.iterateListeners((l) => l.statusChanged?.(new SyncStatus({ connected: false })));
+    this.updateAllStatuses({ connected: false });
   }
 
   /**

--- a/packages/powersync-sdk-web/tests/watch.test.ts
+++ b/packages/powersync-sdk-web/tests/watch.test.ts
@@ -139,6 +139,8 @@ describe('Watch Tests', () => {
 
     // There should be one initial result plus one throttled result
     expect(receivedAssetsUpdatesCount).equals(2);
+
+    // Only the initial result should have yielded.
     expect(receivedCustomersUpdatesCount).equals(1);
   });
 });

--- a/packages/powersync-sdk-web/tests/watch.test.ts
+++ b/packages/powersync-sdk-web/tests/watch.test.ts
@@ -101,4 +101,44 @@ describe('Watch Tests', () => {
     // There should be one initial result plus one throttled result
     expect(receivedUpdatesCount).equals(2);
   });
+
+  it('should only watch tables inside query', async () => {
+    const assetsAbortController = new AbortController();
+
+    const watchAssets = powersync.watch('SELECT count() AS count FROM assets', [], {
+      signal: assetsAbortController.signal
+    });
+
+    const customersAbortController = new AbortController();
+
+    const watchCustomers = powersync.watch('SELECT count() AS count FROM customers', [], {
+      signal: customersAbortController.signal
+    });
+
+    let receivedAssetsUpdatesCount = 0;
+    // Listen to assets updates
+    (async () => {
+      for await (const update of watchAssets) {
+        receivedAssetsUpdatesCount++;
+      }
+    })();
+
+    let receivedCustomersUpdatesCount = 0;
+    (async () => {
+      for await (const update of watchCustomers) {
+        receivedCustomersUpdatesCount++;
+      }
+    })();
+
+    // Create the inserts as fast as possible
+    await powersync.execute('INSERT INTO assets(id, make, customer_id) VALUES (uuid(), ?, ?)', ['test', uuid()]);
+
+    await new Promise<void>((resolve) => setTimeout(resolve, throttleDuration * 2));
+    assetsAbortController.abort();
+    customersAbortController.abort();
+
+    // There should be one initial result plus one throttled result
+    expect(receivedAssetsUpdatesCount).equals(2);
+    expect(receivedCustomersUpdatesCount).equals(1);
+  });
 });


### PR DESCRIPTION
# Description

This fixes a regression from https://github.com/powersync-ja/powersync-js/pull/90 which caused watched queries to update on any data table change instead of tables specified in the query or options.

This also pre-emptively does some code cleanup in the shared sync manager code. 

# Testing

Before: The watched query for the `lists` table would update even when a change was made to the `todos` table 

https://github.com/powersync-ja/powersync-js/assets/51082125/40674d05-6de9-42f9-8c74-7d223578eb02


After: the lists query does not retrigger for external updates

https://github.com/powersync-ja/powersync-js/assets/51082125/20f4faaf-7a3f-40a4-9f77-d3c44d521c17


