### PR TITLE
[Update] powersync-sdk-common: watch/onChange API overloads to support callbacks

### DIFF
--- a/.changeset/clever-phones-hang.md
+++ b/.changeset/clever-phones-hang.md
@@ -1,0 +1,5 @@
+---
+"@journeyapps/powersync-react": minor
+---
+
+No longer using the async iterator version of the watch method for the usePowerSyncWatchedQuery hook, using the callback version instead.

--- a/.changeset/heavy-dogs-work.md
+++ b/.changeset/heavy-dogs-work.md
@@ -1,0 +1,5 @@
+---
+"powersync-example": minor
+---
+
+Updated implementation of attachmentIds in PhotoAttachmentQueue to match updated abstract signature from AbstractAttachmentQueue.

--- a/.changeset/heavy-dogs-work.md
+++ b/.changeset/heavy-dogs-work.md
@@ -2,4 +2,4 @@
 "powersync-example": minor
 ---
 
-Updated implementation of attachmentIds in PhotoAttachmentQueue to match updated abstract signature from AbstractAttachmentQueue.
+Updated/renamed implementation of `attachmentIds` to `onAttachmentIdsChange`, now implements a callback approach instead of AsyncGenerator.

--- a/.changeset/slow-years-pull.md
+++ b/.changeset/slow-years-pull.md
@@ -1,0 +1,5 @@
+---
+"@journeyapps/powersync-attachments": major
+---
+
+Changed abstract attachmentIds member of AbstractAttachmentQueue to use callback instead of an AsyncGenerator.

--- a/.changeset/slow-years-pull.md
+++ b/.changeset/slow-years-pull.md
@@ -2,4 +2,4 @@
 "@journeyapps/powersync-attachments": major
 ---
 
-Changed abstract attachmentIds member of AbstractAttachmentQueue to use callback instead of an AsyncGenerator.
+Renamed abstract `attachmentIds` to `onAttachmentIdsChange` in `AbstractAttachmentQueue`, changed to use callback signature instead of an AsyncGenerator.

--- a/.changeset/sweet-pumpkins-explain.md
+++ b/.changeset/sweet-pumpkins-explain.md
@@ -1,0 +1,5 @@
+---
+"@journeyapps/powersync-sdk-common": minor
+---
+
+Introduced overloaded versions of watch and onChange methods to support a callback approach to handle results and errors alongside the existing AsyncGenerator mechanism.

--- a/demos/react-native-supabase-todolist/library/powersync/PhotoAttachmentQueue.ts
+++ b/demos/react-native-supabase-todolist/library/powersync/PhotoAttachmentQueue.ts
@@ -16,9 +16,9 @@ export class PhotoAttachmentQueue extends AbstractAttachmentQueue {
     await super.init();
   }
 
-  attachmentIds(onResult: (ids: string[]) => void): void {
+  onAttachmentIdsChange(onUpdate: (ids: string[]) => void): void {
     this.powersync.watch(`SELECT photo_id as id FROM ${TODO_TABLE} WHERE photo_id IS NOT NULL`, [], {
-      onResult: result => onResult(result.rows?._array.map((r) => r.id) ?? [])
+      onResult: result => onUpdate(result.rows?._array.map((r) => r.id) ?? [])
     });
   }
 

--- a/demos/react-native-supabase-todolist/library/powersync/PhotoAttachmentQueue.ts
+++ b/demos/react-native-supabase-todolist/library/powersync/PhotoAttachmentQueue.ts
@@ -16,13 +16,10 @@ export class PhotoAttachmentQueue extends AbstractAttachmentQueue {
     await super.init();
   }
 
-  async *attachmentIds(): AsyncIterable<string[]> {
-    for await (const result of this.powersync.watch(
-      `SELECT photo_id as id FROM ${TODO_TABLE} WHERE photo_id IS NOT NULL`,
-      []
-    )) {
-      yield result.rows?._array.map((r) => r.id) ?? [];
-    }
+  attachmentIds(onResult: (ids: string[]) => void): void {
+    this.powersync.watch(`SELECT photo_id as id FROM ${TODO_TABLE} WHERE photo_id IS NOT NULL`, [], {
+      onResult: result => onResult(result.rows?._array.map((r) => r.id) ?? [])
+    });
   }
 
   async newAttachmentRecord(record?: Partial<AttachmentRecord>): Promise<AttachmentRecord> {

--- a/demos/react-native-supabase-todolist/library/powersync/PhotoAttachmentQueue.ts
+++ b/demos/react-native-supabase-todolist/library/powersync/PhotoAttachmentQueue.ts
@@ -18,7 +18,7 @@ export class PhotoAttachmentQueue extends AbstractAttachmentQueue {
 
   onAttachmentIdsChange(onUpdate: (ids: string[]) => void): void {
     this.powersync.watch(`SELECT photo_id as id FROM ${TODO_TABLE} WHERE photo_id IS NOT NULL`, [], {
-      onResult: result => onUpdate(result.rows?._array.map((r) => r.id) ?? [])
+      onResult: (result) => onUpdate(result.rows?._array.map((r) => r.id) ?? [])
     });
   }
 

--- a/packages/powersync-attachments/README.md
+++ b/packages/powersync-attachments/README.md
@@ -73,7 +73,7 @@ import { AbstractAttachmentQueue } from '@journeyapps/powersync-attachments';
 export class AttachmentQueue extends AbstractAttachmentQueue {
   onAttachmentIdsChange(onUpdate) {
     this.powersync.watch('SELECT photo_id as id FROM checklists WHERE photo_id IS NOT NULL', [], {
-      onResult: result => onUpdate(result.rows?._array.map((r) => r.id) ?? [])
+      onResult: (result) => onUpdate(result.rows?._array.map((r) => r.id) ?? [])
    });
   }
 }

--- a/packages/powersync-attachments/README.md
+++ b/packages/powersync-attachments/README.md
@@ -63,7 +63,7 @@ import { AbstractAttachmentQueue } from '@journeyapps/powersync-attachments';
 export class AttachmentQueue extends AbstractAttachmentQueue {}
 ```
 
-2. Implement `attachmentIds`, an `AsyncIterator` method to return an array of `string` values of IDs that relate to attachments in your app. We recommend using `PowerSync`'s `watch` query to return the all IDs of attachments in your app.
+2. Implement `onAttachmentIdsChange`, which takes in a callback to handle an array of `string` values of IDs that relate to attachments in your app. We recommend using `PowerSync`'s `watch` query to return the all IDs of attachments in your app.
 
    In this example, we query all photos that have been captured as part of an inspection and map these to an array of `string` values.
 
@@ -71,13 +71,10 @@ export class AttachmentQueue extends AbstractAttachmentQueue {}
 import { AbstractAttachmentQueue } from '@journeyapps/powersync-attachments';
 
 export class AttachmentQueue extends AbstractAttachmentQueue {
-  async *attachmentIds() {
-    for await (const result of this.powersync.watch(
-      `SELECT photo_id as id FROM checklists WHERE photo_id IS NOT NULL`,
-      []
-    )) {
-      yield result.rows?._array.map((r) => r.id) ?? [];
-    }
+  onAttachmentIdsChange(onUpdate) {
+    this.powersync.watch('SELECT photo_id as id FROM checklists WHERE photo_id IS NOT NULL', [], {
+      onResult: result => onUpdate(result.rows?._array.map((r) => r.id) ?? [])
+   });
   }
 }
 ```

--- a/packages/powersync-attachments/src/AbstractAttachmentQueue.ts
+++ b/packages/powersync-attachments/src/AbstractAttachmentQueue.ts
@@ -57,15 +57,20 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
   }
 
   /**
-   * Returns an async iterator that yields attachment IDs that need to be synced.
-   * In most cases this will be a watch query
+   * Takes in a callback that gets invoked with attachment IDs that need to be synced.
+   * In most cases this will contain a watch query.
    *
-   * Example:
-   * for await (const result of powersync.watch('SELECT photo_id as id FROM todos WHERE photo_id IS NOT NULL', [])) {
-   *    yield result.rows?._array.map((r) => r.id) ?? [];
+   * @example
+   * ```typescript
+   * attachmentIds(onResult: (ids: string[]) => void): void {
+   *    this.powersync.watch('SELECT photo_id as id FROM todos WHERE photo_id IS NOT NULL', [], { 
+   *        onResult: result => onResult(result.rows?._array.map((r) => r.id) ?? []) 
+   *    });
    * }
+   * 
    */
-  abstract attachmentIds(): AsyncIterable<string[]>;
+  abstract attachmentIds(onResult: (ids: string[]) => void): void;
+
 
   /**
    * Create a new AttachmentRecord, this gets called when the attachment id is not found in the database.
@@ -106,7 +111,7 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
   }
 
   async watchAttachmentIds() {
-    for await (const ids of this.attachmentIds()) {
+    this.attachmentIds(async (ids) => {
       const _ids = `${ids.map((id) => `'${id}'`).join(',')}`;
       console.debug(`Queuing for sync, attachment IDs: [${_ids}]`);
 
@@ -157,7 +162,7 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
           AND
             id NOT IN (${ids.map((id) => `'${id}'`).join(',')})`
       );
-    }
+    });
   }
 
   async saveToQueue(record: Omit<AttachmentRecord, 'timestamp'>): Promise<AttachmentRecord> {
@@ -342,8 +347,8 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
     return false;
   }
 
-  async *idsToUpload(): AsyncIterable<string[]> {
-    for await (const result of this.powersync.watch(
+  idsToUpload(onResult: (ids: string[]) => void): void {
+    this.powersync.watch(
       `SELECT id
               FROM ${this.table}
               WHERE
@@ -352,18 +357,17 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
                 (state = ${AttachmentState.QUEUED_UPLOAD}
               OR
                 state = ${AttachmentState.QUEUED_SYNC})`,
-      []
-    )) {
-      yield result.rows?._array.map((r) => r.id) || [];
-    }
+      [],
+      { onResult: (result) => onResult(result.rows?._array.map((r) => r.id) || []) }
+    );
   }
 
-  async watchUploads() {
-    for await (const ids of this.idsToUpload()) {
+  watchUploads() {
+    this.idsToUpload(async (ids) => {
       if (ids.length > 0) {
         await this.uploadRecords();
       }
-    }
+    })
   }
 
   /**
@@ -409,26 +413,25 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
     return res.map((r) => r.id);
   }
 
-  async *idsToDownload(): AsyncIterable<string[]> {
-    for await (const result of this.powersync.watch(
+  idsToDownload(onResult: (ids: string[]) => void): void {
+    this.powersync.watch(
       `SELECT id
               FROM ${this.table}
               WHERE
                 state = ${AttachmentState.QUEUED_DOWNLOAD}
               OR
                 state = ${AttachmentState.QUEUED_SYNC}`,
-      []
-    )) {
-      yield result.rows?._array.map((r) => r.id) || [];
-    }
+      [],
+      { onResult: result => onResult(result.rows?._array.map(r => r.id) || []) }
+    )
   }
 
-  async watchDownloads() {
-    for await (const ids of this.idsToDownload()) {
+  watchDownloads() {
+    this.idsToDownload(async (ids) => {
       ids.map((id) => this.downloadQueue.add(id));
-      // No need to await this, the lock will ensure only loop is running at a time
+      // No need to await this, the lock will ensure only one loop is running at a time
       this.downloadRecords();
-    }
+    })
   }
 
   private async downloadRecords() {

--- a/packages/powersync-attachments/src/AbstractAttachmentQueue.ts
+++ b/packages/powersync-attachments/src/AbstractAttachmentQueue.ts
@@ -61,10 +61,10 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
    * In most cases this will contain a watch query.
    *
    * @example
-   * ```typescript
+   * ```javascript
    * onAttachmentIdsChange(onUpdate) {
    *    this.powersync.watch('SELECT photo_id as id FROM todos WHERE photo_id IS NOT NULL', [], { 
-   *        onResult: result => onUpdate(result.rows?._array.map((r) => r.id) ?? []) 
+   *        onResult: (result) => onUpdate(result.rows?._array.map((r) => r.id) ?? []) 
    *    });
    * }
    * ```

--- a/packages/powersync-attachments/src/AbstractAttachmentQueue.ts
+++ b/packages/powersync-attachments/src/AbstractAttachmentQueue.ts
@@ -62,14 +62,14 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
    *
    * @example
    * ```typescript
-   * attachmentIds(onResult: (ids: string[]) => void): void {
+   * onAttachmentIdsChange(onUpdate) {
    *    this.powersync.watch('SELECT photo_id as id FROM todos WHERE photo_id IS NOT NULL', [], { 
-   *        onResult: result => onResult(result.rows?._array.map((r) => r.id) ?? []) 
+   *        onResult: result => onUpdate(result.rows?._array.map((r) => r.id) ?? []) 
    *    });
    * }
-   * 
+   * ```
    */
-  abstract attachmentIds(onResult: (ids: string[]) => void): void;
+  abstract onAttachmentIdsChange(onUpdate: (ids: string[]) => void): void;
 
 
   /**
@@ -111,7 +111,7 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
   }
 
   async watchAttachmentIds() {
-    this.attachmentIds(async (ids) => {
+    this.onAttachmentIdsChange(async (ids) => {
       const _ids = `${ids.map((id) => `'${id}'`).join(',')}`;
       console.debug(`Queuing for sync, attachment IDs: [${_ids}]`);
 

--- a/packages/powersync-react/src/hooks/usePowerSyncWatchedQuery.ts
+++ b/packages/powersync-react/src/hooks/usePowerSyncWatchedQuery.ts
@@ -24,14 +24,15 @@ export const usePowerSyncWatchedQuery = <T = any>(
     // Abort any previous watches
     abortController.current?.abort();
     abortController.current = new AbortController();
-    (async () => {
-      for await (const result of powerSync.watch(sqlStatement, parameters, {
-        ...options,
-        signal: abortController.current.signal
-      })) {
-        setData(result.rows?._array ?? []);
-      }
-    })();
+
+    powerSync.watch(sqlStatement, parameters, {
+      onResult(results) {
+        setData(results.rows?._array ?? []);
+      },
+    }, {
+      ...options,
+      signal: abortController.current.signal
+    });
 
     return () => {
       abortController.current?.abort();

--- a/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
@@ -555,10 +555,37 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
   /**
    * This version of `watch` uses {@link AsyncGenerator}, for documentation see {@link watchWithAsyncGenerator}.
    * Can be overloaded to use a callback handler instead, for documentation see {@link watchWithCallback}.
+   * 
+   * @example
+   * ```typescript
+   * async *attachmentIds(): AsyncIterable<string[]> {
+   *   for await (const result of this.powersync.watch(
+   *     `SELECT photo_id as id FROM todos WHERE photo_id IS NOT NULL`,
+   *     []
+   *   )) {
+   *     yield result.rows?._array.map((r) => r.id) ?? [];
+   *   }
+   * }
+   * ```
    */
   watch(sql: string, parameters?: any[], options?: SQLWatchOptions): AsyncIterable<QueryResult>;
   /**
    * See {@link watchWithCallback}.
+   * 
+   * @example
+   * ```typescript
+   * attachmentIds(onResult: (ids: string[]) => void): void {
+   *   this.powersync.watch(
+   *     `SELECT photo_id as id FROM todos WHERE photo_id IS NOT NULL`,
+   *     [],
+   *     {
+   *       onResult: (result) => {
+   *         onResult(result.rows?._array.map((r) => r.id) ?? []);
+   *       }
+   *     }
+   *   );
+   * }
+   * ```
    */
   watch(sql: string, parameters?: any[], handler?: WatchHandler, options?: SQLWatchOptions): void;
 
@@ -650,10 +677,30 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
   /**
   * This version of `onChange` uses {@link AsyncGenerator}, for documentation see {@link onChangeWithAsyncGenerator}.
   * Can be overloaded to use a callback handler instead, for documentation see {@link onChangeWithCallback}.
+  * 
+  * @example
+  * ```typescript
+  * async monitorChanges() {
+  *   for await (const event of this.powersync.onChange({tables: ['todos']})) {
+  *     console.log('Detected change event:', event);
+  *   }
+  * }
+  * ```
   */
   onChange(options?: SQLWatchOptions): AsyncIterable<WatchOnChangeEvent>;
   /**
   * See {@link onChangeWithCallback}.
+  * 
+  * @example 
+  * ```typescript
+  * monitorChanges(): void {
+  *   this.powersync.onChange({
+  *     onChange: (event) => {
+  *       console.log('Change detected:', event);
+  *     }
+  *   }, { tables: ['todos'] });
+  * }
+  * ```
   */
   onChange(handler?: WatchOnChangeHandler, options?: SQLWatchOptions): () => void;
 

--- a/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
@@ -552,7 +552,14 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
     );
   }
 
+  /**
+   * This version of `watch` uses {@link AsyncGenerator}, for documentation see {@link watchWithAsyncGenerator}.
+   * Can be overloaded to use a callback handler instead, for documentation see {@link watchWithCallback}.
+   */
   watch(sql: string, parameters?: any[], options?: SQLWatchOptions): AsyncIterable<QueryResult>;
+  /**
+   * See {@link watchWithCallback}.
+   */
   watch(sql: string, parameters?: any[], handler?: WatchHandler, options?: SQLWatchOptions): void;
 
   watch(sql: string, parameters?: any[], handlerOrOptions?: WatchHandler | SQLWatchOptions, maybeOptions?: SQLWatchOptions): void | AsyncIterable<QueryResult> {
@@ -572,7 +579,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
    * Use {@link SQLWatchOptions.throttleMs} to specify the minimum interval between queries.
    * Source tables are automatically detected using `EXPLAIN QUERY PLAN`.
    * 
-   * Note that the `onChange` callback of the handler is required.
+   * Note that the `onChange` callback member of the handler is required.
    */
   watchWithCallback(sql: string, parameters?: any[], handler?: WatchHandler, options?: SQLWatchOptions,
   ): void {
@@ -640,19 +647,26 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
     return resolvedTables;
   }
 
+  /**
+  * This version of `onChange` uses {@link AsyncGenerator}, for documentation see {@link onChangeWithAsyncGenerator}.
+  * Can be overloaded to use a callback handler instead, for documentation see {@link onChangeWithCallback}.
+  */
   onChange(options?: SQLWatchOptions): AsyncIterable<WatchOnChangeEvent>;
-  onChange(handler?: WatchOnChangeHandler, options?: SQLWatchOptions): void;
+  /**
+  * See {@link onChangeWithCallback}.
+  */
+  onChange(handler?: WatchOnChangeHandler, options?: SQLWatchOptions): () => void;
 
-  onChange(handlerOrOptions?: WatchOnChangeHandler | SQLWatchOptions, maybeOptions?: SQLWatchOptions): void | AsyncIterable<WatchOnChangeEvent> {
+  onChange(handlerOrOptions?: (WatchOnChangeHandler | SQLWatchOptions), maybeOptions?: SQLWatchOptions): (() => void) | AsyncIterable<WatchOnChangeEvent> {
     if (handlerOrOptions && typeof handlerOrOptions === 'object' && 'onChange' in handlerOrOptions) {
       const handler = handlerOrOptions as WatchOnChangeHandler;
       const options = maybeOptions;
 
-      this.onChangeWithCallback(handler, options);
-    } else {
-      const options = handlerOrOptions as SQLWatchOptions | undefined;
-      return this.onChangeWithAsyncGenerator(options);
+      return this.onChangeWithCallback(handler, options);
     }
+
+    const options = handlerOrOptions as SQLWatchOptions | undefined;
+    return this.onChangeWithAsyncGenerator(options);
   }
 
   /**
@@ -661,7 +675,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
   * This is preferred over {@link watchWithCallback} when multiple queries need to be performed
   * together when data is changed.
   * 
-  * Note that the `onChange` callback of the handler is required.
+  * Note that the `onChange` callback member of the handler is required.
   * 
   * Returns dispose function to stop watching.
   */

--- a/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
@@ -557,8 +557,8 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
    * Can be overloaded to use a callback handler instead, for documentation see {@link watchWithCallback}.
    * 
    * @example
-   * ```typescript
-   * async *attachmentIds(): AsyncIterable<string[]> {
+   * ```javascript
+   * async *attachmentIds() {
    *   for await (const result of this.powersync.watch(
    *     `SELECT photo_id as id FROM todos WHERE photo_id IS NOT NULL`,
    *     []
@@ -573,15 +573,13 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
    * See {@link watchWithCallback}.
    * 
    * @example
-   * ```typescript
-   * attachmentIds(onResult: (ids: string[]) => void): void {
+   * ```javascript
+   * onAttachmentIdsChange(onResult) {
    *   this.powersync.watch(
    *     `SELECT photo_id as id FROM todos WHERE photo_id IS NOT NULL`,
    *     [],
    *     {
-   *       onResult: (result) => {
-   *         onResult(result.rows?._array.map((r) => r.id) ?? []);
-   *       }
+   *       onResult: (result) => onResult(result.rows?._array.map((r) => r.id) ?? [])
    *     }
    *   );
    * }
@@ -679,7 +677,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
   * Can be overloaded to use a callback handler instead, for documentation see {@link onChangeWithCallback}.
   * 
   * @example
-  * ```typescript
+  * ```javascript
   * async monitorChanges() {
   *   for await (const event of this.powersync.onChange({tables: ['todos']})) {
   *     console.log('Detected change event:', event);
@@ -692,8 +690,8 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
   * See {@link onChangeWithCallback}.
   * 
   * @example 
-  * ```typescript
-  * monitorChanges(): void {
+  * ```javascript
+  * monitorChanges() {
   *   this.powersync.onChange({
   *     onChange: (event) => {
   *       console.log('Change detected:', event);

--- a/packages/powersync-sdk-web/src/db/sync/SharedWebStreamingSyncImplementation.ts
+++ b/packages/powersync-sdk-web/src/db/sync/SharedWebStreamingSyncImplementation.ts
@@ -183,6 +183,6 @@ export class SharedWebStreamingSyncImplementation extends WebStreamingSyncImplem
    * Used in tests to force a connection states
    */
   private async _testUpdateStatus(status: SyncStatus) {
-    return (this.syncManager as any).syncStreamClient.updateSyncStatus(status.toJSON());
+    return (this.syncManager as any)['_testUpdateAllStatuses'](status.toJSON());
   }
 }

--- a/packages/powersync-sdk-web/src/worker/sync/SharedSyncImplementation.ts
+++ b/packages/powersync-sdk-web/src/worker/sync/SharedSyncImplementation.ts
@@ -279,4 +279,19 @@ export class SharedSyncImplementation
     this.syncStatus = new SyncStatus(status);
     this.ports.forEach((p) => p.clientProvider.statusChanged(status));
   }
+
+  /**
+   * A function only used for unit tests which updates the internal
+   * sync stream client and all tab client's sync status
+   */
+  private _testUpdateAllStatuses(status: SyncStatusOptions) {
+    if (!this.syncStreamClient) {
+      console.warn('no stream client has been initialized yet');
+    }
+
+    // Only assigning, don't call listeners for this test
+    this.syncStreamClient!.syncStatus = new SyncStatus(status);
+
+    this.updateAllStatuses(status);
+  }
 }

--- a/packages/powersync-sdk-web/tests/multiple_instances.test.ts
+++ b/packages/powersync-sdk-web/tests/multiple_instances.test.ts
@@ -187,15 +187,14 @@ describe('Multiple Instances', () => {
     await stream2UpdatedPromise;
     expect(stream2.isConnected).true;
 
-    // Manual trigger since tests don't entirely configure watches for ps_crud
-    stream1.triggerCrudUpload();
-
     // Create something with CRUD in it.
     await db.execute('INSERT into customers (id, name, email) VALUES (uuid(), ?, ?)', [
       'steven',
       'steven@journeyapps.com'
     ]);
 
+    // Manual trigger since tests don't entirely configure watches for ps_crud
+    stream1.triggerCrudUpload();
     // The second connector should be called to upload
     await upload2TriggeredPromise;
 


### PR DESCRIPTION
# Description
A suggestion was made to add a callback support to the `watch` and `onChange` methods which can be used over the existing AsyncIterator approach. Which we would likely want to use instead when we add new js packages (Vue etc). This is introduced as overloaded versions of the existing functions, which means existing usage of the existing `watch` and `onChange` should be unaffected.

Usage with existing AsyncIterator signature:
```typescript
for await (const result of powerSync.watch(sqlStatement, parameters, {
    ...options,
    signal: abortController.signal
})) {
    data = result.rows?._array ?? [];
}
```

Usage with new overloaded signature:
```typescript
powerSync.watch(sqlStatement, parameters, {
    onResult(results) {
        data = results.rows?._array ?? [];
     },
    onError(e) { } // onError is optional
}, {
    ...options,
    signal: abortController.signal
});
```

## What was done to verify this works
1. Tested both the AsyncIterator and Callback versions in the Vue poc
2. Tested both versions with the `react-supabase-todo` project
3. Tested both versions with the `react-native-supabase-todo` project
4. Add tests to the test suite `powersync-sdk-web`, most of which are duplicated versions of the existing tests and just using the callback approach.

## Futher work as of 28 March
1. Updated `packages/ps-react` package to use new watch with callbacks
2. Updated `packages/ps-attachments` package to use new watch with callbacks.
3. Updates `demos/react-native-supabase-todo` project to support breaking change from updating `ps-attachments`. I have tested that at the very least the android version still works (on my phone).

## Drive-by commit
Used a cherry-picked commit provided by @stevensJourney  to fix tests from `powersync-sdk-web` failing locally on `main`
You can view it [here](https://github.com/powersync-ja/powersync-js/commit/b56e3c6544da02d384ffa20097b7f725e245212a)