### PR TITLE
RN: lock package versions in README

### DIFF
--- a/packages/powersync-sdk-react-native/README.md
+++ b/packages/powersync-sdk-react-native/README.md
@@ -38,12 +38,12 @@ This SDK requires HTTP streaming in order to function. The following `fetch` pol
 - react-native-polyfill-globals
 - react-native-url-polyfill
 - text-encoding
-- web-streams-polyfill
+- web-streams-polyfill@3.2.1
 
 These are listed as peer dependencies and need to be added to the React Native project
 
 ```bash
-npx expo install react-native-fetch-api react-native-polyfill-globals react-native-url-polyfill text-encoding web-streams-polyfill base-64 react-native-get-random-values
+npx expo install react-native-fetch-api react-native-polyfill-globals react-native-url-polyfill text-encoding web-streams-polyfill@3.2.1 base-64 react-native-get-random-values@1.9.0
 ```
 
 Enable the polyfills in React Native app with


### PR DESCRIPTION
Some newer version of dependencies have been released, namely `web-streams-polyfill` 4.0 and `react-native-get-random-values` 1.11 which break installation. 

This PR locks to known good values.