### PR TITLE
Update lodash reference in vite optimizeDeps demo configs

### DIFF
--- a/demos/example-vite/vite.config.ts
+++ b/demos/example-vite/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     // Don't optimize these packages as they contain web workers and WASM files.
     // https://github.com/vitejs/vite/issues/11672#issuecomment-1415820673
     exclude: ['@journeyapps/wa-sqlite', '@journeyapps/powersync-sdk-web'],
-    include: ['object-hash', 'uuid', 'event-iterator', 'js-logger', 'lodash', 'can-ndjson-stream']
+    include: ['object-hash', 'uuid', 'event-iterator', 'js-logger', 'lodash/throttle', 'can-ndjson-stream']
   },
   plugins: [wasm(), topLevelAwait()],
   worker: {

--- a/demos/react-supabase-todolist/vite.config.mts
+++ b/demos/react-supabase-todolist/vite.config.mts
@@ -25,7 +25,7 @@ export default defineConfig({
     // Don't optimize these packages as they contain web workers and WASM files.
     // https://github.com/vitejs/vite/issues/11672#issuecomment-1415820673
     exclude: ['@journeyapps/wa-sqlite', '@journeyapps/powersync-sdk-web'],
-    include: ['object-hash', 'uuid', 'event-iterator', 'js-logger', 'lodash', 'can-ndjson-stream']
+    include: ['object-hash', 'uuid', 'event-iterator', 'js-logger', 'lodash/throttle', 'can-ndjson-stream']
   },
   plugins: [
     wasm(),

--- a/demos/yjs-react-supabase-text-collab/vite.config.mts
+++ b/demos/yjs-react-supabase-text-collab/vite.config.mts
@@ -26,7 +26,7 @@ export default defineConfig({
     // Don't optimize these packages as they contain web workers and WASM files.
     // https://github.com/vitejs/vite/issues/11672#issuecomment-1415820673
     exclude: ['@journeyapps/wa-sqlite', '@journeyapps/powersync-sdk-web'],
-    include: ['object-hash', 'uuid', 'event-iterator', 'js-logger', 'lodash', 'can-ndjson-stream']
+    include: ['object-hash', 'uuid', 'event-iterator', 'js-logger', 'lodash/throttle', 'can-ndjson-stream']
   },
   plugins: [
     wasm(),


### PR DESCRIPTION
Hey folks!

I ran into a bit of trouble during setup with a new codebase, using powersync-sdk-web, bundled with vite.  I modeled my vite config after the [demo config here](https://github.com/powersync-ja/powersync-js/tree/main/demos/example-vite). Upon page load, the following error was displayed in the browser console:

```Uncaught SyntaxError: The requested module '.../lodash/throttle.js' does not provide an export named 'default' (at AbstractStreamingSyncImplementation.js)```

I was able to resolve the issue by changing the vite config `lodash` depdency line to `lodash/throttle`.  I suspect this may've been a regression with the recent [lodash optimization](https://github.com/powersync-ja/powersync-js/pull/90).  I'm new to vite, not sure if this is the best solution, but it worked for me, and I hope it'll help others hitting the same wall I ran into.

Appreciate the great work you're doing here!