### PR TITLE
fix default onError callback values for watch() and onChange()

### DIFF
--- a/.changeset/rare-pumpkins-study.md
+++ b/.changeset/rare-pumpkins-study.md
@@ -1,0 +1,5 @@
+---
+"@journeyapps/powersync-sdk-common": patch
+---
+
+Fixed default onError callback for watch() and onChange() that used an unbounded member.

--- a/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/powersync-sdk-common/src/client/AbstractPowerSyncDatabase.ts
@@ -695,7 +695,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
    * Note that the `onChange` callback member of the handler is required.
    */
   watchWithCallback(sql: string, parameters?: any[], handler?: WatchHandler, options?: SQLWatchOptions): void {
-    const { onResult, onError = this.options.logger?.error } = handler ?? {};
+    const { onResult, onError = (e: Error) => this.options.logger?.error(e) } = handler ?? {};
     if (!onResult) {
       throw new Error('onResult is required');
     }
@@ -829,7 +829,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
    * Returns dispose function to stop watching.
    */
   onChangeWithCallback(handler?: WatchOnChangeHandler, options?: SQLWatchOptions): () => void {
-    const { onChange, onError = this.options.logger?.error } = handler ?? {};
+    const { onChange, onError = (e: Error) => this.options.logger?.error(e) } = handler ?? {};
     if (!onChange) {
       throw new Error('onChange is required');
     }


### PR DESCRIPTION
Fumbled `this` usage. Issue occurred when an onError handler wasn't specified for a watched query.