### PR TITLE
feat(react): add useQuery and useStatus hooks

### DIFF
--- a/.changeset/strange-spiders-study.md
+++ b/.changeset/strange-spiders-study.md
@@ -1,0 +1,11 @@
+---
+"react-native-supabase-group-chat": minor
+"react-native-supabase-todolist": minor
+"yjs-react-supabase-text-collab": minor
+"django-react-native-todolist": minor
+"react-supabase-todolist": minor
+"example-nextjs": minor
+"@powersync/react": minor
+---
+
+Deprecate usePowerSyncStatus, usePowerSyncQuery and usePowerSyncWatchedQuery in favor of useQuery and useStatus

--- a/demos/django-react-native-todolist/library/widgets/HeaderWidget.tsx
+++ b/demos/django-react-native-todolist/library/widgets/HeaderWidget.tsx
@@ -3,7 +3,7 @@ import { Alert, Text } from 'react-native';
 import { Icon } from 'react-native-elements';
 import { useNavigation } from 'expo-router';
 import { useSystem } from '../stores/system';
-import { usePowerSyncStatus } from '@powersync/react';
+import { useStatus } from '@powersync/react';
 import { Header } from 'react-native-elements';
 import { observer } from 'mobx-react-lite';
 import { DrawerActions } from '@react-navigation/native';
@@ -13,7 +13,7 @@ export const HeaderWidget: React.FC<{
 }> = observer((props) => {
   const { title } = props;
   const { powersync } = useSystem();
-  const status = usePowerSyncStatus();
+  const status = useStatus();
   const navigation = useNavigation();
 
   return (
@@ -39,8 +39,7 @@ export const HeaderWidget: React.FC<{
           onPress={() => {
             Alert.alert(
               'Status',
-              `${status.connected ? 'Connected' : 'Disconnected'}. \nLast Synced at ${
-                status.lastSyncedAt?.toISOString() ?? '-'
+              `${status.connected ? 'Connected' : 'Disconnected'}. \nLast Synced at ${status.lastSyncedAt?.toISOString() ?? '-'
               }\nVersion: ${powersync.sdkVersion}`
             );
           }}

--- a/demos/example-nextjs/src/app/page.tsx
+++ b/demos/example-nextjs/src/app/page.tsx
@@ -2,13 +2,11 @@
 
 import React, { useEffect } from 'react';
 import { CircularProgress, Grid, ListItem, styled } from '@mui/material';
-import { useRouter } from 'next/navigation';
-import { usePowerSync, usePowerSyncWatchedQuery } from '@powersync/react';
+import { usePowerSync, useQuery } from '@powersync/react';
 
 export default function EntryPage() {
-  const router = useRouter();
   const db = usePowerSync();
-  const customers = usePowerSyncWatchedQuery('SELECT id, name FROM customers');
+  const { data: customers } = useQuery('SELECT id, name FROM customers');
 
   useEffect(() => {
     // Insert some test data

--- a/demos/react-native-supabase-group-chat/src/app/(app)/(chats)/c/[profile]/index.tsx
+++ b/demos/react-native-supabase-group-chat/src/app/(app)/(chats)/c/[profile]/index.tsx
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { usePowerSync, usePowerSyncWatchedQuery } from '@powersync/react-native';
+import { usePowerSync, useQuery } from '@powersync/react-native';
 import { FlashList } from '@shopify/flash-list';
 import { Stack, useLocalSearchParams } from 'expo-router';
 import { useEffect, useState } from 'react';
@@ -13,12 +13,12 @@ export default function ChatsChatIndex() {
   const { profile: profileId } = useLocalSearchParams<{ profile: string }>();
   const { user } = useAuth();
   const powerSync = usePowerSync();
-  const profiles = usePowerSyncWatchedQuery('SELECT id, name, handle, demo FROM profiles WHERE id = ?', [profileId]);
+  const { data: profiles } = useQuery('SELECT id, name, handle, demo FROM profiles WHERE id = ?', [profileId]);
   const profile = profiles.length ? profiles[0] : undefined;
   const [draftId, setDraftId] = useState<string>();
   const [listMessages, setListMessages] = useState<any[]>([]);
 
-  const messages = usePowerSyncWatchedQuery(
+  const { data: messages } = useQuery(
     'SELECT sender_id, content, created_at FROM messages WHERE (((sender_id = ?1 AND recipient_id = ?2) OR (sender_id = ?2 AND recipient_id = ?1)) AND NOT (sender_id = ?1 AND sent_at IS NULL)) ORDER BY created_at ASC',
     [user?.id, profile?.id]
   );

--- a/demos/react-native-supabase-group-chat/src/app/(app)/(chats)/g/[group]/index.tsx
+++ b/demos/react-native-supabase-group-chat/src/app/(app)/(chats)/g/[group]/index.tsx
@@ -1,4 +1,4 @@
-import { usePowerSync, usePowerSyncWatchedQuery } from '@powersync/react-native';
+import { usePowerSync, useQuery } from '@powersync/react-native';
 import { FlashList } from '@shopify/flash-list';
 import { Stack, useLocalSearchParams } from 'expo-router';
 import { useState } from 'react';
@@ -12,10 +12,10 @@ export default function ChatsChatIndex() {
   const { group: groupId } = useLocalSearchParams<{ group: string }>();
   const { user } = useAuth();
   const powerSync = usePowerSync();
-  const groups = usePowerSyncWatchedQuery('SELECT id, name FROM groups WHERE id = ?', [groupId]);
+  const { data: groups } = useQuery('SELECT id, name FROM groups WHERE id = ?', [groupId]);
   const group = groups.length ? groups[0] : undefined;
 
-  const messages = usePowerSyncWatchedQuery(
+  const { data: messages } = useQuery(
     'SELECT sender_id, content, created_at FROM messages WHERE group_id = ? ORDER BY created_at ASC',
     [group?.id]
   );

--- a/demos/react-native-supabase-group-chat/src/app/(app)/(chats)/index.tsx
+++ b/demos/react-native-supabase-group-chat/src/app/(app)/(chats)/index.tsx
@@ -1,4 +1,4 @@
-import { usePowerSync, usePowerSyncWatchedQuery } from '@powersync/react-native';
+import { usePowerSync, useQuery } from '@powersync/react-native';
 import { MessageSquare, Plus } from '@tamagui/lucide-icons';
 import { Link, useNavigation } from 'expo-router';
 import { useEffect, useState } from 'react';
@@ -24,7 +24,7 @@ export default function ChatsIndex() {
     return unsubscribe;
   }, [navigation]);
 
-  const chats = usePowerSyncWatchedQuery(
+  const { data: chats } = useQuery(
     `SELECT profiles.id as partner_id, profiles.name as name, profiles.handle as handle, 'contact' as type, m.created_at as last_message_at FROM chats LEFT JOIN profiles on chats.id = profiles.id LEFT JOIN (SELECT * FROM messages WHERE (sender_id, recipient_id, created_at) IN (SELECT sender_id, recipient_id, MAX(created_at) FROM messages GROUP BY group_id)) as m ON m.recipient_id = chats.id OR m.sender_id = chats.id WHERE (name LIKE '%' || ?1 || '%' OR handle LIKE '%' || ?1 || '%') GROUP BY profiles.id UNION
     SELECT groups.id as partner_id, groups.name as name, '' as handle, 'group' as type, m.created_at as last_message_at FROM groups LEFT JOIN (SELECT * FROM messages WHERE (group_id, created_at) IN (SELECT group_id, MAX(created_at) FROM messages GROUP BY group_id)) as m ON m.group_id = groups.id WHERE (name LIKE '%' || ?1 || '%') GROUP BY groups.id ORDER BY last_message_at DESC`,
     [search]

--- a/demos/react-native-supabase-group-chat/src/app/(app)/contacts/index.tsx
+++ b/demos/react-native-supabase-group-chat/src/app/(app)/contacts/index.tsx
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { usePowerSync, usePowerSyncWatchedQuery } from '@powersync/react-native';
+import { usePowerSync, useQuery } from '@powersync/react-native';
 import { Search, Shuffle } from '@tamagui/lucide-icons';
 import { useState } from 'react';
 import { Button, Input, XStack, YStack } from 'tamagui';
@@ -17,7 +17,7 @@ export default function ContactsIndex() {
   const [search, setSearch] = useState<string>('');
   const [profiles, setProfiles] = useState<any[]>([]);
 
-  const contacts = usePowerSyncWatchedQuery(
+  const { data: contacts } = useQuery(
     "SELECT contacts.id, profiles.id as profile_id, profiles.name, profiles.handle, 'contact' as type FROM contacts LEFT JOIN profiles ON contacts.profile_id = profiles.id WHERE (profiles.name LIKE '%' || ?1 || '%' OR profiles.handle LIKE '%' || ?1 || '%') ORDER BY name ASC",
     [search]
   );
@@ -112,7 +112,7 @@ export default function ContactsIndex() {
           icon={<Search size="$1.5" />}
           backgroundColor="$brand1"
           borderRadius="$3"
-          // circular
+        // circular
         />
       </XStack>
 

--- a/demos/react-native-supabase-group-chat/src/app/(app)/settings/index.tsx
+++ b/demos/react-native-supabase-group-chat/src/app/(app)/settings/index.tsx
@@ -1,4 +1,4 @@
-import { usePowerSync, usePowerSyncWatchedQuery } from '@powersync/react-native';
+import { usePowerSync, useQuery } from '@powersync/react-native';
 import { useEffect, useState } from 'react';
 import { Button, Input, Label, Switch, Text, XStack, YStack } from 'tamagui';
 
@@ -10,7 +10,7 @@ export default function SettingsIndex() {
   const [name, setName] = useState('');
   const [handle, setHandle] = useState('');
 
-  const profiles = usePowerSyncWatchedQuery('SELECT * FROM profiles WHERE id = ?', [user?.id]);
+  const { data: profiles } = useQuery('SELECT * FROM profiles WHERE id = ?', [user?.id]);
 
   useEffect(() => {
     if (profiles.length > 0) {

--- a/demos/react-native-supabase-group-chat/src/components/groups/MemberSelector.tsx
+++ b/demos/react-native-supabase-group-chat/src/components/groups/MemberSelector.tsx
@@ -1,4 +1,4 @@
-import { usePowerSyncWatchedQuery } from '@powersync/react-native';
+import { useQuery } from '@powersync/react-native';
 import { CheckCircle2, Circle } from '@tamagui/lucide-icons';
 import { useState } from 'react';
 import { Input, ListItem, XStack, YStack } from 'tamagui';
@@ -15,7 +15,7 @@ export function MemberSelector({
 }) {
   const [search, setSearch] = useState<string>('');
 
-  const contacts = usePowerSyncWatchedQuery(
+  const { data: contacts } = useQuery(
     "SELECT contacts.id, profiles.id as profile_id, profiles.name, profiles.handle, 'contact' as type FROM contacts LEFT JOIN profiles ON contacts.profile_id = profiles.id WHERE (profiles.name LIKE '%' || ?1 || '%' OR profiles.handle LIKE '%' || ?1 || '%') ORDER BY name ASC",
     [search]
   );

--- a/demos/react-native-supabase-todolist/app/views/todos/edit/[id].tsx
+++ b/demos/react-native-supabase-todolist/app/views/todos/edit/[id].tsx
@@ -1,5 +1,5 @@
 import { ATTACHMENT_TABLE, AttachmentRecord } from '@powersync/attachments';
-import { usePowerSync, usePowerSyncWatchedQuery } from '@powersync/react-native';
+import { usePowerSync, useQuery } from '@powersync/react-native';
 import { CameraCapturedPicture } from 'expo-camera';
 import _ from 'lodash';
 import * as React from 'react';
@@ -34,11 +34,11 @@ const TodoView: React.FC = () => {
   const params = useLocalSearchParams<{ id: string }>();
   const listID = params.id;
 
-  const [listRecord] = usePowerSyncWatchedQuery<{ name: string }>(`SELECT name FROM ${LIST_TABLE} WHERE id = ?`, [
-    listID
-  ]);
+  const {
+    data: [listRecord]
+  } = useQuery<{ name: string }>(`SELECT name FROM ${LIST_TABLE} WHERE id = ?`, [listID]);
 
-  const todos = usePowerSyncWatchedQuery<TodoEntry>(
+  const { data: todos } = useQuery<TodoEntry>(
     `
         SELECT
             ${TODO_TABLE}.id AS todo_id,

--- a/demos/react-native-supabase-todolist/app/views/todos/lists.tsx
+++ b/demos/react-native-supabase-todolist/app/views/todos/lists.tsx
@@ -7,7 +7,7 @@ import prompt from 'react-native-prompt-android';
 import { router, Stack } from 'expo-router';
 import { LIST_TABLE, TODO_TABLE, ListRecord } from '../../../library/powersync/AppSchema';
 import { useSystem } from '../../../library/powersync/system';
-import { usePowerSyncWatchedQuery } from '@powersync/react-native';
+import { useQuery } from '@powersync/react-native';
 import { ListItemWidget } from '../../../library/widgets/ListItemWidget';
 
 const description = (total: number, completed: number = 0) => {
@@ -16,7 +16,7 @@ const description = (total: number, completed: number = 0) => {
 
 const ListsViewWidget: React.FC = () => {
   const system = useSystem();
-  const listRecords = usePowerSyncWatchedQuery<ListRecord & { total_tasks: number; completed_tasks: number }>(`
+  const { data: listRecords } = useQuery<ListRecord & { total_tasks: number; completed_tasks: number }>(`
       SELECT
         ${LIST_TABLE}.*, COUNT(${TODO_TABLE}.id) AS total_tasks, SUM(CASE WHEN ${TODO_TABLE}.completed = true THEN 1 ELSE 0 END) as completed_tasks
       FROM

--- a/demos/react-native-supabase-todolist/library/widgets/HeaderWidget.tsx
+++ b/demos/react-native-supabase-todolist/library/widgets/HeaderWidget.tsx
@@ -3,7 +3,7 @@ import { Alert, Text } from 'react-native';
 import { Icon } from 'react-native-elements';
 import { useNavigation } from 'expo-router';
 import { Header } from 'react-native-elements';
-import { usePowerSyncStatus } from '@powersync/react';
+import { useStatus } from '@powersync/react';
 import { DrawerActions } from '@react-navigation/native';
 import { useSystem } from '../powersync/system';
 
@@ -13,7 +13,7 @@ export const HeaderWidget: React.FC<{
   const system = useSystem();
   const { powersync } = system;
   const navigation = useNavigation();
-  const status = usePowerSyncStatus();
+  const status = useStatus();
 
   const { title } = props;
   return (

--- a/demos/react-supabase-todolist/src/app/views/layout.tsx
+++ b/demos/react-supabase-todolist/src/app/views/layout.tsx
@@ -25,13 +25,13 @@ import React from 'react';
 
 import { useNavigationPanel } from '@/components/navigation/NavigationPanelContext';
 import { useSupabase } from '@/components/providers/SystemProvider';
-import { usePowerSync, usePowerSyncStatus } from '@powersync/react';
+import { usePowerSync, useStatus } from '@powersync/react';
 import { useNavigate } from 'react-router-dom';
 import { LOGIN_ROUTE, SQL_CONSOLE_ROUTE, TODO_LISTS_ROUTE } from '@/app/router';
 
 export default function ViewsLayout({ children }: { children: React.ReactNode }) {
   const powerSync = usePowerSync();
-  const status = usePowerSyncStatus();
+  const status = useStatus();
   const supabase = useSupabase();
   const navigate = useNavigate();
 

--- a/demos/react-supabase-todolist/src/app/views/sql-console/page.tsx
+++ b/demos/react-supabase-todolist/src/app/views/sql-console/page.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { usePowerSyncWatchedQuery } from '@powersync/react';
+import { useQuery } from '@powersync/react';
 import { Box, Button, Grid, TextField, styled } from '@mui/material';
 import { DataGrid } from '@mui/x-data-grid';
 import { NavigationPage } from '@/components/navigation/NavigationPage';
@@ -14,7 +14,7 @@ const DEFAULT_QUERY = 'SELECT * FROM lists';
 export default function SQLConsolePage() {
   const inputRef = React.useRef<HTMLInputElement>();
   const [query, setQuery] = React.useState(DEFAULT_QUERY);
-  const querySQLResult = usePowerSyncWatchedQuery(query);
+  const { data: querySQLResult } = useQuery(query);
 
   const queryDataGridResult = React.useMemo(() => {
     const firstItem = querySQLResult?.[0];

--- a/demos/react-supabase-todolist/src/app/views/todo-lists/edit/page.tsx
+++ b/demos/react-supabase-todolist/src/app/views/todo-lists/edit/page.tsx
@@ -1,7 +1,7 @@
 import { useSupabase } from '@/components/providers/SystemProvider';
 import { TodoItemWidget } from '@/components/widgets/TodoItemWidget';
 import { LISTS_TABLE, TODOS_TABLE, TodoRecord } from '@/library/powersync/AppSchema';
-import { usePowerSync, usePowerSyncWatchedQuery } from '@powersync/react';
+import { usePowerSync, useQuery } from '@powersync/react';
 import AddIcon from '@mui/icons-material/Add';
 import {
   Box,
@@ -32,11 +32,11 @@ const TodoEditSection = () => {
   const supabase = useSupabase();
   const { id: listID } = useParams();
 
-  const [listRecord] = usePowerSyncWatchedQuery<{ name: string }>(`SELECT name FROM ${LISTS_TABLE} WHERE id = ?`, [
-    listID
-  ]);
+  const {
+    data: [listRecord]
+  } = useQuery<{ name: string }>(`SELECT name FROM ${LISTS_TABLE} WHERE id = ?`, [listID]);
 
-  const todos = usePowerSyncWatchedQuery<TodoRecord>(
+  const { data: todos } = useQuery<TodoRecord>(
     `SELECT * FROM ${TODOS_TABLE} WHERE list_id=? ORDER BY created_at DESC, id`,
     [listID]
   );

--- a/demos/react-supabase-todolist/src/components/widgets/TodoListsWidget.tsx
+++ b/demos/react-supabase-todolist/src/components/widgets/TodoListsWidget.tsx
@@ -1,6 +1,6 @@
 import { TODO_LISTS_ROUTE } from '@/app/router';
 import { LISTS_TABLE, ListRecord, TODOS_TABLE } from '@/library/powersync/AppSchema';
-import { usePowerSync, usePowerSyncWatchedQuery } from '@powersync/react';
+import { usePowerSync, useQuery } from '@powersync/react';
 import { List } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { ListItemWidget } from './ListItemWidget';
@@ -17,7 +17,7 @@ export function TodoListsWidget(props: TodoListsWidgetProps) {
   const powerSync = usePowerSync();
   const navigate = useNavigate();
 
-  const listRecords = usePowerSyncWatchedQuery<ListRecord & { total_tasks: number; completed_tasks: number }>(`
+  const { data: listRecords } = useQuery<ListRecord & { total_tasks: number; completed_tasks: number }>(`
       SELECT
         ${LISTS_TABLE}.*, COUNT(${TODOS_TABLE}.id) AS total_tasks, SUM(CASE WHEN ${TODOS_TABLE}.completed = true THEN 1 ELSE 0 END) as completed_tasks
       FROM

--- a/demos/yjs-react-supabase-text-collab/src/app/editor/page.tsx
+++ b/demos/yjs-react-supabase-text-collab/src/app/editor/page.tsx
@@ -1,4 +1,4 @@
-import { usePowerSync, usePowerSyncWatchedQuery } from '@powersync/react';
+import { usePowerSync, useQuery } from '@powersync/react';
 import { Box, Container, Typography } from '@mui/material';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -37,7 +37,7 @@ export default function EditorPage() {
   }, [ydoc, powerSync]);
 
   // watch for total number of document updates changing to update the counter
-  const docUpdatesCount = usePowerSyncWatchedQuery(
+  const { data: docUpdatesCount } = useQuery(
     'SELECT COUNT(*) as total_updates FROM document_updates WHERE document_id=?',
     [documentId]
   );

--- a/demos/yjs-react-supabase-text-collab/src/app/sql-console/page.tsx
+++ b/demos/yjs-react-supabase-text-collab/src/app/sql-console/page.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { usePowerSyncWatchedQuery } from '@powersync/react';
+import { useQuery } from '@powersync/react';
 import { Box, Button, Grid, TextField, styled } from '@mui/material';
 import { DataGrid } from '@mui/x-data-grid';
 
@@ -8,7 +8,7 @@ const DEFAULT_QUERY = 'SELECT * FROM documents';
 export default function SQLConsolePage() {
   const inputRef = React.useRef<HTMLInputElement>();
   const [query, setQuery] = React.useState(DEFAULT_QUERY);
-  const querySQLResult = usePowerSyncWatchedQuery(query);
+  const { data: querySQLResult } = useQuery(query);
 
   const queryDataGridResult = React.useMemo(() => {
     const firstItem = querySQLResult?.[0];

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -47,10 +47,10 @@ export const TodoListDisplay = () => {
 The provided PowerSync client status is available with the `usePowerSyncStatus` hook.
 
 ```JSX
-import { usePowerSyncStatus } from "@powersync/react";
+import { useStatus } from "@powersync/react";
 
 const Component = () => {
-  const status = usePowerSyncStatus();
+  const status = useStatus();
 
   return <div>
     status.connected ? 'wifi' : 'wifi-off'

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "@testing-library/react": "^15.0.2",
-    "@testing-library/react-hooks": "^8.0.1",
     "@types/react": "^18.2.34",
     "jsdom": "^24.0.0",
     "react": "18.2.0",

--- a/packages/react/src/hooks/usePowerSyncQuery.ts
+++ b/packages/react/src/hooks/usePowerSyncQuery.ts
@@ -2,6 +2,7 @@ import React from 'react';
 import { usePowerSync } from './PowerSyncContext';
 
 /**
+ * @deprecated use {@link useQuery} instead
  * A hook to access a single static query.
  * For an updated result, use {@link usePowerSyncWatchedQuery} instead
  */

--- a/packages/react/src/hooks/usePowerSyncStatus.ts
+++ b/packages/react/src/hooks/usePowerSyncStatus.ts
@@ -2,6 +2,7 @@ import { useContext, useEffect, useState } from 'react';
 import { PowerSyncContext } from './PowerSyncContext';
 
 /**
+ * @deprecated Use {@link useStatus} instead.
  * Custom hook that provides access to the current status of PowerSync.
  * @returns The PowerSync Database status.
  * @example

--- a/packages/react/src/hooks/usePowerSyncWatchedQuery.ts
+++ b/packages/react/src/hooks/usePowerSyncWatchedQuery.ts
@@ -3,6 +3,7 @@ import React from 'react';
 import { usePowerSync } from './PowerSyncContext';
 
 /**
+ * @deprecated use {@link useQuery} instead
  * A hook to access the results of a watched query.
  * @example
  * export const Component = () => {

--- a/packages/react/src/hooks/useQuery.ts
+++ b/packages/react/src/hooks/useQuery.ts
@@ -1,0 +1,111 @@
+import { SQLWatchOptions } from '@powersync/common';
+import React from 'react';
+import { usePowerSync } from './PowerSyncContext';
+
+interface AdditionalOptions extends Omit<SQLWatchOptions, 'signal'> {
+  runQueryOnce?: boolean;
+}
+
+export type WatchedQueryResult<T> = {
+  data: T[];
+  /**
+   * Indicates the initial loading state (hard loading). Loading becomes false once the first set of results from the watched query is available or an error occurs.
+   */
+  isLoading: boolean;
+  error: Error;
+  /**
+   * Function used to run the query again.
+   */
+  refresh?: () => Promise<void>;
+};
+
+/**
+ * A hook to access the results of a watched query.
+ * @example
+ * ```tsx
+ * export const Component = () => {
+ * const lists = useQuery('SELECT * from lists');
+ *
+ * return <View>
+ *   {lists.map((l) => (
+ *     <Text key={l.id}>{JSON.stringify(l)}</Text>
+ *   ))}
+ * </View>
+ * }
+ * ```
+ */
+export const useQuery = <T = any>(
+  sqlStatement: string,
+  parameters: any[] = [],
+  options: AdditionalOptions = {}
+): WatchedQueryResult<T> => {
+  const powerSync = usePowerSync();
+  if (!powerSync) {
+    return { isLoading: false, data: [], error: new Error('PowerSync not configured.') };
+  }
+
+  const [data, setData] = React.useState<T[]>([]);
+  const [error, setError] = React.useState<Error>(undefined);
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  const memoizedParams = React.useMemo(() => parameters, [...parameters]);
+  const memoizedOptions = React.useMemo(() => options, [JSON.stringify(options)]);
+  const abortController = React.useRef(new AbortController());
+
+  const handleResult = (result: T[]) => {
+    setIsLoading(false);
+    setData(result);
+    setError(undefined);
+  };
+
+  const handleError = (e: Error) => {
+    setIsLoading(false);
+    setData([]);
+    const wrappedError = new Error('PowerSync failed to fetch data: ' + e.message);
+    wrappedError.cause = e;
+    setError(wrappedError);
+  };
+
+  const fetchData = async () => {
+    setIsLoading(true);
+    try {
+      const result = await powerSync.getAll<T>(sqlStatement, parameters);
+      handleResult(result);
+    } catch (e) {
+      handleError(e);
+    }
+  };
+
+  React.useEffect(() => {
+    // Abort any previous watches
+    abortController.current?.abort();
+    abortController.current = new AbortController();
+
+    if (options.runQueryOnce) {
+      fetchData();
+    } else {
+      powerSync.watch(
+        sqlStatement,
+        parameters,
+        {
+          onResult(results) {
+            handleResult(results.rows?._array ?? []);
+          },
+          onError(e) {
+            handleError(e);
+          }
+        },
+        {
+          ...options,
+          signal: abortController.current.signal
+        }
+      );
+    }
+
+    return () => {
+      abortController.current?.abort();
+    };
+  }, [powerSync, sqlStatement, memoizedParams, memoizedOptions]);
+
+  return { isLoading, data, error, refresh: fetchData };
+};

--- a/packages/react/src/hooks/useStatus.ts
+++ b/packages/react/src/hooks/useStatus.ts
@@ -1,0 +1,19 @@
+import { usePowerSyncStatus } from './usePowerSyncStatus';
+
+/**
+ * Custom hook that provides access to the current status of PowerSync.
+ * @returns The PowerSync Database status.
+ * @example
+ * ```JSX
+ * import { useStatus } from "@powersync/react";
+ *
+ * const Component = () => {
+ *   const status = useStatus();
+ *
+ *   return <div>
+ *     status.connected ? 'wifi' : 'wifi-off'
+ *   </div>
+ * };
+ * ```
+ */
+export const useStatus = usePowerSyncStatus;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,6 @@
 export * from './hooks/PowerSyncContext';
 export { usePowerSyncQuery } from './hooks/usePowerSyncQuery';
+export { useStatus } from './hooks/useStatus';
+export { useQuery } from './hooks/useQuery';
 export { usePowerSyncWatchedQuery } from './hooks/usePowerSyncWatchedQuery';
 export { usePowerSyncStatus } from './hooks/usePowerSyncStatus';

--- a/packages/react/tests/useQuery.test.tsx
+++ b/packages/react/tests/useQuery.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { vi, describe, expect, it, afterEach } from 'vitest';
+import { useQuery } from '../src/hooks/useQuery';
+import { PowerSyncContext } from '../src/hooks/PowerSyncContext';
+
+const mockPowerSync = {
+  currentStatus: { status: 'initial' },
+  registerListener: vi.fn(() => ({
+    statusChanged: vi.fn(() => 'updated')
+  })),
+  watch: vi.fn(),
+  getAll: vi.fn(() => ['list1', 'list2'])
+};
+
+vi.mock('./PowerSyncContext', () => ({
+  useContext: vi.fn(() => mockPowerSync)
+}));
+
+describe('useQuery', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should error when PowerSync is not set', () => {
+    const { result } = renderHook(() => useQuery('SELECT * from lists'));
+    expect(result.current.error).toEqual(Error('PowerSync not configured.'));
+    expect(result.current.isLoading).toEqual(false);
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('should set isLoading to true on initial load', async () => {
+    const wrapper = ({ children }) => (
+      <PowerSyncContext.Provider value={mockPowerSync as any}>{children}</PowerSyncContext.Provider>
+    );
+
+    const { result } = renderHook(() => useQuery('SELECT * from lists'), { wrapper });
+    expect(result.current.isLoading).toEqual(true);
+  });
+
+  it('should run the query once if runQueryOnce flag is set', async () => {
+    const wrapper = ({ children }) => (
+      <PowerSyncContext.Provider value={mockPowerSync as any}>{children}</PowerSyncContext.Provider>
+    );
+
+    const { result } = renderHook(() => useQuery('SELECT * from lists', [], { runQueryOnce: true }), { wrapper });
+    expect(result.current.isLoading).toEqual(true);
+
+    waitFor(
+      () => {
+        expect(result.current.isLoading).toEqual(false);
+        expect(result.current.data).toEqual(['list1', 'list2']);
+        expect(result.current.isLoading).toEqual(false);
+        expect(mockPowerSync.watch).not.toHaveBeenCalled();
+        expect(mockPowerSync.getAll).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 100 }
+    );
+  });
+
+  it('should rerun the query when refresh is used', async () => {
+    const wrapper = ({ children }) => (
+      <PowerSyncContext.Provider value={mockPowerSync as any}>{children}</PowerSyncContext.Provider>
+    );
+
+    const { result } = renderHook(() => useQuery('SELECT * from lists', [], { runQueryOnce: true }), { wrapper });
+    expect(result.current.isLoading).toEqual(true);
+
+    let refresh;
+
+    waitFor(
+      () => {
+        refresh = result.current.refresh;
+        expect(result.current.isLoading).toEqual(false);
+        expect(mockPowerSync.getAll).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 100 }
+    );
+
+    await refresh();
+    expect(mockPowerSync.getAll).toHaveBeenCalledTimes(2);
+  });
+
+  it('should set error when error occurs and runQueryOnce flag is set', async () => {
+    const mockPowerSyncError = {
+      currentStatus: { status: 'initial' },
+      registerListener: vi.fn(() => ({
+        statusChanged: vi.fn(() => 'updated')
+      })),
+      watch: vi.fn(),
+      getAll: vi.fn(() => {
+        throw new Error('some error');
+      })
+    };
+
+    const wrapper = ({ children }) => (
+      <PowerSyncContext.Provider value={mockPowerSyncError as any}>{children}</PowerSyncContext.Provider>
+    );
+
+    const { result } = renderHook(() => useQuery('SELECT * from lists', [], { runQueryOnce: true }), { wrapper });
+    expect(result.current.error).toEqual(Error('PowerSync failed to fetch data: some error'));
+  });
+
+  // TODO: Add tests for powersync.watch path
+});

--- a/packages/react/tests/useStatus.test.tsx
+++ b/packages/react/tests/useStatus.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react';
 import { vi, describe, expect, it, afterEach } from 'vitest';
-import { usePowerSyncStatus } from '../src/hooks/usePowerSyncStatus';
+import { useStatus } from '../src/hooks/useStatus';
 import { PowerSyncContext } from '../src/hooks/PowerSyncContext';
 
 const mockPowerSync = {
@@ -15,7 +15,7 @@ vi.mock('./PowerSyncContext', () => ({
   useContext: vi.fn(() => mockPowerSync)
 }));
 
-describe('usePowerSyncStatus', () => {
+describe('useStatus', () => {
   afterEach(() => {
     vi.resetAllMocks();
   });
@@ -25,7 +25,7 @@ describe('usePowerSyncStatus', () => {
       <PowerSyncContext.Provider value={mockPowerSync as any}>{children}</PowerSyncContext.Provider>
     );
 
-    const { result } = renderHook(() => usePowerSyncStatus(), { wrapper });
+    const { result } = renderHook(() => useStatus(), { wrapper });
     expect(result.current).toEqual(mockPowerSync.currentStatus);
   });
 
@@ -35,7 +35,7 @@ describe('usePowerSyncStatus', () => {
       <PowerSyncContext.Provider value={mockPowerSync as any}>{children}</PowerSyncContext.Provider>
     );
 
-    const { result } = renderHook(() => usePowerSyncStatus(), { wrapper });
+    const { result } = renderHook(() => useStatus(), { wrapper });
 
     act(() => {
       mockPowerSync.registerListener.mockResolvedValue({ statusChanged: vi.fn(() => 'updated') });
@@ -49,7 +49,7 @@ describe('usePowerSyncStatus', () => {
       <PowerSyncContext.Provider value={mockPowerSync as any}>{children}</PowerSyncContext.Provider>
     );
 
-    const { unmount } = renderHook(() => usePowerSyncStatus(), { wrapper });
+    const { unmount } = renderHook(() => useStatus(), { wrapper });
     const listenerUnsubscribe = mockPowerSync.registerListener;
 
     unmount();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1210,9 +1210,6 @@ importers:
       '@testing-library/react':
         specifier: ^15.0.2
         version: 15.0.2(react-dom@18.2.0)(react@18.2.0)
-      '@testing-library/react-hooks':
-        specifier: ^8.0.1
-        version: 8.0.1(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
       '@types/react':
         specifier: ^18.2.34
         version: 18.2.79
@@ -16250,29 +16247,6 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@testing-library/react-hooks@8.0.1(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      '@types/react': ^16.9.0 || ^17.0.0
-      react: ^16.9.0 || ^17.0.0
-      react-dom: ^16.9.0 || ^17.0.0
-      react-test-renderer: ^16.9.0 || ^17.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      react-dom:
-        optional: true
-      react-test-renderer:
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.24.0
-      '@types/react': 18.2.79
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      react-error-boundary: 3.1.4(react@18.2.0)
-    dev: true
-
   /@testing-library/react@15.0.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-5mzIpuytB1ctpyywvyaY2TAAUQVCZIGqwiqFQf6u9lvj/SJQepGUzNV18Xpk+NLCaCE2j7CWrZE0tEf9xLZYiQ==}
     engines: {node: '>=18'}
@@ -30788,6 +30762,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.24.0
       react: 18.2.0
+    dev: false
 
   /react-error-overlay@6.0.11:
     resolution: {integrity: sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==}


### PR DESCRIPTION
## Description
Implement new hooks

## Work Done
* Added `useQuery` hook 
* Added `useStatus` hook
* Deprecated `usePowersyncWatchedQuery`, `usePowerSyncQuery` and `usePowerSyncStatus` hooks
* Updated demos to use latest hooks

## How to test
* Load any of the demos and confirm that all items still load as expected

**Note:** The suspense and kysely hook changes will follow after this, and I will make a separate change for the Vue hooks so that they conform to this new change