### PR TITLE
chore: remove client property from fetchCredentials

### DIFF
--- a/demos/react-native-supabase-todolist/library/supabase/SupabaseConnector.ts
+++ b/demos/react-native-supabase-todolist/library/supabase/SupabaseConnector.ts
@@ -55,7 +55,6 @@ export class SupabaseConnector implements PowerSyncBackendConnector {
     console.debug('session expires at', session.expires_at);
 
     return {
-      client: this.client,
       endpoint: AppConfig.powersyncUrl,
       token: session.access_token ?? '',
       expiresAt: session.expires_at ? new Date(session.expires_at * 1000) : undefined,

--- a/demos/react-supabase-todolist/src/library/powersync/SupabaseConnector.ts
+++ b/demos/react-supabase-todolist/src/library/powersync/SupabaseConnector.ts
@@ -97,7 +97,6 @@ export class SupabaseConnector extends BaseObserver<SupabaseConnectorListener> i
     console.debug('session expires at', session.expires_at);
 
     return {
-      client: this.client,
       endpoint: this.config.powersyncUrl,
       token: session.access_token ?? '',
       expiresAt: session.expires_at ? new Date(session.expires_at * 1000) : undefined

--- a/demos/vue-supabase-todolist/src/library/powersync/SupabaseConnector.ts
+++ b/demos/vue-supabase-todolist/src/library/powersync/SupabaseConnector.ts
@@ -97,7 +97,6 @@ export class SupabaseConnector extends BaseObserver<SupabaseConnectorListener> i
     console.debug('session expires at', session.expires_at);
 
     return {
-      client: this.client,
       endpoint: this.config.powersyncUrl,
       token: session.access_token ?? '',
       expiresAt: session.expires_at ? new Date(session.expires_at * 1000) : undefined

--- a/demos/yjs-react-supabase-text-collab/src/library/powersync/SupabaseConnector.ts
+++ b/demos/yjs-react-supabase-text-collab/src/library/powersync/SupabaseConnector.ts
@@ -68,7 +68,6 @@ export class SupabaseConnector extends BaseObserver<SupabaseConnectorListener> i
     }
 
     return {
-      client: this.client,
       endpoint: data.powersync_url,
       token: data.token,
       expiresAt: undefined


### PR DESCRIPTION
## Description
client is not a required property and is not used in `fetchCredentials` implementation of the demos and should be removed