### PR TITLE
fix: mentioned packages in change file were outdated

### DIFF
--- a/.changeset/clever-kiwis-lay.md
+++ b/.changeset/clever-kiwis-lay.md
@@ -1,8 +1,8 @@
 ---
-"example-vite": patch
-"@journeyapps/powersync-react-supabase-todolist": patch
-"@journeyapps/powersync-yjs-text-collab-demo": patch
-"@journeyapps/powersync-vue": patch
+'example-vite': patch
+'react-supabase-todolist': patch
+'yjs-react-supabase-text-collab': patch
+'@powersync/vue': patch
 ---
 
 Updated Vite Demo apps' `include` entries to use nested dependency syntax, fixes issue with CJS nested dependencies.


### PR DESCRIPTION
This wasn't picked up as a conflict. Should be a simple rename.