### PR TITLE
chore: Updated react-native-quick-sqlite depedency to 1.1.5

### DIFF
--- a/.changeset/tame-chefs-flash.md
+++ b/.changeset/tame-chefs-flash.md
@@ -1,0 +1,8 @@
+---
+"react-native-supabase-group-chat": patch
+"react-native-supabase-todolist": patch
+"django-react-native-todolist": patch
+"@powersync/react-native": patch
+---
+
+Updated @journeyapps/react-native-quick-sqlite dependency.

--- a/demos/django-react-native-todolist/package.json
+++ b/demos/django-react-native-todolist/package.json
@@ -13,7 +13,7 @@
     "@powersync/react-native": "workspace:*",
     "@powersync/react": "workspace:*",
     "@powersync/common": "workspace:*",
-    "@journeyapps/react-native-quick-sqlite": "^1.1.4",
+    "@journeyapps/react-native-quick-sqlite": "^1.1.5",
     "@react-native-community/async-storage": "^1.12.1",
     "@react-native-community/masked-view": "^0.1.11",
     "@react-navigation/drawer": "^6.6.15",

--- a/demos/react-native-supabase-group-chat/package.json
+++ b/demos/react-native-supabase-group-chat/package.json
@@ -24,7 +24,7 @@
     "@powersync/react-native": "workspace:*",
     "@powersync/common": "workspace:*",
     "@powersync/react": "workspace:*",
-    "@journeyapps/react-native-quick-sqlite": "1.1.3",
+    "@journeyapps/react-native-quick-sqlite": "1.1.5",
     "@react-native-async-storage/async-storage": "1.21.0",
     "@shopify/flash-list": "1.6.3",
     "@supabase/supabase-js": "2.39.0",

--- a/demos/react-native-supabase-todolist/package.json
+++ b/demos/react-native-supabase-todolist/package.json
@@ -15,7 +15,7 @@
     "@powersync/react": "workspace:*",
     "@powersync/common": "workspace:*",
     "@powersync/react-native": "workspace:*",
-    "@journeyapps/react-native-quick-sqlite": "^1.1.4",
+    "@journeyapps/react-native-quick-sqlite": "^1.1.5",
     "@react-native-community/masked-view": "^0.1.11",
     "@react-navigation/drawer": "^6.6.3",
     "@react-navigation/native": "^6.0.0",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://docs.powersync.com/",
   "peerDependencies": {
-    "@journeyapps/react-native-quick-sqlite": "^1.1.4",
+    "@journeyapps/react-native-quick-sqlite": "^1.1.5",
     "base-64": "^1.0.0",
     "react": "*",
     "react-native": "*",
@@ -44,7 +44,7 @@
     "async-lock": "^1.4.0"
   },
   "devDependencies": {
-    "@journeyapps/react-native-quick-sqlite": "^1.1.4",
+    "@journeyapps/react-native-quick-sqlite": "^1.1.5",
     "@types/async-lock": "^1.4.0",
     "react-native": "0.72.4",
     "react": "18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0
       '@journeyapps/react-native-quick-sqlite':
-        specifier: ^1.1.4
-        version: 1.1.4(react-native@0.73.6)(react@18.2.0)
+        specifier: ^1.1.5
+        version: 1.1.5(react-native@0.73.6)(react@18.2.0)
       '@powersync/common':
         specifier: workspace:*
         version: link:../../packages/common
@@ -428,8 +428,8 @@ importers:
         specifier: 8.3.1
         version: 8.3.1
       '@journeyapps/react-native-quick-sqlite':
-        specifier: 1.1.3
-        version: 1.1.3(react-native@0.73.4)(react@18.2.0)
+        specifier: 1.1.5
+        version: 1.1.5(react-native@0.73.4)(react@18.2.0)
       '@powersync/common':
         specifier: workspace:*
         version: link:../../packages/common
@@ -582,8 +582,8 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0
       '@journeyapps/react-native-quick-sqlite':
-        specifier: ^1.1.4
-        version: 1.1.4(react-native@0.73.2)(react@18.2.0)
+        specifier: ^1.1.5
+        version: 1.1.5(react-native@0.73.2)(react@18.2.0)
       '@powersync/attachments':
         specifier: workspace:*
         version: link:../../packages/attachments
@@ -1260,8 +1260,8 @@ importers:
         version: 3.3.3
     devDependencies:
       '@journeyapps/react-native-quick-sqlite':
-        specifier: ^1.1.4
-        version: 1.1.4(react-native@0.72.4)(react@18.2.0)
+        specifier: ^1.1.5
+        version: 1.1.5(react-native@0.72.4)(react@18.2.0)
       '@types/async-lock':
         specifier: ^1.4.0
         version: 1.4.2
@@ -10991,20 +10991,8 @@ packages:
       '@types/yargs': 17.0.32
       chalk: 4.1.2
 
-  /@journeyapps/react-native-quick-sqlite@1.1.3(react-native@0.73.4)(react@18.2.0):
-    resolution: {integrity: sha512-dN8pw3LoqnWK9xwRFFKXVkfeY9SOFgKLyDkd2XbjYErRSF2BeklBba6GAbGkgX9WU4hI4ppGoAmaZD8VxBHLTA==}
-    peerDependencies:
-      react: '*'
-      react-native: '*'
-    dependencies:
-      lodash: 4.17.21
-      react: 18.2.0
-      react-native: 0.73.4(@babel/core@7.23.5)(@babel/preset-env@7.24.4)(react@18.2.0)
-      uuid: 3.4.0
-    dev: false
-
-  /@journeyapps/react-native-quick-sqlite@1.1.4(react-native@0.72.4)(react@18.2.0):
-    resolution: {integrity: sha512-EygtxGTKNWygXrDrUNzMNvHMN/gg8WEfP0IjmxzNIIhAqm5XrUuYhNeQniAd4sP+hP76yfDKEA/+P2VsNg15kA==}
+  /@journeyapps/react-native-quick-sqlite@1.1.5(react-native@0.72.4)(react@18.2.0):
+    resolution: {integrity: sha512-JRlF5k1Ui/XPxtDBkDBoCkfs2ldjdcXLW8OnpO9+f0sE8E3MoKqOzMFH+oRwso3NrT/OABhhXKSYnZgLyCphvQ==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -11015,8 +11003,8 @@ packages:
       uuid: 9.0.1
     dev: true
 
-  /@journeyapps/react-native-quick-sqlite@1.1.4(react-native@0.73.2)(react@18.2.0):
-    resolution: {integrity: sha512-EygtxGTKNWygXrDrUNzMNvHMN/gg8WEfP0IjmxzNIIhAqm5XrUuYhNeQniAd4sP+hP76yfDKEA/+P2VsNg15kA==}
+  /@journeyapps/react-native-quick-sqlite@1.1.5(react-native@0.73.2)(react@18.2.0):
+    resolution: {integrity: sha512-JRlF5k1Ui/XPxtDBkDBoCkfs2ldjdcXLW8OnpO9+f0sE8E3MoKqOzMFH+oRwso3NrT/OABhhXKSYnZgLyCphvQ==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -11027,8 +11015,20 @@ packages:
       uuid: 9.0.1
     dev: false
 
-  /@journeyapps/react-native-quick-sqlite@1.1.4(react-native@0.73.6)(react@18.2.0):
-    resolution: {integrity: sha512-EygtxGTKNWygXrDrUNzMNvHMN/gg8WEfP0IjmxzNIIhAqm5XrUuYhNeQniAd4sP+hP76yfDKEA/+P2VsNg15kA==}
+  /@journeyapps/react-native-quick-sqlite@1.1.5(react-native@0.73.4)(react@18.2.0):
+    resolution: {integrity: sha512-JRlF5k1Ui/XPxtDBkDBoCkfs2ldjdcXLW8OnpO9+f0sE8E3MoKqOzMFH+oRwso3NrT/OABhhXKSYnZgLyCphvQ==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+    dependencies:
+      lodash: 4.17.21
+      react: 18.2.0
+      react-native: 0.73.4(@babel/core@7.23.5)(@babel/preset-env@7.24.4)(react@18.2.0)
+      uuid: 9.0.1
+    dev: false
+
+  /@journeyapps/react-native-quick-sqlite@1.1.5(react-native@0.73.6)(react@18.2.0):
+    resolution: {integrity: sha512-JRlF5k1Ui/XPxtDBkDBoCkfs2ldjdcXLW8OnpO9+f0sE8E3MoKqOzMFH+oRwso3NrT/OABhhXKSYnZgLyCphvQ==}
     peerDependencies:
       react: '*'
       react-native: '*'
@@ -25847,8 +25847,6 @@ packages:
     peerDependenciesMeta:
       webpack:
         optional: true
-      webpack-sources:
-        optional: true
     dependencies:
       webpack: 5.89.0(esbuild@0.19.11)
       webpack-sources: 3.2.3
@@ -35132,12 +35130,6 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  /uuid@3.4.0:
-    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
-    hasBin: true
-    dev: false
-
   /uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
     hasBin: true
@@ -36705,6 +36697,7 @@ packages:
 
   /workbox-google-analytics@7.0.0:
     resolution: {integrity: sha512-MEYM1JTn/qiC3DbpvP2BVhyIH+dV/5BjHk756u9VbwuAhu0QHyKscTnisQuz21lfRpOwiS9z4XdqeVAKol0bzg==}
+    deprecated: It is not compatible with newer versions of GA starting with v4, as long as you are using GAv3 it should be ok, but the package is not longer being maintained
     dependencies:
       workbox-background-sync: 7.0.0
       workbox-core: 7.0.0


### PR DESCRIPTION
Verified todo app still works on a clean install (with 10k+ todos).