### PR TITLE
fix: kysely closing db on execute

### DIFF
--- a/.changeset/metal-cheetahs-try.md
+++ b/.changeset/metal-cheetahs-try.md
@@ -1,0 +1,5 @@
+---
+"@powersync/kysely-driver": minor
+---
+
+Made `destroy` and `releaseConnection` no-op functions. If you relied on `destroy` you will need to use `disconnectAndClear` on the PowerSync DB directly.

--- a/packages/kysely-driver/src/sqlite/sqlite-connection.ts
+++ b/packages/kysely-driver/src/sqlite/sqlite-connection.ts
@@ -105,9 +105,7 @@ export class PowerSyncConnection implements DatabaseConnection {
     this.releaseTransaction();
   }
 
-  async releaseConnection(): Promise<void> {
-    this.#db.close();
-  }
+  async releaseConnection(): Promise<void> {}
 
   private releaseTransaction() {
     if (!this.#completeTransaction) {

--- a/packages/kysely-driver/src/sqlite/sqlite-driver.ts
+++ b/packages/kysely-driver/src/sqlite/sqlite-driver.ts
@@ -35,5 +35,8 @@ export class PowerSyncDriver implements Driver {
     await connection.releaseConnection();
   }
 
+  /**
+    This will do nothing. Instead use PowerSync `disconnectAndClear` function.
+   */
   async destroy(): Promise<void> {}
 }

--- a/packages/kysely-driver/src/sqlite/sqlite-driver.ts
+++ b/packages/kysely-driver/src/sqlite/sqlite-driver.ts
@@ -35,7 +35,5 @@ export class PowerSyncDriver implements Driver {
     await connection.releaseConnection();
   }
 
-  async destroy(): Promise<void> {
-    this.#db.disconnectAndClear();
-  }
+  async destroy(): Promise<void> {}
 }

--- a/packages/kysely-driver/tests/sqlite/db.test.ts
+++ b/packages/kysely-driver/tests/sqlite/db.test.ts
@@ -15,7 +15,7 @@ describe('CRUD operations', () => {
   });
 
   afterEach(async () => {
-    await db.destroy();
+    await powerSyncDb.disconnectAndClear();
   });
 
   it('should insert a user and select that user', async () => {


### PR DESCRIPTION
## Description
Make `releaseConnection` and `destroy` no-ops to fix issue where `execute` was resulting in the PowerSync DB being closed.

## Work Done
* Made `releaseConnection` a no-op
* Made `destroy` a no-op