### PR TITLE
[diagnostics-app] Fix sync status

### DIFF
--- a/tools/diagnostics-app/src/app/views/layout.tsx
+++ b/tools/diagnostics-app/src/app/views/layout.tsx
@@ -28,14 +28,14 @@ import React from 'react';
 import { LOGIN_ROUTE, SCHEMA_ROUTE, SQL_CONSOLE_ROUTE, SYNC_DIAGNOSTICS_ROUTE } from '@/app/router';
 import { useNavigationPanel } from '@/components/navigation/NavigationPanelContext';
 import { signOut, sync, syncErrorTracker } from '@/library/powersync/ConnectionManager';
-import { usePowerSync, useStatus } from '@powersync/react';
+import { usePowerSync } from '@powersync/react';
 import { useNavigate } from 'react-router-dom';
 
 export default function ViewsLayout({ children }: { children: React.ReactNode }) {
   const powerSync = usePowerSync();
   const navigate = useNavigate();
 
-  const syncStatus = useStatus();
+  const [syncStatus, setSyncStatus] = React.useState(sync.syncStatus);
   const [syncError, setSyncError] = React.useState<Error | null>(null);
   const { title } = useNavigationPanel();
 
@@ -85,6 +85,16 @@ export default function ViewsLayout({ children }: { children: React.ReactNode })
     ],
     [powerSync]
   );
+
+  // Cannot use `useStatus()`, since we're not using the default sync implementation.
+  React.useEffect(() => {
+    const l = sync.registerListener({
+      statusChanged: (status) => {
+        setSyncStatus(status);
+      }
+    });
+    return () => l();
+  }, [powerSync]);
 
   React.useEffect(() => {
     const l = syncErrorTracker.registerListener({


### PR DESCRIPTION
The diagnostics app uses a custom instance of `WebStreamingSyncImplementation`, so the sync status is not reported on the database, and `useStatus()` doesn't work correctly.

Reverts https://github.com/powersync-ja/powersync-js/pull/151/commits/c19246c5a3cece2519dad46a8ce51a4ff51cbea4.