### PR TITLE
Remove uuid and react-native-get-random-values dependencies

### DIFF
--- a/.changeset/heavy-dancers-drum.md
+++ b/.changeset/heavy-dancers-drum.md
@@ -1,0 +1,6 @@
+---
+'@powersync/common': patch
+'@powersync/web': patch
+---
+
+Remove uuid dependency

--- a/.changeset/proud-falcons-lay.md
+++ b/.changeset/proud-falcons-lay.md
@@ -1,0 +1,5 @@
+---
+'@powersync/react-native': patch
+---
+
+Remove react-native-get-random-values dependency

--- a/demos/angular-supabase-todolist/angular.json
+++ b/demos/angular-supabase-todolist/angular.json
@@ -24,7 +24,6 @@
               "object-hash",
               "event-iterator",
               "can-ndjson-stream",
-              "uuid",
               "lodash",
               "js-logger",
               "websocket"

--- a/demos/django-react-native-todolist/library/stores/AbstractStore.ts
+++ b/demos/django-react-native-todolist/library/stores/AbstractStore.ts
@@ -1,5 +1,3 @@
-// Needed to import early for uuids
-import 'react-native-get-random-values';
 import _ from 'lodash';
 import { action, makeObservable, observable } from 'mobx';
 import { AbstractModel } from '../models/AbstractModel';

--- a/demos/django-react-native-todolist/package.json
+++ b/demos/django-react-native-todolist/package.json
@@ -19,7 +19,6 @@
     "@react-navigation/drawer": "^6.6.15",
     "@react-navigation/native": "^6.1.17",
     "@supabase/supabase-js": "^2.42.4",
-    "@types/react-native-get-random-values": "^1.8.2",
     "base-64": "^1.0.0",
     "expo": "~50.0.15",
     "expo-constants": "~15.4.5",
@@ -39,7 +38,6 @@
     "react-native-encrypted-storage": "^4.0.3",
     "react-native-fetch-api": "^3.0.0",
     "react-native-gesture-handler": "~2.14.1",
-    "react-native-get-random-values": "~1.8.0",
     "react-native-polyfill-globals": "^3.1.0",
     "react-native-prompt-android": "^1.1.0",
     "react-native-reanimated": "~3.6.3",
@@ -52,7 +50,6 @@
     "react-navigation-stack": "^2.10.4",
     "text-encoding": "^0.7.0",
     "typed-async-storage": "^3.1.2",
-    "uuid": "^9.0.1",
     "web-streams-polyfill": "^3.3.3"
   },
   "devDependencies": {

--- a/demos/example-electron/vite.renderer.config.ts
+++ b/demos/example-electron/vite.renderer.config.ts
@@ -26,7 +26,6 @@ export default defineConfig((env) => {
       // https://github.com/vitejs/vite/issues/11672#issuecomment-1415820673
       exclude: ['@journeyapps/wa-sqlite', '@powersync/web'],
       include: [
-        '@powersync/web > uuid',
         '@powersync/web > event-iterator',
         '@powersync/web > js-logger',
         '@powersync/web > lodash/throttle',

--- a/demos/example-nextjs/package.json
+++ b/demos/example-nextjs/package.json
@@ -33,15 +33,13 @@
     "react-dom": "^18.2.0",
     "remixicon": "^2.5.0",
     "shiki": "^0.10.1",
-    "simplify-js": "^1.2.4",
-    "uuid": "9.0.1"
+    "simplify-js": "^1.2.4"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.202",
     "@types/node": "^20.11.25",
     "@types/react": "^18.2.64",
     "@types/react-dom": "^18.2.21",
-    "@types/uuid": "9.0.8",
     "autoprefixer": "^10.4.18",
     "babel-loader": "^9.1.3",
     "css-loader": "^6.10.0",

--- a/demos/example-vite/vite.config.ts
+++ b/demos/example-vite/vite.config.ts
@@ -19,7 +19,6 @@ export default defineConfig({
     // https://github.com/vitejs/vite/issues/11672#issuecomment-1415820673
     exclude: ['@journeyapps/wa-sqlite', '@powersync/web'],
     include: [
-      '@powersync/web > uuid',
       '@powersync/web > event-iterator',
       '@powersync/web > js-logger',
       '@powersync/web > lodash/throttle',

--- a/demos/react-native-supabase-group-chat/package.json
+++ b/demos/react-native-supabase-group-chat/package.json
@@ -49,7 +49,6 @@
     "react-native": "0.73.4",
     "react-native-fetch-api": "^3.0.0",
     "react-native-gesture-handler": "~2.14.1",
-    "react-native-get-random-values": "~1.8.0",
     "react-native-pager-view": "6.2.3",
     "react-native-polyfill-globals": "^3.1.0",
     "react-native-reanimated": "~3.6.2",

--- a/demos/react-native-supabase-todolist/library/powersync/PhotoAttachmentQueue.ts
+++ b/demos/react-native-supabase-todolist/library/powersync/PhotoAttachmentQueue.ts
@@ -1,5 +1,5 @@
 import * as FileSystem from 'expo-file-system';
-import { v4 as uuid } from 'uuid';
+import { randomUUID } from 'expo-crypto';
 import { AppConfig } from '../supabase/AppConfig';
 import { AbstractAttachmentQueue, AttachmentRecord, AttachmentState } from '@powersync/attachments';
 import { TODO_TABLE } from './AppSchema';
@@ -23,7 +23,7 @@ export class PhotoAttachmentQueue extends AbstractAttachmentQueue {
   }
 
   async newAttachmentRecord(record?: Partial<AttachmentRecord>): Promise<AttachmentRecord> {
-    const photoId = record?.id ?? uuid();
+    const photoId = record?.id ?? randomUUID();
     const filename = record?.filename ?? `${photoId}.jpg`;
     return {
       id: photoId,

--- a/demos/react-native-supabase-todolist/package.json
+++ b/demos/react-native-supabase-todolist/package.json
@@ -26,6 +26,7 @@
     "expo-build-properties": "~0.11.0",
     "expo-camera": "~14.0.3",
     "expo-constants": "~15.4.5",
+    "expo-crypto": "~12.8.0",
     "expo-file-system": "^16.0.5",
     "expo-linking": "~6.2.2",
     "expo-modules-autolinking": "^1.5.1",
@@ -43,7 +44,6 @@
     "react-native-encrypted-storage": "^4.0.3",
     "react-native-fetch-api": "^3.0.0",
     "react-native-gesture-handler": "~2.14.1",
-    "react-native-get-random-values": "~1.10.0",
     "react-native-polyfill-globals": "^3.1.0",
     "react-native-prompt-android": "^1.1.0",
     "react-native-reanimated": "~3.6.2",
@@ -55,7 +55,6 @@
     "react-native-vector-icons": "^10.0.0",
     "react-navigation-stack": "^2.10.4",
     "text-encoding": "^0.7.0",
-    "uuid": "^9.0.1",
     "web-streams-polyfill": "^3.3.2"
   },
   "devDependencies": {
@@ -65,7 +64,6 @@
     "@types/base-64": "^1.0.2",
     "@types/lodash": "^4.14.202",
     "@types/react": "~18.2.57",
-    "@types/uuid": "^9.0.1",
     "babel-preset-expo": "^10.0.1",
     "prettier": "^3.2.5",
     "typescript": "^5.3.3"

--- a/demos/react-supabase-todolist/vite.config.mts
+++ b/demos/react-supabase-todolist/vite.config.mts
@@ -26,7 +26,6 @@ export default defineConfig({
     // https://github.com/vitejs/vite/issues/11672#issuecomment-1415820673
     exclude: ['@journeyapps/wa-sqlite', '@powersync/web'],
     include: [
-      '@powersync/web > uuid',
       '@powersync/web > event-iterator',
       '@powersync/web > js-logger',
       '@powersync/web > lodash/throttle',

--- a/demos/vue-supabase-todolist/package.json
+++ b/demos/vue-supabase-todolist/package.json
@@ -17,7 +17,6 @@
     "@vuelidate/core": "^2.0.3",
     "@vuelidate/validators": "^2.0.4",
     "js-logger": "^1.6.1",
-    "uuid": "^9.0.1",
     "vue": "^3.4.21",
     "vue-router": "4",
     "vuetify": "^3.5.7"

--- a/demos/vue-supabase-todolist/vite.config.ts
+++ b/demos/vue-supabase-todolist/vite.config.ts
@@ -79,7 +79,6 @@ export default defineConfig({
     // https://github.com/vitejs/vite/issues/11672#issuecomment-1415820673
     exclude: ['@journeyapps/wa-sqlite', '@powersync/web'],
     include: [
-      '@powersync/web > uuid',
       '@powersync/web > event-iterator',
       '@powersync/web > js-logger',
       '@powersync/web > lodash/throttle',

--- a/demos/yjs-react-supabase-text-collab/package.json
+++ b/demos/yjs-react-supabase-text-collab/package.json
@@ -44,7 +44,7 @@
     "remixicon": "^2.5.0",
     "shiki": "^0.10.1",
     "simplify-js": "^1.2.4",
-    "uuid": "9.0.1",
+    "uuid": "^9.0.1",
     "y-prosemirror": "1.0.20",
     "y-protocols": "1.0.6",
     "yjs": "^13.6.14"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -31,8 +31,7 @@
     "can-ndjson-stream": "^1.0.2",
     "event-iterator": "^2.0.0",
     "js-logger": "^1.6.1",
-    "lodash": "^4.17.21",
-    "uuid": "^9.0.1"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.197",

--- a/packages/common/src/utils/BaseObserver.ts
+++ b/packages/common/src/utils/BaseObserver.ts
@@ -1,5 +1,3 @@
-import { v4 } from 'uuid';
-
 export interface Disposable {
   dispose: () => Promise<void>;
 }
@@ -13,26 +11,23 @@ export type BaseListener = {
 };
 
 export class BaseObserver<T extends BaseListener = BaseListener> implements BaseObserverInterface<T> {
-  protected listeners: { [id: string]: Partial<T> };
+  protected listeners = new Set<Partial<T>>();
 
-  constructor() {
-    this.listeners = {};
-  }
+  constructor() {}
 
   /**
    * Register a listener for updates to the PowerSync client.
    */
   registerListener(listener: Partial<T>): () => void {
-    const id = v4();
-    this.listeners[id] = listener;
+    this.listeners.add(listener);
     return () => {
-      delete this.listeners[id];
+      this.listeners.delete(listener);
     };
   }
 
   iterateListeners(cb: (listener: Partial<T>) => any) {
-    for (const i in this.listeners) {
-      cb(this.listeners[i]);
+    for (const listener of this.listeners) {
+      cb(listener);
     }
   }
 }

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -43,7 +43,7 @@ This SDK requires HTTP streaming in order to function. The following `fetch` pol
 These are listed as peer dependencies and need to be added to the React Native project
 
 ```bash
-npx expo install react-native-fetch-api react-native-polyfill-globals react-native-url-polyfill text-encoding web-streams-polyfill@3.2.1 base-64 react-native-get-random-values@1.9.0
+npx expo install react-native-fetch-api react-native-polyfill-globals react-native-url-polyfill text-encoding web-streams-polyfill@3.2.1 base-64
 ```
 
 Enable the polyfills in React Native app with

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -32,7 +32,6 @@
     "react": "*",
     "react-native": "*",
     "react-native-fetch-api": "^3.0.0",
-    "react-native-get-random-values": "^1.9.0",
     "react-native-polyfill-globals": "^3.1.0",
     "react-native-url-polyfill": "^2.0.0",
     "text-encoding": "^0.7.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -42,7 +42,8 @@
     "vite-plugin-top-level-await": "^1.4.1",
     "vite-plugin-wasm": "^3.3.0",
     "vitest": "^1.3.1",
-    "webdriverio": "^8.32.3"
+    "webdriverio": "^8.32.3",
+    "uuid": "^9.0.1"
   },
   "peerDependencies": {
     "@journeyapps/wa-sqlite": "~0.2.0"
@@ -52,7 +53,6 @@
     "async-mutex": "^0.4.0",
     "comlink": "^4.4.1",
     "js-logger": "^1.6.1",
-    "lodash": "^4.17.21",
-    "uuid": "^9.0.1"
+    "lodash": "^4.17.21"
   }
 }

--- a/packages/web/src/worker/db/SharedWASQLiteDB.worker.ts
+++ b/packages/web/src/worker/db/SharedWASQLiteDB.worker.ts
@@ -1,7 +1,6 @@
 import '@journeyapps/wa-sqlite';
 
 import * as Comlink from 'comlink';
-import { v4 as uuid } from 'uuid';
 
 import { DBWorkerInterface, _openDB } from './open-db';
 
@@ -10,7 +9,7 @@ import { DBWorkerInterface, _openDB } from './open-db';
  * are using it.
  */
 type SharedDBWorkerConnection = {
-  clientIds: Set<string>;
+  clientIds: Set<number>;
   db: DBWorkerInterface;
 };
 
@@ -19,13 +18,15 @@ const _self: SharedWorkerGlobalScope = self as any;
 const DBMap = new Map<string, SharedDBWorkerConnection>();
 const OPEN_DB_LOCK = 'open-wasqlite-db';
 
+let nextClientId = 1;
+
 const openDB = async (dbFileName: string): Promise<DBWorkerInterface> => {
   // Prevent multiple simultaneous opens from causing race conditions
   return navigator.locks.request(OPEN_DB_LOCK, async () => {
-    const clientId = uuid();
+    const clientId = nextClientId++;
 
     if (!DBMap.has(dbFileName)) {
-      const clientIds = new Set<string>();
+      const clientIds = new Set<number>();
       const connection = await _openDB(dbFileName);
       DBMap.set(dbFileName, {
         clientIds,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,9 +126,6 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.42.4
         version: 2.43.1
-      '@types/react-native-get-random-values':
-        specifier: ^1.8.2
-        version: 1.8.2
       base-64:
         specifier: ^1.0.0
         version: 1.0.0
@@ -186,12 +183,9 @@ importers:
       react-native-gesture-handler:
         specifier: ~2.14.1
         version: 2.14.1(react-native@0.73.6)(react@18.2.0)
-      react-native-get-random-values:
-        specifier: ~1.8.0
-        version: 1.8.0(react-native@0.73.6)
       react-native-polyfill-globals:
         specifier: ^3.1.0
-        version: 3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.8.0)(react-native-url-polyfill@2.0.0)(text-encoding@0.7.0)(web-streams-polyfill@3.3.3)
+        version: 3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.10.0)(react-native-url-polyfill@2.0.0)(text-encoding@0.7.0)(web-streams-polyfill@3.3.3)
       react-native-prompt-android:
         specifier: ^1.1.0
         version: 1.1.0
@@ -225,9 +219,6 @@ importers:
       typed-async-storage:
         specifier: ^3.1.2
         version: 3.1.2
-      uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
       web-streams-polyfill:
         specifier: ^3.3.3
         version: 3.3.3
@@ -431,9 +422,6 @@ importers:
       simplify-js:
         specifier: ^1.2.4
         version: 1.2.4
-      uuid:
-        specifier: 9.0.1
-        version: 9.0.1
     devDependencies:
       '@types/lodash':
         specifier: ^4.14.202
@@ -447,9 +435,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.21
         version: 18.3.0
-      '@types/uuid':
-        specifier: 9.0.8
-        version: 9.0.8
       autoprefixer:
         specifier: ^10.4.18
         version: 10.4.19(postcss@8.4.38)
@@ -611,9 +596,6 @@ importers:
       react-native-gesture-handler:
         specifier: ~2.14.1
         version: 2.14.1(react-native@0.73.4)(react@18.2.0)
-      react-native-get-random-values:
-        specifier: ~1.8.0
-        version: 1.8.0(react-native@0.73.4)
       react-native-pager-view:
         specifier: 6.2.3
         version: 6.2.3(react-native@0.73.4)(react@18.2.0)
@@ -950,9 +932,6 @@ importers:
       js-logger:
         specifier: ^1.6.1
         version: 1.6.1
-      uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
       vue:
         specifier: ^3.4.21
         version: 3.4.21(typescript@5.4.5)
@@ -1108,7 +1087,7 @@ importers:
         specifier: ^1.2.4
         version: 1.2.4
       uuid:
-        specifier: 9.0.1
+        specifier: ^9.0.1
         version: 9.0.1
       y-prosemirror:
         specifier: 1.0.20
@@ -1238,9 +1217,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
     devDependencies:
       '@types/lodash':
         specifier: ^4.14.197
@@ -1343,9 +1319,6 @@ importers:
       react-native-fetch-api:
         specifier: ^3.0.0
         version: 3.0.0
-      react-native-get-random-values:
-        specifier: ^1.9.0
-        version: 1.10.0(react-native@0.72.4)
       react-native-polyfill-globals:
         specifier: ^3.1.0
         version: 3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.10.0)(react-native-url-polyfill@2.0.0)(text-encoding@0.7.0)(web-streams-polyfill@3.3.3)
@@ -1414,9 +1387,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
     devDependencies:
       '@journeyapps/wa-sqlite':
         specifier: ~0.2.0
@@ -1433,6 +1403,9 @@ importers:
       typescript:
         specifier: ^5.2.2
         version: 5.4.5
+      uuid:
+        specifier: ^9.0.1
+        version: 9.0.1
       vite:
         specifier: ^5.1.1
         version: 5.2.11(sass@1.76.0)
@@ -14607,10 +14580,6 @@ packages:
     dependencies:
       '@types/react': 18.2.79
     dev: true
-
-  /@types/react-native-get-random-values@1.8.2:
-    resolution: {integrity: sha512-CmtnfZnHKkVupG71SI9S7DDqkV6dtxxNIAzh2r1F1/tB8vg2weBtLhHmcruMIwp9Y69IZZ3DwJ0BhRpsbj42QA==}
-    dev: false
 
   /@types/react-native-table-component@1.2.8(@babel/core@7.24.5)(@babel/preset-env@7.24.5)(react@18.2.0):
     resolution: {integrity: sha512-ZhWnoW3LpzXx+fCyosNBVasVCuaWNCMDMcP0mO9FSSK8eRE4ihLTqKiit6zjpph9ot4LQ/mD8hmbhV0YpRLvOQ==}
@@ -28433,15 +28402,6 @@ packages:
       react-native: 0.73.6(@babel/core@7.24.5)(@babel/preset-env@7.24.5)(react@18.2.0)
     dev: false
 
-  /react-native-get-random-values@1.10.0(react-native@0.72.4):
-    resolution: {integrity: sha512-gZ1zbXhbb8+Jy9qYTV8c4Nf45/VB4g1jmXuavY5rPfUn7x3ok9Vl3FTl0dnE92Z4FFtfbUNNwtSfcmomdtWg+A==}
-    peerDependencies:
-      react-native: '>=0.56'
-    dependencies:
-      fast-base64-decode: 1.0.0
-      react-native: 0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.5)(react@18.2.0)
-    dev: false
-
   /react-native-get-random-values@1.10.0(react-native@0.73.2):
     resolution: {integrity: sha512-gZ1zbXhbb8+Jy9qYTV8c4Nf45/VB4g1jmXuavY5rPfUn7x3ok9Vl3FTl0dnE92Z4FFtfbUNNwtSfcmomdtWg+A==}
     peerDependencies:
@@ -28458,15 +28418,6 @@ packages:
     dependencies:
       fast-base64-decode: 1.0.0
       react-native: 0.73.4(@babel/core@7.23.5)(@babel/preset-env@7.24.5)(react@18.2.0)
-    dev: false
-
-  /react-native-get-random-values@1.8.0(react-native@0.73.6):
-    resolution: {integrity: sha512-H/zghhun0T+UIJLmig3+ZuBCvF66rdbiWUfRSNS6kv5oDSpa1ZiVyvRWtuPesQpT8dXj+Bv7WJRQOUP+5TB1sA==}
-    peerDependencies:
-      react-native: '>=0.56'
-    dependencies:
-      fast-base64-decode: 1.0.0
-      react-native: 0.73.6(@babel/core@7.24.5)(@babel/preset-env@7.24.5)(react@18.2.0)
     dev: false
 
   /react-native-iphone-x-helper@1.3.1(react-native@0.73.2):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,7 +601,7 @@ importers:
         version: 6.2.3(react-native@0.73.4)(react@18.2.0)
       react-native-polyfill-globals:
         specifier: ^3.1.0
-        version: 3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.8.0)(react-native-url-polyfill@2.0.0)(text-encoding@0.7.0)(web-streams-polyfill@3.3.3)
+        version: 3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.10.0)(react-native-url-polyfill@2.0.0)(text-encoding@0.7.0)(web-streams-polyfill@3.3.3)
       react-native-reanimated:
         specifier: ~3.6.2
         version: 3.6.3(@babel/core@7.23.5)(@babel/plugin-proposal-nullish-coalescing-operator@7.18.6)(@babel/plugin-proposal-optional-chaining@7.21.0)(@babel/plugin-transform-arrow-functions@7.24.1)(@babel/plugin-transform-shorthand-properties@7.24.1)(@babel/plugin-transform-template-literals@7.24.1)(react-native@0.73.4)(react@18.2.0)
@@ -708,6 +708,9 @@ importers:
       expo-constants:
         specifier: ~15.4.5
         version: 15.4.6(expo@50.0.17)
+      expo-crypto:
+        specifier: ~12.8.0
+        version: 12.8.1(expo@50.0.17)
       expo-file-system:
         specifier: ^16.0.5
         version: 16.0.9(expo@50.0.17)
@@ -759,9 +762,6 @@ importers:
       react-native-gesture-handler:
         specifier: ~2.14.1
         version: 2.14.1(react-native@0.73.2)(react@18.2.0)
-      react-native-get-random-values:
-        specifier: ~1.10.0
-        version: 1.10.0(react-native@0.73.2)
       react-native-polyfill-globals:
         specifier: ^3.1.0
         version: 3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.10.0)(react-native-url-polyfill@2.0.0)(text-encoding@0.7.0)(web-streams-polyfill@3.3.3)
@@ -795,9 +795,6 @@ importers:
       text-encoding:
         specifier: ^0.7.0
         version: 0.7.0
-      uuid:
-        specifier: ^9.0.1
-        version: 9.0.1
       web-streams-polyfill:
         specifier: ^3.3.2
         version: 3.3.3
@@ -820,9 +817,6 @@ importers:
       '@types/react':
         specifier: ~18.2.57
         version: 18.2.79
-      '@types/uuid':
-        specifier: ^9.0.1
-        version: 9.0.8
       babel-preset-expo:
         specifier: ^10.0.1
         version: 10.0.2(@babel/core@7.24.5)
@@ -28402,17 +28396,8 @@ packages:
       react-native: 0.73.6(@babel/core@7.24.5)(@babel/preset-env@7.24.5)(react@18.2.0)
     dev: false
 
-  /react-native-get-random-values@1.10.0(react-native@0.73.2):
+  /react-native-get-random-values@1.10.0(react-native@0.73.4):
     resolution: {integrity: sha512-gZ1zbXhbb8+Jy9qYTV8c4Nf45/VB4g1jmXuavY5rPfUn7x3ok9Vl3FTl0dnE92Z4FFtfbUNNwtSfcmomdtWg+A==}
-    peerDependencies:
-      react-native: '>=0.56'
-    dependencies:
-      fast-base64-decode: 1.0.0
-      react-native: 0.73.2(@babel/core@7.24.5)(@babel/preset-env@7.24.5)(react@18.2.0)
-    dev: false
-
-  /react-native-get-random-values@1.8.0(react-native@0.73.4):
-    resolution: {integrity: sha512-H/zghhun0T+UIJLmig3+ZuBCvF66rdbiWUfRSNS6kv5oDSpa1ZiVyvRWtuPesQpT8dXj+Bv7WJRQOUP+5TB1sA==}
     peerDependencies:
       react-native: '>=0.56'
     dependencies:
@@ -28458,25 +28443,7 @@ packages:
     dependencies:
       base-64: 1.0.0
       react-native-fetch-api: 3.0.0
-      react-native-get-random-values: 1.10.0(react-native@0.73.2)
-      react-native-url-polyfill: 2.0.0(react-native@0.73.2)
-      text-encoding: 0.7.0
-      web-streams-polyfill: 3.3.3
-    dev: false
-
-  /react-native-polyfill-globals@3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.8.0)(react-native-url-polyfill@2.0.0)(text-encoding@0.7.0)(web-streams-polyfill@3.3.3):
-    resolution: {integrity: sha512-6ACmV1SjXvZP2LN6J2yK58yNACKddcvoiKLrSQdISx32IdYStfdmGXrbAfpd+TANrTlIaZ2SLoFXohNwhnqm/w==}
-    peerDependencies:
-      base-64: '*'
-      react-native-fetch-api: '*'
-      react-native-get-random-values: '*'
-      react-native-url-polyfill: '*'
-      text-encoding: '*'
-      web-streams-polyfill: '*'
-    dependencies:
-      base-64: 1.0.0
-      react-native-fetch-api: 3.0.0
-      react-native-get-random-values: 1.8.0(react-native@0.73.4)
+      react-native-get-random-values: 1.10.0(react-native@0.73.4)
       react-native-url-polyfill: 2.0.0(react-native@0.73.4)
       text-encoding: 0.7.0
       web-streams-polyfill: 3.3.3


### PR DESCRIPTION
This helps to reduce build issues, especially for react-native which needs `react-native-get-random-values` for that.

Most of the places we use it is in-memory only can be replaced by a simple incrementing integer id.

`deleteBucket` is slightly more complex, but we can let SQLite generate a uuid for us in that case.

Some demos still use `uuid` in other places, but none of the core packages should need it anymore.

Also see https://github.com/powersync-ja/react-native-quick-sqlite/pull/31.