### PR TITLE
chore: add common as peer dependency to packages

### DIFF
--- a/.changeset/tasty-teachers-switch.md
+++ b/.changeset/tasty-teachers-switch.md
@@ -1,0 +1,10 @@
+---
+"@powersync/kysely-driver": patch
+"@powersync/react-native": patch
+"@powersync/attachments": patch
+"@powersync/react": patch
+"@powersync/vue": patch
+"@powersync/web": patch
+---
+
+Add @powersync/common as peer dependency

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -26,7 +26,9 @@
     "clean": "rm -rf lib tsconfig.tsbuildinfo",
     "watch": "tsc -b -w"
   },
-  "devDependencies": {},
+  "peerDependencies": {
+    "@powersync/common": "1.x"
+  },
   "dependencies": {
     "@powersync/common": "workspace:*"
   }

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -27,9 +27,6 @@
     "watch": "tsc -b -w"
   },
   "peerDependencies": {
-    "@powersync/common": "1.x"
-  },
-  "dependencies": {
-    "@powersync/common": "workspace:*"
+    "@powersync/common": "workspace:1.x"
   }
 }

--- a/packages/kysely-driver/package.json
+++ b/packages/kysely-driver/package.json
@@ -25,10 +25,9 @@
     "test": "pnpm build && vitest"
   },
   "peerDependencies": {
-    "@powersync/common": "1.x"
+    "@powersync/common": "workspace:1.x"
   },
   "dependencies": {
-    "@powersync/common": "workspace:*",
     "kysely": "^0.27.2"
   },
   "devDependencies": {

--- a/packages/kysely-driver/package.json
+++ b/packages/kysely-driver/package.json
@@ -24,6 +24,9 @@
     "watch": "tsc --build -w",
     "test": "pnpm build && vitest"
   },
+  "peerDependencies": {
+    "@powersync/common": "1.x"
+  },
   "dependencies": {
     "@powersync/common": "workspace:*",
     "kysely": "^0.27.2"

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -30,7 +30,8 @@
     "@journeyapps/react-native-quick-sqlite": "^1.1.6",
     "react": "*",
     "react-native": "*",
-    "react-native-polyfill-globals": "^3.1.0"
+    "react-native-polyfill-globals": "^3.1.0",
+    "@powersync/common": "1.x"
   },
   "dependencies": {
     "@powersync/react": "workspace:*",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -31,11 +31,10 @@
     "react": "*",
     "react-native": "*",
     "react-native-polyfill-globals": "^3.1.0",
-    "@powersync/common": "1.x"
+    "@powersync/common": "workspace:1.x"
   },
   "dependencies": {
     "@powersync/react": "workspace:*",
-    "@powersync/common": "workspace:*",
     "async-lock": "^1.4.0"
   },
   "devDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,7 +31,8 @@
     "@powersync/common": "workspace:*"
   },
   "peerDependencies": {
-    "react": "*"
+    "react": "*",
+    "@powersync/common": "1.x"
   },
   "devDependencies": {
     "@testing-library/react": "^15.0.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -27,12 +27,9 @@
     "url": "https://github.com/powersync-ja/powersync-js/issues"
   },
   "homepage": "https://docs.powersync.com/resources/api-reference",
-  "dependencies": {
-    "@powersync/common": "workspace:*"
-  },
   "peerDependencies": {
     "react": "*",
-    "@powersync/common": "1.x"
+    "@powersync/common": "workspace:1.x"
   },
   "devDependencies": {
     "@testing-library/react": "^15.0.2",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -31,7 +31,8 @@
     "@powersync/common": "workspace:*"
   },
   "peerDependencies": {
-    "vue": "*"
+    "vue": "*",
+    "@powersync/common": "1.x"
   },
   "devDependencies": {
     "flush-promises": "^1.0.2",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -27,12 +27,9 @@
     "url": "https://github.com/powersync-ja/powersync-js/issues"
   },
   "homepage": "https://docs.powersync.com/resources/api-reference",
-  "dependencies": {
-    "@powersync/common": "workspace:*"
-  },
   "peerDependencies": {
     "vue": "*",
-    "@powersync/common": "1.x"
+    "@powersync/common": "workspace:1.x"
   },
   "devDependencies": {
     "flush-promises": "^1.0.2",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -46,7 +46,8 @@
     "uuid": "^9.0.1"
   },
   "peerDependencies": {
-    "@journeyapps/wa-sqlite": "~0.2.0"
+    "@journeyapps/wa-sqlite": "~0.2.0",
+    "@powersync/common": "1.x"
   },
   "dependencies": {
     "@powersync/common": "workspace:*",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -32,6 +32,17 @@
   ],
   "author": "JOURNEYAPPS",
   "license": "Apache-2.0",
+  "peerDependencies": {
+    "@journeyapps/wa-sqlite": "~0.2.0",
+    "@powersync/common": "workspace:1.x"
+  },
+  "dependencies": {
+    "async-mutex": "^0.4.0",
+    "buffer": "^6.0.3",
+    "comlink": "^4.4.1",
+    "js-logger": "^1.6.1",
+    "lodash": "^4.17.21"
+  },
   "devDependencies": {
     "@journeyapps/wa-sqlite": "~0.2.0",
     "@types/lodash": "^4.14.200",
@@ -44,17 +55,5 @@
     "vitest": "^1.3.1",
     "webdriverio": "^8.32.3",
     "uuid": "^9.0.1"
-  },
-  "peerDependencies": {
-    "@journeyapps/wa-sqlite": "~0.2.0",
-    "@powersync/common": "1.x"
-  },
-  "dependencies": {
-    "@powersync/common": "workspace:*",
-    "async-mutex": "^0.4.0",
-    "buffer": "^6.0.3",
-    "comlink": "^4.4.1",
-    "js-logger": "^1.6.1",
-    "lodash": "^4.17.21"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1197,7 +1197,7 @@ importers:
   packages/attachments:
     dependencies:
       '@powersync/common':
-        specifier: workspace:*
+        specifier: workspace:1.x
         version: link:../common
 
   packages/common:
@@ -1252,7 +1252,7 @@ importers:
   packages/kysely-driver:
     dependencies:
       '@powersync/common':
-        specifier: workspace:*
+        specifier: workspace:1.x
         version: link:../common
       kysely:
         specifier: ^0.27.2
@@ -1298,7 +1298,7 @@ importers:
   packages/react:
     dependencies:
       '@powersync/common':
-        specifier: workspace:*
+        specifier: workspace:1.x
         version: link:../common
     devDependencies:
       '@testing-library/react':
@@ -1320,7 +1320,7 @@ importers:
   packages/react-native:
     dependencies:
       '@powersync/common':
-        specifier: workspace:*
+        specifier: workspace:1.x
         version: link:../common
       '@powersync/react':
         specifier: workspace:*
@@ -1351,7 +1351,7 @@ importers:
   packages/vue:
     dependencies:
       '@powersync/common':
-        specifier: workspace:*
+        specifier: workspace:1.x
         version: link:../common
     devDependencies:
       flush-promises:
@@ -1373,7 +1373,7 @@ importers:
   packages/web:
     dependencies:
       '@powersync/common':
-        specifier: workspace:*
+        specifier: workspace:1.x
         version: link:../common
       async-mutex:
         specifier: ^0.4.0
@@ -8978,7 +8978,7 @@ packages:
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-validator-option': 7.23.5
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.23.9)
-      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.23.9)
       '@babel/plugin-transform-typescript': 7.23.6(@babel/core@7.23.9)
     dev: false
 
@@ -8992,7 +8992,7 @@ packages:
       '@babel/helper-plugin-utils': 7.24.0
       '@babel/helper-validator-option': 7.23.5
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.24.0)
-      '@babel/plugin-transform-modules-commonjs': 7.24.1(@babel/core@7.24.0)
+      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.24.0)
       '@babel/plugin-transform-typescript': 7.23.6(@babel/core@7.24.0)
 
   /@babel/register@7.23.7(@babel/core@7.24.0):


### PR DESCRIPTION
## Description
Add common to peerDependency of packages so that users are warned if common is mismatched under breaking change.

There is no need to have common a dependency anymore as peerDeps are auto installed in npm and pnpm and a warning is given in yarn.

**Example warning in NPM and Yarn (using an example from the internet)**:
![image](https://github.com/powersync-ja/powersync-js/assets/46312751/07490c4e-bf36-4d8e-9e79-fd10fce1a500)

![image](https://github.com/powersync-ja/powersync-js/assets/46312751/0e221dc2-8f57-491e-9788-41399593402a)

**Notes:**
* There is a possibility to use changesets to update peerDeps but that appears to have issues as outlined here https://github.com/changesets/changesets/issues/1011
* NPM, PNPM and Yarn handle these differently. There seems to be an issue with PNPM not adhering to the peerDeps as mentioned here [pnpm does not fail when missing peer deps with strict-peer-dependencies](https://github.com/pnpm/pnpm/issues/6893)