### PR TITLE
chore: reinclude common package as a dependency

### DIFF
--- a/.changeset/sour-coats-lay.md
+++ b/.changeset/sour-coats-lay.md
@@ -1,0 +1,10 @@
+---
+'@powersync/kysely-driver': patch
+'@powersync/react-native': patch
+'@powersync/attachments': patch
+'@powersync/react': patch
+'@powersync/vue': patch
+'@powersync/web': patch
+---
+
+Reinclude common package as a dependency

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -28,5 +28,8 @@
   },
   "peerDependencies": {
     "@powersync/common": "workspace:>=1.9.0"
+  },
+  "dependencies": {
+    "@powersync/common": "workspace:*"
   }
 }

--- a/packages/kysely-driver/package.json
+++ b/packages/kysely-driver/package.json
@@ -28,7 +28,8 @@
     "@powersync/common": "workspace:>=1.9.0"
   },
   "dependencies": {
-    "kysely": "^0.27.2"
+    "kysely": "^0.27.2",
+    "@powersync/common": "workspace:*"
   },
   "devDependencies": {
     "@powersync/web": "workspace:*",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@powersync/react": "workspace:*",
+    "@powersync/common": "workspace:*",
     "async-lock": "^1.4.0",
     "bson": "^6.6.0"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,6 +31,9 @@
     "react": "*",
     "@powersync/common": "workspace:>=1.9.0"
   },
+  "dependencies": {
+    "@powersync/common": "workspace:*"
+  },
   "devDependencies": {
     "@testing-library/react": "^15.0.2",
     "@types/react": "^18.2.34",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -31,6 +31,9 @@
     "vue": "*",
     "@powersync/common": "workspace:>=1.9.0"
   },
+  "dependencies": {
+    "@powersync/common": "workspace:*"
+  },
   "devDependencies": {
     "flush-promises": "^1.0.2",
     "jsdom": "^24.0.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -37,6 +37,7 @@
     "@powersync/common": "workspace:>=1.9.0"
   },
   "dependencies": {
+    "@powersync/common": "workspace:*",
     "async-mutex": "^0.4.0",
     "buffer": "^6.0.3",
     "bson": "^6.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1176,7 +1176,7 @@ importers:
   packages/attachments:
     dependencies:
       '@powersync/common':
-        specifier: workspace:>=1.9.0
+        specifier: workspace:*
         version: link:../common
 
   packages/common:
@@ -1231,7 +1231,7 @@ importers:
   packages/kysely-driver:
     dependencies:
       '@powersync/common':
-        specifier: workspace:>=1.9.0
+        specifier: workspace:*
         version: link:../common
       kysely:
         specifier: ^0.27.2
@@ -1277,7 +1277,7 @@ importers:
   packages/react:
     dependencies:
       '@powersync/common':
-        specifier: workspace:>=1.9.0
+        specifier: workspace:*
         version: link:../common
     devDependencies:
       '@testing-library/react':
@@ -1299,7 +1299,7 @@ importers:
   packages/react-native:
     dependencies:
       '@powersync/common':
-        specifier: workspace:>=1.9.0
+        specifier: workspace:*
         version: link:../common
       '@powersync/react':
         specifier: workspace:*
@@ -1333,7 +1333,7 @@ importers:
   packages/vue:
     dependencies:
       '@powersync/common':
-        specifier: workspace:>=1.9.0
+        specifier: workspace:*
         version: link:../common
     devDependencies:
       flush-promises:
@@ -1355,7 +1355,7 @@ importers:
   packages/web:
     dependencies:
       '@powersync/common':
-        specifier: workspace:>=1.9.0
+        specifier: workspace:*
         version: link:../common
       async-mutex:
         specifier: ^0.4.0
@@ -9922,7 +9922,7 @@ packages:
       '@docusaurus/utils': 3.2.1(@docusaurus/types@3.2.1)
       '@docusaurus/utils-common': 3.2.1(@docusaurus/types@3.2.1)
       '@types/history': 4.7.11
-      '@types/react': 18.2.79
+      '@types/react': 18.3.2
       '@types/react-router-config': 5.0.11
       clsx: 2.1.0
       parse-numeric-range: 1.3.0
@@ -18966,7 +18966,7 @@ packages:
   /@types/react-native@0.70.19:
     resolution: {integrity: sha512-c6WbyCgWTBgKKMESj/8b4w+zWcZSsCforson7UdXtXMecG3MxCinYi6ihhrHVPyUrVzORsvEzK8zg32z4pK6Sg==}
     dependencies:
-      '@types/react': 18.2.79
+      '@types/react': 18.3.2
     dev: false
 
   /@types/react-router-config@5.0.11:
@@ -18987,7 +18987,7 @@ packages:
     resolution: {integrity: sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==}
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 18.2.79
+      '@types/react': 18.3.2
 
   /@types/react-transition-group@4.4.10:
     resolution: {integrity: sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==}


### PR DESCRIPTION
## Description
Reinclude `@powersync/common` package as a dependency to downstream dependencies so that we do not rely on the auto installation of peer dependencies.