### PR TITLE
Upgrade Vue support into beta

### DIFF
--- a/.changeset/curly-penguins-march.md
+++ b/.changeset/curly-penguins-march.md
@@ -1,0 +1,6 @@
+---
+'vue-supabase-todolist': patch
+'@powersync/vue': patch
+---
+
+Moved Vue package to beta.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ _Bad connectivity is everywhere, and we're tired of it. PowerSync is on a missio
 
   - React integration for PowerSync.
 
+- [packages/vue](./packages/vue/README.md)
+
+  - Vue composables for PowerSync.
+
 - [packages/attachments](./packages/attachments/README.md)
 
   - Attachments helper package for React Native and JavaScript/TypeScript projects.

--- a/demos/vue-supabase-todolist/README.md
+++ b/demos/vue-supabase-todolist/README.md
@@ -2,7 +2,7 @@
 
 ## Note: Beta Release
 
-This package is currently in a beta release.
+The `@powersync/vue` package is currently in a beta release.
 
 ## Overview
 

--- a/demos/vue-supabase-todolist/README.md
+++ b/demos/vue-supabase-todolist/README.md
@@ -2,7 +2,7 @@
 
 ## Note: Beta Release
 
-This package is currently in an beta release.
+This package is currently in a beta release.
 
 ## Overview
 

--- a/demos/vue-supabase-todolist/README.md
+++ b/demos/vue-supabase-todolist/README.md
@@ -1,8 +1,8 @@
 # PowerSync + Supabase Vue Demo: Todo List (TypeScript)
 
-## Note: Alpha Release
+## Note: Beta Release
 
-This package is currently in an alpha release.
+This package is currently in an beta release.
 
 ## Overview
 

--- a/demos/vue-supabase-todolist/README.md
+++ b/demos/vue-supabase-todolist/README.md
@@ -2,7 +2,7 @@
 
 ## Note: Beta Release
 
-The `@powersync/vue` package is currently in a beta release.
+The `powersync/vue` package is currently in a beta release.
 
 ## Overview
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,8 +1,8 @@
 # Vue composables for PowerSync
 
-## Note: Alpha Release
+## Note: Beta Release
 
-This package is currently in an alpha release.
+This package is currently in a beta release.
 
 ## Setup
 


### PR DESCRIPTION
Bump Vue composables package to beta after a period of testing.
No updates were necessary besides references to "alpha release".