### PR TITLE
chore(docs): remove common

### DIFF
--- a/docs/utils/packageMap.ts
+++ b/docs/utils/packageMap.ts
@@ -4,7 +4,6 @@ enum Packages {
   ReactNativeSdk = 'react-native-sdk',
   ReactSdk = 'react-sdk',
   VueSdk = 'vue-sdk',
-  CommonSdk = 'common-sdk',
   AttachmentsSdk = 'attachments-sdk',
   WebSdk = 'web-sdk'
 }
@@ -42,13 +41,6 @@ export const packageMap: PackageMap = {
     entryPoints: ['../packages/vue/src/index.ts'],
     tsconfig: '../packages/vue/tsconfig.json',
     id: Packages.VueSdk
-  },
-  [Packages.CommonSdk]: {
-    name: 'Common SDK',
-    dirName: Packages.CommonSdk,
-    entryPoints: ['../packages/common/src/index.ts'],
-    tsconfig: '../packages/common/tsconfig.json',
-    id: Packages.CommonSdk
   },
   [Packages.AttachmentsSdk]: {
     name: 'Attachments SDK',


### PR DESCRIPTION
## Description
This removes `common-sdk` from the docs.

## Notes
After an internal discussion, we came to a realization that having `common-sdk` in the JS Docs is not necessary as the SDK's that require `common-sdk` already have the relevant properties in their documentation due to them re-exporting `@powersync/common` and thus `common-sdk` adds unnecessary repetition.

## Screenshots
<img width="313" alt="image" src="https://github.com/powersync-ja/powersync-js/assets/46312751/eaca2b96-f8a7-4cdb-a240-408c4a874cec">
