### PR TITLE
chore(docs): update properties table styling

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -59,6 +59,8 @@
 /* Expand parameter and enumeration tables to full width */
 #parameters + table,
 [id^="parameters-"] + table,
+#properties + table,
+[id^="properties-"] + table,
 #enumeration-members + table,
 [id^="enumeration-members-"] + table {
   width: 100%;


### PR DESCRIPTION
## Description
The style changes to tables in docs have not been applied to the properties table. This change adds those.

## Screenshots
<img width="1022" alt="image" src="https://github.com/powersync-ja/powersync-js/assets/46312751/0695b849-4a04-46bf-9cd2-d520db17c884">
 