### PR TITLE
[Fix] Lockfile update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,8 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+          # Update the monorepo lockfile after versioning
+          version: pnpm changeset version && pnpm install --lockfile-only --frozen-lockfile=false
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: pnpm release
         env:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1289,7 +1289,7 @@ importers:
   packages/kysely-driver:
     dependencies:
       '@powersync/common':
-        specifier: workspace:^1.10.0
+        specifier: workspace:^1.11.0
         version: link:../common
       kysely:
         specifier: ^0.27.2


### PR DESCRIPTION
# Overview

Recently the Github actions have sometimes been failing after the Changeset version pull request has been merged due to PNPM lockfile issues https://github.com/powersync-ja/powersync-js/actions/runs/9397015900.

This PR updates the lockfile and also adds a step to update the lockfile automatically after Changesets has versioned packages.

