### PR TITLE
[Fix] CRUD upload retries

### DIFF
--- a/.changeset/famous-teachers-design.md
+++ b/.changeset/famous-teachers-design.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Fixed CRUD uploads which would not retry after failing until the connection status was updated. A failed CRUD operation should not change the status to `connected: false`.

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -221,13 +221,18 @@ export abstract class AbstractStreamingSyncImplementation
             }
           } catch (ex) {
             this.updateSyncStatus({
-              connected: false,
               dataFlow: {
                 uploading: false
               }
             });
             await this.delayRetry();
-            break;
+            if (!this.isConnected) {
+              // Exit the upload loop if the sync stream is no longer connected
+              break;
+            }
+            this.logger.debug(
+              `Caught exception when uploading. Upload will retry after a delay. Exception: ${ex.message}`
+            );
           } finally {
             this.updateSyncStatus({
               dataFlow: {

--- a/packages/web/tests/utils/MockStreamOpenFactory.ts
+++ b/packages/web/tests/utils/MockStreamOpenFactory.ts
@@ -27,7 +27,8 @@ export class TestConnector implements PowerSyncBackendConnector {
     };
   }
   async uploadData(database: AbstractPowerSyncDatabase): Promise<void> {
-    return;
+    const tx = await database.getNextCrudTransaction();
+    await tx?.complete();
   }
 }
 
@@ -49,8 +50,16 @@ export class MockRemote extends AbstractRemote {
   post(path: string, data: any, headers?: Record<string, string> | undefined): Promise<any> {
     throw new Error('Method not implemented.');
   }
-  get(path: string, headers?: Record<string, string> | undefined): Promise<any> {
-    throw new Error('Method not implemented.');
+  async get(path: string, headers?: Record<string, string> | undefined): Promise<any> {
+    // mock a response for write checkpoint API
+    if (path.includes('checkpoint')) {
+      return {
+        data: {
+          write_checkpoint: '1000'
+        }
+      };
+    }
+    throw new Error('Not implemented');
   }
   async postStreaming(
     path: string,


### PR DESCRIPTION
# Overview

A bug was recently discovered where CRUD uploads would not retry (for a long time) after failing when using the WebSocket connection method. 

This was due to a failed upload updating the connection status to `connected: false`. Following CRUD loop iterations would check the connection status and exit if not connected. 

The connection status is usually updated to `true` whenever a sync event is received from the PowerSync backend server. For the HTTP method keep-alive events are sent at regular intervals which will update the status back to `connected: true`. This is not the case for WebSockets as that method handles keep-alive events internally. 

This PR aligns the CRUD upload connection status logic with the Dart SDK. The connection status is not set to `false` if an upload fails. It is only set to `false` if the connection to the backend server is closed. Reference here:  https://github.com/powersync-ja/powersync.dart/blob/d812f78a5ae830e4ccdf29e1cb0a76aa27b01042/packages/powersync/lib/src/streaming_sync.dart#L102

# Testing

Unit tests have been added to ensure CRUD uploads are correctly triggered and retried.

