### PR TITLE
[Chore]: fix Changeset version action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         uses: changesets/action@v1
         with:
           # Update the monorepo lockfile after versioning
-          version: pnpm changeset version && pnpm install --lockfile-only --frozen-lockfile=false
+          version: changeset:version
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: pnpm release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         uses: changesets/action@v1
         with:
           # Update the monorepo lockfile after versioning
-          version: changeset:version
+          version: pnpm changeset:version
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: pnpm release
         env:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "clean:packages": "pnpm run --filter './packages/**' -r clean",
     "build:packages:prod": "pnpm build:packages --sourceMap false",
     "watch:packages": "pnpm run --parallel --filter './packages/**' -r build -w",
+    "changeset:version": "pnpm changeset version && pnpm install --lockfile-only --frozen-lockfile=false",
     "build": "pnpm run -r build",
     "ci:publish": "changeset publish && git push --follow-tags",
     "ci:version": "changeset version && pnpm install --no-frozen-lockfile",


### PR DESCRIPTION
# Overview

This PR is a follow up to https://github.com/powersync-ja/powersync-js/pull/203. From the latest [action run](https://github.com/powersync-ja/powersync-js/actions/runs/9444115848/job/26009056296) the Changeset `version` command does not parse `&&` commands well. 

The PNPM lockfile update command has been updated to a PNPM script which is usable as a Changeset command.

This has been tested and verified [here](https://github.com/powersync-ja/changesets-slave)