### PR TITLE
[Fix] Vue useQuery comlink error caused when using reactive sql parameters

### DIFF
--- a/.changeset/short-snails-visit.md
+++ b/.changeset/short-snails-visit.md
@@ -1,0 +1,5 @@
+---
+'@powersync/vue': patch
+---
+
+Fixed comlink issue caused when using reactive sql parameters.

--- a/packages/vue/src/composables/useQuery.ts
+++ b/packages/vue/src/composables/useQuery.ts
@@ -105,7 +105,7 @@ export const useQuery = <T = any>(
 
     let parsedQuery: ParsedQuery;
     try {
-      parsedQuery = parseQuery(toValue(query), toValue(sqlParameters));
+      parsedQuery = parseQuery(toValue(query), toValue(sqlParameters).map(toValue));
     } catch (e) {
       console.error('Failed to parse query:', e);
       handleError(e);


### PR DESCRIPTION
Vue wraps its reactive variables in Proxy objects. It seems there's a point at which we provide these objects to comlink (in the sharedWorker I believe) where it fails to parse the input. This PR ensures that the SQL parameters are raw when it reaches that point.

According to Discord user who reported this [issue](https://discord.com/channels/1138230179878154300/1138251135929548850/threads/1258980918895575120), the changeset fixes this problem (tested via dev package publish).