### PR TITLE
Diagnostics app improvements

### DIFF
--- a/.changeset/happy-gifts-sort.md
+++ b/.changeset/happy-gifts-sort.md
@@ -1,0 +1,5 @@
+---
+'diagnostics-app': minor
+---
+
+Faster initial sync and other fixes

--- a/tools/diagnostics-app/src/app/views/sync-diagnostics.tsx
+++ b/tools/diagnostics-app/src/app/views/sync-diagnostics.tsx
@@ -15,7 +15,6 @@ import {
   styled
 } from '@mui/material';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
-import { useQuery } from '@powersync/react';
 import React from 'react';
 
 const BUCKETS_QUERY = `

--- a/tools/diagnostics-app/src/app/views/sync-diagnostics.tsx
+++ b/tools/diagnostics-app/src/app/views/sync-diagnostics.tsx
@@ -181,50 +181,40 @@ export default function SyncDiagnosticsPage() {
   );
 
   const tablesTable = (
-    <S.QueryResultContainer>
-      <Typography variant="h4" gutterBottom>
-        Tables
-      </Typography>
-      <DataGrid
-        autoHeight={true}
-        rows={tablesRows}
-        columns={tablesColumns}
-        initialState={{
-          pagination: {
-            paginationModel: {
-              pageSize: 10
-            }
+    <DataGrid
+      autoHeight={true}
+      rows={tablesRows}
+      columns={tablesColumns}
+      initialState={{
+        pagination: {
+          paginationModel: {
+            pageSize: 10
           }
-        }}
-        pageSizeOptions={[10, 50, 100]}
-        disableRowSelectionOnClick
-      />
-    </S.QueryResultContainer>
+        }
+      }}
+      pageSizeOptions={[10, 50, 100]}
+      disableRowSelectionOnClick
+    />
   );
 
   const bucketsTable = (
-    <S.QueryResultContainer>
-      <Typography variant="h4" gutterBottom>
-        Buckets
-      </Typography>
-      <DataGrid
-        autoHeight={true}
-        rows={rows}
-        columns={columns}
-        initialState={{
-          pagination: {
-            paginationModel: {
-              pageSize: 50
-            }
-          },
-          sorting: {
-            sortModel: [{ field: 'total_operations', sort: 'desc' }]
+    <DataGrid
+      autoHeight={true}
+      rows={rows}
+      columns={columns}
+      initialState={{
+        pagination: {
+          paginationModel: {
+            pageSize: 50
           }
-        }}
-        pageSizeOptions={[10, 50, 100]}
-        disableRowSelectionOnClick
-      />
-    </S.QueryResultContainer>
+        },
+        sorting: {
+          sortModel: [{ field: 'total_operations', sort: 'desc' }]
+        }
+      }}
+      pageSizeOptions={[10, 50, 100]}
+      disableRowSelectionOnClick
+    />
   );
 
   return (
@@ -239,8 +229,18 @@ export default function SyncDiagnosticsPage() {
           }}>
           Clear & Redownload
         </Button>
-        {tableRowsLoading ? <CircularProgress /> : tablesTable}
-        {bucketRowsLoading ? <CircularProgress /> : bucketsTable}
+        <S.QueryResultContainer>
+          <Typography variant="h4" gutterBottom>
+            Tables
+          </Typography>
+          {tableRowsLoading ? <CircularProgress /> : tablesTable}
+        </S.QueryResultContainer>
+        <S.QueryResultContainer>
+          <Typography variant="h4" gutterBottom>
+            Buckets
+          </Typography>
+          {bucketRowsLoading ? <CircularProgress /> : bucketsTable}
+        </S.QueryResultContainer>
       </S.MainContainer>
     </NavigationPage>
   );

--- a/tools/diagnostics-app/src/library/powersync/ConnectionManager.ts
+++ b/tools/diagnostics-app/src/library/powersync/ConnectionManager.ts
@@ -2,6 +2,7 @@ import {
   BaseListener,
   BaseObserver,
   PowerSyncDatabase,
+  SyncStreamConnectionMethod,
   WebRemote,
   WebStreamingSyncImplementation,
   WebStreamingSyncImplementationOptions
@@ -10,6 +11,12 @@ import Logger from 'js-logger';
 import { DynamicSchemaManager } from './DynamicSchemaManager';
 import { RecordingStorageAdapter } from './RecordingStorageAdapter';
 import { TokenConnector } from './TokenConnector';
+
+import { Buffer } from 'buffer';
+
+if (typeof self.Buffer == 'undefined') {
+  self.Buffer = Buffer;
+}
 
 Logger.useDefaults();
 Logger.setLevel(Logger.DEBUG);
@@ -71,7 +78,7 @@ if (connector.hasCredentials()) {
 }
 
 export async function connect() {
-  await sync.connect();
+  await sync.connect({ connectionMethod: SyncStreamConnectionMethod.WEB_SOCKET });
   if (!sync.syncStatus.connected) {
     // Disconnect but don't wait for it
     sync.disconnect();
@@ -87,7 +94,7 @@ export async function clearData() {
   await schemaManager.clear();
   await schemaManager.refreshSchema(db.database);
   if (connector.hasCredentials()) {
-    await sync.connect();
+    await sync.connect({ connectionMethod: SyncStreamConnectionMethod.WEB_SOCKET });
   }
 }
 

--- a/tools/diagnostics-app/src/library/powersync/ConnectionManager.ts
+++ b/tools/diagnostics-app/src/library/powersync/ConnectionManager.ts
@@ -29,6 +29,8 @@ export const db = new PowerSyncDatabase({
   },
   schema: schemaManager.buildSchema()
 });
+db.execute('PRAGMA cache_size=-50000');
+
 export const connector = new TokenConnector();
 
 const remote = new WebRemote(connector);

--- a/tools/diagnostics-app/src/library/powersync/RecordingStorageAdapter.ts
+++ b/tools/diagnostics-app/src/library/powersync/RecordingStorageAdapter.ts
@@ -42,7 +42,11 @@ export class RecordingStorageAdapter extends SqliteBucketStorage {
 
   async syncLocalDatabase(checkpoint: Checkpoint) {
     const r = await super.syncLocalDatabase(checkpoint);
-    await this.schemaManager.refreshSchema(this.rdb);
+    // Refresh schema asynchronously, to allow us to better measure
+    // performance of initial sync.
+    setTimeout(() => {
+      this.schemaManager.refreshSchema(this.rdb);
+    }, 60);
     if (r.checkpointValid) {
       await this.rdb.execute('UPDATE local_bucket_data SET downloading = FALSE');
     }


### PR DESCRIPTION
This makes the initial sync significantly faster in the diagnostics app.

The main issue was the queries scanning the entire oplog, every time a batch of data was downloaded. Those queries were often significantly slower than the saving of the data itself. And since the web SDK does not support concurrent reads, it slowed down the entire initial sync.

This now runs a much faster query (with less stats) during initial sync, then switches over to the full queries after that.
This also increases the SQLite cache size for the diagnostics app, which makes those same queries run much faster.

This also contains other minor fixes, such as fixing issues in the stats calculations (which were mostly relevant during initial sync so not that relevant anymore), improving the loader UI, and using websockets.

