### PR TITLE
Add a debugMode flag to log queries to the performance timeline

### DIFF
--- a/.changeset/spicy-poems-complain.md
+++ b/.changeset/spicy-poems-complain.md
@@ -1,0 +1,6 @@
+---
+'@powersync/common': minor
+'@powersync/web': minor
+---
+
+Add debugMode flag to log queries on the performance timeline

--- a/packages/common/src/client/SQLOpenFactory.ts
+++ b/packages/common/src/client/SQLOpenFactory.ts
@@ -13,8 +13,11 @@ export interface SQLOpenOptions {
   /**
    * Enable debugMode to log queries to the performance timeline.
    *
-   * Defaults to false if `process.env.NODE_ENV == 'production'`,
-   * true otherwise.
+   * Defaults to false.
+   *
+   * To enable in development builds, use:
+   *
+   *    debugMode: process.env.NODE_ENV !== 'production'
    */
   debugMode?: boolean;
 }

--- a/packages/common/src/client/SQLOpenFactory.ts
+++ b/packages/common/src/client/SQLOpenFactory.ts
@@ -9,6 +9,14 @@ export interface SQLOpenOptions {
    * Directory where the database file is located.
    */
   dbLocation?: string;
+
+  /**
+   * Enable debugMode to log queries to the performance timeline.
+   *
+   * Defaults to false if `process.env.NODE_ENV == 'production'`,
+   * true otherwise.
+   */
+  debugMode?: boolean;
 }
 
 export interface SQLOpenFactory {

--- a/packages/web/src/db/adapters/wa-sqlite/WASQLiteDBAdapter.ts
+++ b/packages/web/src/db/adapters/wa-sqlite/WASQLiteDBAdapter.ts
@@ -53,10 +53,10 @@ export class WASQLiteDBAdapter extends BaseObserver<DBAdapterListener> implement
         const start = performance.now();
         try {
           const r = await originalExecute(sql, bindings);
-          performance.measure(`SQL: ${sql}`, { start });
+          performance.measure(`[SQL] ${sql}`, { start });
           return r;
         } catch (e: any) {
-          performance.measure(`SQL ERROR: ${e.message} | ${sql}`, { start });
+          performance.measure(`[SQL] [ERROR: ${e.message}] ${sql}`, { start });
           throw e;
         }
       };

--- a/packages/web/src/db/adapters/wa-sqlite/WASQLiteDBAdapter.ts
+++ b/packages/web/src/db/adapters/wa-sqlite/WASQLiteDBAdapter.ts
@@ -39,12 +39,28 @@ export class WASQLiteDBAdapter extends BaseObserver<DBAdapterListener> implement
   private logger: ILogger;
   private dbGetHelpers: DBGetUtils | null;
   private methods: DBFunctionsInterface | null;
+  private debugMode: boolean;
 
   constructor(protected options: WASQLiteDBAdapterOptions) {
     super();
     this.logger = Logger.get('WASQLite');
     this.dbGetHelpers = null;
     this.methods = null;
+    this.debugMode = options.debugMode ?? process.env.NODE_ENV !== 'production';
+    if (this.debugMode) {
+      const originalExecute = this._execute.bind(this);
+      this._execute = async (sql, bindings) => {
+        const start = performance.now();
+        try {
+          const r = await originalExecute(sql, bindings);
+          performance.measure(`SQL: ${sql}`, { start });
+          return r;
+        } catch (e: any) {
+          performance.measure(`SQL ERROR: ${e.message} | ${sql}`, { start });
+          throw e;
+        }
+      };
+    }
     this.initialized = this.init();
     this.dbGetHelpers = this.generateDBHelpers({
       execute: (query, params) => this.acquireLock(() => this._execute(query, params))

--- a/packages/web/src/db/adapters/wa-sqlite/WASQLiteDBAdapter.ts
+++ b/packages/web/src/db/adapters/wa-sqlite/WASQLiteDBAdapter.ts
@@ -46,7 +46,7 @@ export class WASQLiteDBAdapter extends BaseObserver<DBAdapterListener> implement
     this.logger = Logger.get('WASQLite');
     this.dbGetHelpers = null;
     this.methods = null;
-    this.debugMode = options.debugMode ?? process.env.NODE_ENV !== 'production';
+    this.debugMode = options.debugMode ?? false;
     if (this.debugMode) {
       const originalExecute = this._execute.bind(this);
       this._execute = async (sql, bindings) => {

--- a/tools/diagnostics-app/src/library/powersync/ConnectionManager.ts
+++ b/tools/diagnostics-app/src/library/powersync/ConnectionManager.ts
@@ -25,7 +25,8 @@ export const schemaManager = new DynamicSchemaManager();
 
 export const db = new PowerSyncDatabase({
   database: {
-    dbFilename: 'example.db'
+    dbFilename: 'example.db',
+    debugMode: true
   },
   schema: schemaManager.buildSchema()
 });


### PR DESCRIPTION
This displays all SQL queries on the performance timeline. Currently only implemented in the Web SDK.

This excludes the time waiting for the global transaction lock, but includes all overhead in worker communication. This means you won't see concurrent queries in most cases.

This includes internal statements from PowerSync, including queries saving sync data, and begin/commit statements. It does not include internal statements from powersync-sqlite-core.

TODO:
 * ~The flag currently defaults to false if `process.env.NODE_ENV == 'production'`, similar to what React does. All other cases default to true. Should we perhaps be more conservative and require explicit opt-in, since the queries could be considered semi-sensitive data?~ Updated default to false, requiring explicit opt-in for now.

Example of the diagnostics app during initial sync:

![image](https://github.com/user-attachments/assets/45a58db2-2bcf-466d-8eac-902de2ac1ebe)
