### PR TITLE
chore: update @powersync/common peer dep range

### DIFF
--- a/.changeset/healthy-insects-push.md
+++ b/.changeset/healthy-insects-push.md
@@ -1,0 +1,10 @@
+---
+'@powersync/kysely-driver': patch
+'@powersync/react-native': patch
+'@powersync/attachments': patch
+'@powersync/react': patch
+'@powersync/vue': patch
+'@powersync/web': patch
+---
+
+Change @powersync/common peerDep to ^

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -27,6 +27,6 @@
     "watch": "tsc -b -w"
   },
   "peerDependencies": {
-    "@powersync/common": "workspace:^1.9.0"
+    "@powersync/common": "workspace:^"
   }
 }

--- a/packages/kysely-driver/package.json
+++ b/packages/kysely-driver/package.json
@@ -25,7 +25,7 @@
     "test": "pnpm build && vitest"
   },
   "peerDependencies": {
-    "@powersync/common": "workspace:^1.13.0"
+    "@powersync/common": "workspace:^"
   },
   "dependencies": {
     "kysely": "^0.27.2"

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -31,7 +31,7 @@
     "react": "*",
     "react-native": "*",
     "react-native-polyfill-globals": "^3.1.0",
-    "@powersync/common": "workspace:^1.13.0"
+    "@powersync/common": "workspace:^"
   },
   "dependencies": {
     "@powersync/react": "workspace:*",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://docs.powersync.com/resources/api-reference",
   "peerDependencies": {
     "react": "*",
-    "@powersync/common": "workspace:^1.9.0"
+    "@powersync/common": "workspace:^"
   },
   "devDependencies": {
     "@testing-library/react": "^15.0.2",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://docs.powersync.com/resources/api-reference",
   "peerDependencies": {
     "vue": "*",
-    "@powersync/common": "workspace:^1.10.0"
+    "@powersync/common": "workspace:^"
   },
   "devDependencies": {
     "flush-promises": "^1.0.2",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -34,7 +34,7 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "@journeyapps/wa-sqlite": "~0.2.0",
-    "@powersync/common": "workspace:^1.13.0"
+    "@powersync/common": "workspace:^"
   },
   "dependencies": {
     "@powersync/common": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,31 +25,31 @@ importers:
     dependencies:
       '@angular/animations':
         specifier: ^18.1.1
-        version: 18.1.1(@angular/core@18.1.1)
+        version: 18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))
       '@angular/common':
         specifier: ^18.1.1
-        version: 18.1.1(@angular/core@18.1.1)(rxjs@7.8.1)
+        version: 18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1)
       '@angular/compiler':
         specifier: ^18.1.1
-        version: 18.1.1(@angular/core@18.1.1)
+        version: 18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))
       '@angular/core':
         specifier: ^18.1.1
         version: 18.1.1(rxjs@7.8.1)(zone.js@0.14.8)
       '@angular/forms':
         specifier: ^18.1.1
-        version: 18.1.1(@angular/common@18.1.1)(@angular/core@18.1.1)(@angular/platform-browser@18.1.1)(rxjs@7.8.1)
+        version: 18.1.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(@angular/platform-browser@18.1.1(@angular/animations@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(rxjs@7.8.1)
       '@angular/platform-browser':
         specifier: ^18.1.1
-        version: 18.1.1(@angular/animations@18.1.1)(@angular/common@18.1.1)(@angular/core@18.1.1)
+        version: 18.1.1(@angular/animations@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))
       '@angular/platform-browser-dynamic':
         specifier: ^18.1.1
-        version: 18.1.1(@angular/common@18.1.1)(@angular/compiler@18.1.1)(@angular/core@18.1.1)(@angular/platform-browser@18.1.1)
+        version: 18.1.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/compiler@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(@angular/platform-browser@18.1.1(@angular/animations@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))
       '@angular/router':
         specifier: ^18.1.1
-        version: 18.1.1(@angular/common@18.1.1)(@angular/core@18.1.1)(@angular/platform-browser@18.1.1)(rxjs@7.8.1)
+        version: 18.1.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(@angular/platform-browser@18.1.1(@angular/animations@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(rxjs@7.8.1)
       '@angular/service-worker':
         specifier: ^18.1.1
-        version: 18.1.1(@angular/common@18.1.1)(@angular/core@18.1.1)
+        version: 18.1.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))
       '@journeyapps/wa-sqlite':
         specifier: ^0.2.0
         version: 0.2.0
@@ -71,16 +71,16 @@ importers:
     devDependencies:
       '@angular-builders/custom-webpack':
         specifier: ^18.0.0
-        version: 18.0.0(@angular/compiler-cli@18.1.1)(@angular/service-worker@18.1.1)(@types/node@20.14.11)(typescript@5.5.3)
+        version: 18.0.0(@angular/compiler-cli@18.1.1(@angular/compiler@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(typescript@5.5.3))(@angular/service-worker@18.1.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@swc/core@1.6.13)(@types/node@20.14.11)(chokidar@3.6.0)(html-webpack-plugin@5.6.0(webpack@5.92.1(@swc/core@1.6.13)))(tailwindcss@3.4.6)(typescript@5.5.3)
       '@angular-devkit/build-angular':
         specifier: ^18.1.1
-        version: 18.1.1(@angular/compiler-cli@18.1.1)(@angular/service-worker@18.1.1)(@types/node@20.14.11)(typescript@5.5.3)
+        version: 18.1.1(@angular/compiler-cli@18.1.1(@angular/compiler@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(typescript@5.5.3))(@angular/service-worker@18.1.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@swc/core@1.6.13)(@types/node@20.14.11)(chokidar@3.6.0)(html-webpack-plugin@5.6.0(webpack@5.92.1(@swc/core@1.6.13)))(tailwindcss@3.4.6)(typescript@5.5.3)
       '@angular/cli':
         specifier: ^18.1.1
-        version: 18.1.1
+        version: 18.1.1(chokidar@3.6.0)
       '@angular/compiler-cli':
         specifier: ^18.1.1
-        version: 18.1.1(@angular/compiler@18.1.1)(typescript@5.5.3)
+        version: 18.1.1(@angular/compiler@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(typescript@5.5.3)
       http-server:
         specifier: ^14.1.1
         version: 14.1.1
@@ -95,13 +95,13 @@ importers:
         version: 1.0.2
       '@craftzdog/react-native-buffer':
         specifier: ^6.0.5
-        version: 6.0.5(react-native@0.74.1)(react@18.2.0)
+        version: 6.0.5(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@expo/vector-icons':
         specifier: ^14.0.0
         version: 14.0.2
       '@journeyapps/react-native-quick-sqlite':
         specifier: ^1.1.7
-        version: 1.1.8(react-native@0.74.1)(react@18.2.0)
+        version: 1.1.8(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@powersync/common':
         specifier: workspace:*
         version: link:../../packages/common
@@ -113,16 +113,16 @@ importers:
         version: link:../../packages/react-native
       '@react-native-community/async-storage':
         specifier: ^1.12.1
-        version: 1.12.1(react-native@0.74.1)(react@18.2.0)
+        version: 1.12.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@react-native-community/masked-view':
         specifier: ^0.1.11
-        version: 0.1.11(react-native@0.74.1)(react@18.2.0)
+        version: 0.1.11(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@react-navigation/drawer':
         specifier: ^6.6.15
-        version: 6.7.2(@react-navigation/native@6.1.18)(react-native-gesture-handler@2.16.2)(react-native-reanimated@3.10.1)(react-native-safe-area-context@4.10.1)(react-native-screens@3.31.1)(react-native@0.74.1)(react@18.2.0)
+        version: 6.7.2(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.7)(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@react-navigation/native':
         specifier: ^6.1.17
-        version: 6.1.18(react-native@0.74.1)(react@18.2.0)
+        version: 6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@supabase/supabase-js':
         specifier: ^2.42.4
         version: 2.44.4
@@ -131,25 +131,25 @@ importers:
         version: 1.0.0
       expo:
         specifier: ~51.0.10
-        version: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+        version: 51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)
       expo-build-properties:
         specifier: ~0.12.1
-        version: 0.12.3(expo@51.0.21)
+        version: 0.12.3(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13))
       expo-constants:
         specifier: ~16.0.2
-        version: 16.0.2(expo@51.0.21)
+        version: 16.0.2(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13))
       expo-linking:
         specifier: ~6.3.1
-        version: 6.3.1(expo@51.0.21)
+        version: 6.3.1(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13))
       expo-modules-autolinking:
         specifier: ^1.11.1
         version: 1.11.1
       expo-router:
         specifier: 3.5.15
-        version: 3.5.15(@react-navigation/drawer@6.7.2)(expo-constants@16.0.2)(expo-linking@6.3.1)(expo-modules-autolinking@1.11.1)(expo-status-bar@1.12.1)(expo@51.0.21)(react-native-reanimated@3.10.1)(react-native-safe-area-context@4.10.1)(react-native-screens@3.31.1)(react-native@0.74.1)(react@18.2.0)(typescript@5.5.3)
+        version: 3.5.15(@react-navigation/drawer@6.7.2(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.7)(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(encoding@0.1.13)(expo-constants@16.0.2(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)))(expo-linking@6.3.1(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)))(expo-modules-autolinking@1.11.1)(expo-status-bar@1.12.1)(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13))(react-native-reanimated@3.10.1(@babel/core@7.24.7)(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)(typescript@5.5.3)
       expo-splash-screen:
         specifier: ~0.27.4
-        version: 0.27.5(expo-modules-autolinking@1.11.1)(expo@51.0.21)
+        version: 0.27.5(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13))
       expo-status-bar:
         specifier: ~1.12.1
         version: 1.12.1
@@ -161,55 +161,55 @@ importers:
         version: 4.17.21
       metro:
         specifier: ~0.80.8
-        version: 0.80.9
+        version: 0.80.9(encoding@0.1.13)
       react:
         specifier: 18.2.0
         version: 18.2.0
       react-native:
         specifier: 0.74.1
-        version: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
+        version: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
       react-native-elements:
         specifier: ^3.4.3
-        version: 3.4.3(react-native-safe-area-context@4.10.1)(react-native-vector-icons@10.1.0)(react-native@0.74.1)(react@18.2.0)
+        version: 3.4.3(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-vector-icons@10.1.0)(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-encrypted-storage:
         specifier: ^4.0.3
-        version: 4.0.3(react-native@0.74.1)(react@18.2.0)
+        version: 4.0.3(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-fetch-api:
         specifier: ^3.0.0
         version: 3.0.0
       react-native-gesture-handler:
         specifier: ~2.16.2
-        version: 2.16.2(react-native@0.74.1)(react@18.2.0)
+        version: 2.16.2(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-polyfill-globals:
         specifier: ^3.1.0
-        version: 3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0)(react-native-url-polyfill@2.0.0)(text-encoding@0.7.0)(web-streams-polyfill@3.3.3)
+        version: 3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)))(react-native-url-polyfill@2.0.0(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)))(text-encoding@0.7.0)(web-streams-polyfill@3.3.3)
       react-native-prompt-android:
         specifier: ^1.1.0
         version: 1.1.0
       react-native-reanimated:
         specifier: ~3.10.1
-        version: 3.10.1(@babel/core@7.24.5)(react-native@0.74.1)(react@18.2.0)
+        version: 3.10.1(@babel/core@7.24.7)(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-safe-area-context:
         specifier: 4.10.1
-        version: 4.10.1(react-native@0.74.1)(react@18.2.0)
+        version: 4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-safe-area-view:
         specifier: ^1.1.1
-        version: 1.1.1(react-native-safe-area-context@4.10.1)(react-native@0.74.1)(react@18.2.0)
+        version: 1.1.1(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-screens:
         specifier: ~3.31.1
-        version: 3.31.1(react-native@0.74.1)(react@18.2.0)
+        version: 3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-table-component:
         specifier: ^1.2.2
         version: 1.2.2
       react-native-url-polyfill:
         specifier: ^2.0.0
-        version: 2.0.0(react-native@0.74.1)
+        version: 2.0.0(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))
       react-native-vector-icons:
         specifier: ^10.0.0
         version: 10.1.0
       react-navigation-stack:
         specifier: ^2.10.4
-        version: 2.10.4(@react-native-community/masked-view@0.1.11)(react-native-gesture-handler@2.16.2)(react-native-safe-area-context@4.10.1)(react-native-screens@3.31.1)(react-native@0.74.1)(react-navigation@4.4.4)(react@18.2.0)
+        version: 2.10.4(@react-native-community/masked-view@0.1.11(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react-navigation@4.4.4(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0)
       text-encoding:
         specifier: ^0.7.0
         version: 0.7.0
@@ -222,10 +222,10 @@ importers:
     devDependencies:
       '@babel/plugin-transform-async-generator-functions':
         specifier: ^7.24.3
-        version: 7.24.7(@babel/core@7.24.5)
+        version: 7.24.7(@babel/core@7.24.7)
       '@babel/preset-env':
         specifier: ^7.24.4
-        version: 7.24.8(@babel/core@7.24.5)
+        version: 7.24.8(@babel/core@7.24.7)
       '@types/lodash':
         specifier: ^4.17.0
         version: 4.17.7
@@ -237,7 +237,7 @@ importers:
         version: 18.2.25
       '@types/react-native-table-component':
         specifier: ^1.2.8
-        version: 1.2.8(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(react@18.2.0)
+        version: 1.2.8(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)(react@18.2.0)
       typescript:
         specifier: ^5.3.3
         version: 5.5.3
@@ -276,14 +276,14 @@ importers:
         version: 18.2.0(react@18.2.0)
       react-router-dom:
         specifier: ^6.23.0
-        version: 6.25.1(react-dom@18.2.0)(react@18.2.0)
+        version: 6.25.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@capacitor/cli':
         specifier: ^6.0.0
         version: 6.1.1
       '@swc/core':
         specifier: ~1.6.0
-        version: 1.6.13
+        version: 1.6.13(@swc/helpers@0.5.5)
       '@types/node':
         specifier: ^20.12.12
         version: 20.14.11
@@ -295,16 +295,16 @@ importers:
         version: 18.3.0
       vite:
         specifier: ^5.2.11
-        version: 5.3.4(@types/node@20.14.11)
+        version: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
       vite-plugin-require:
         specifier: ^1.2.14
-        version: 1.2.14(@swc/core@1.6.13)(vite@5.3.4)
+        version: 1.2.14(@swc/core@1.6.13(@swc/helpers@0.5.5))(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       vite-plugin-top-level-await:
         specifier: ^1.4.1
-        version: 1.4.1(rollup@2.79.1)(vite@5.3.4)
+        version: 1.4.1(@swc/helpers@0.5.5)(rollup@4.18.1)(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       vite-plugin-wasm:
         specifier: ^3.3.0
-        version: 3.3.0(vite@5.3.4)
+        version: 3.3.0(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
 
   demos/example-electron:
     dependencies:
@@ -313,13 +313,13 @@ importers:
         version: 0.2.0
       '@mui/icons-material':
         specifier: ^5.15.16
-        version: 5.16.4(@mui/material@5.16.4)(@types/react@18.3.3)(react@18.2.0)
+        version: 5.16.4(@mui/material@5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.3.3)(react@18.2.0)
       '@mui/material':
         specifier: ^5.15.16
-        version: 5.16.4(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
+        version: 5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@mui/x-data-grid':
         specifier: ^6.19.11
-        version: 6.20.3(@mui/material@5.16.4)(@mui/system@5.16.4)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
+        version: 6.20.3(@mui/material@5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@mui/system@5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@powersync/react':
         specifier: workspace:*
         version: link:../../packages/react
@@ -340,11 +340,11 @@ importers:
         version: 18.2.0(react@18.2.0)
       react-router-dom:
         specifier: ^6.23.0
-        version: 6.25.1(react-dom@18.2.0)(react@18.2.0)
+        version: 6.25.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@electron-forge/cli':
         specifier: ^7.4.0
-        version: 7.4.0
+        version: 7.4.0(encoding@0.1.13)
       '@electron-forge/maker-deb':
         specifier: ^7.4.0
         version: 7.4.0
@@ -371,7 +371,7 @@ importers:
         version: 1.8.0
       '@swc/core':
         specifier: ~1.6.0
-        version: 1.6.13
+        version: 1.6.13(@swc/helpers@0.5.5)
       '@types/node':
         specifier: ^20.12.8
         version: 20.14.11
@@ -383,34 +383,34 @@ importers:
         version: 18.3.0
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.3.1(vite@5.3.4)
+        version: 4.3.1(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.19(postcss@8.4.39)
       babel-loader:
         specifier: ^9.1.3
-        version: 9.1.3(@babel/core@7.24.5)(webpack@5.93.0)
+        version: 9.1.3(@babel/core@7.24.5)(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5)))
       electron:
         specifier: 30.0.2
         version: 30.0.2
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.6.13)(@types/node@20.14.11)(typescript@4.5.5)
+        version: 10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@4.5.5)
       typescript:
         specifier: ~4.5.5
         version: 4.5.5
       vite:
         specifier: ^5.2.11
-        version: 5.3.4(@types/node@20.14.11)
+        version: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
       vite-plugin-require:
         specifier: ^1.1.14
-        version: 1.2.14(@swc/core@1.6.13)(vite@5.3.4)
+        version: 1.2.14(@swc/core@1.6.13(@swc/helpers@0.5.5))(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       vite-plugin-top-level-await:
         specifier: ^1.4.1
-        version: 1.4.1(rollup@2.79.1)(vite@5.3.4)
+        version: 1.4.1(@swc/helpers@0.5.5)(rollup@4.18.1)(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       vite-plugin-wasm:
         specifier: ^3.3.0
-        version: 3.3.0(vite@5.3.4)
+        version: 3.3.0(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
 
   demos/example-nextjs:
     dependencies:
@@ -419,7 +419,7 @@ importers:
         version: 11.11.4(@types/react@18.3.3)(react@18.2.0)
       '@emotion/styled':
         specifier: ^11.11.5
-        version: 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.2.0)
+        version: 11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0)
       '@fontsource/roboto':
         specifier: ^5.0.13
         version: 5.0.13
@@ -428,13 +428,13 @@ importers:
         version: 0.2.0
       '@lexical/react':
         specifier: ^0.15.0
-        version: 0.15.0(react-dom@18.2.0)(react@18.2.0)(yjs@13.6.18)
+        version: 0.15.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(yjs@13.6.18)
       '@mui/icons-material':
         specifier: ^5.15.18
-        version: 5.16.4(@mui/material@5.16.4)(@types/react@18.3.3)(react@18.2.0)
+        version: 5.16.4(@mui/material@5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.3.3)(react@18.2.0)
       '@mui/material':
         specifier: ^5.15.18
-        version: 5.16.4(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
+        version: 5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@powersync/react':
         specifier: workspace:*
         version: link:../../packages/react
@@ -455,7 +455,7 @@ importers:
         version: 0.15.0
       next:
         specifier: 14.2.3
-        version: 14.2.3(@babel/core@7.24.5)(react-dom@18.2.0)(react@18.2.0)(sass@1.77.8)
+        version: 14.2.3(@babel/core@7.24.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.77.8)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -477,7 +477,7 @@ importers:
         version: 10.4.19(postcss@8.4.39)
       babel-loader:
         specifier: ^9.1.3
-        version: 9.1.3(@babel/core@7.24.5)(webpack@5.93.0)
+        version: 9.1.3(@babel/core@7.24.7)(webpack@5.93.0)
       css-loader:
         specifier: ^6.11.0
         version: 6.11.0(webpack@5.93.0)
@@ -501,7 +501,7 @@ importers:
         version: 3.3.4(webpack@5.93.0)
       tailwindcss:
         specifier: ^3.4.3
-        version: 3.4.6
+        version: 3.4.6(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
 
   demos/example-vite:
     dependencies:
@@ -511,16 +511,16 @@ importers:
     devDependencies:
       '@swc/core':
         specifier: ~1.6.0
-        version: 1.6.13
+        version: 1.6.13(@swc/helpers@0.5.5)
       vite:
         specifier: ^5.0.12
-        version: 5.3.4(sass@1.77.8)
+        version: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
       vite-plugin-top-level-await:
         specifier: ^1.4.1
-        version: 1.4.1(rollup@2.79.1)(vite@5.3.4)
+        version: 1.4.1(@swc/helpers@0.5.5)(rollup@4.18.1)(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       vite-plugin-wasm:
         specifier: ^3.3.0
-        version: 3.3.0(vite@5.3.4)
+        version: 3.3.0(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
 
   demos/example-webpack:
     dependencies:
@@ -530,10 +530,10 @@ importers:
     devDependencies:
       '@types/webpack':
         specifier: ^5.28.5
-        version: 5.28.5(webpack-cli@5.1.4)
+        version: 5.28.5(webpack-cli@5.1.4(webpack@5.93.0))
       html-webpack-plugin:
         specifier: ^5.6.0
-        version: 5.6.0(webpack@5.93.0)
+        version: 5.6.0(webpack@5.93.0(webpack-cli@5.1.4))
       serve:
         specifier: ^14.2.1
         version: 14.2.3
@@ -560,7 +560,7 @@ importers:
         version: 2.44.4
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.3.1(vite@5.3.4)
+        version: 4.3.1(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       '@webflow/webflow-cli':
         specifier: ^1.6.9
         version: 1.6.12
@@ -588,7 +588,7 @@ importers:
     devDependencies:
       '@swc/core':
         specifier: ~1.6.0
-        version: 1.6.13
+        version: 1.6.13(@swc/helpers@0.5.5)
       '@types/cors':
         specifier: ~2.8.17
         version: 2.8.17
@@ -615,16 +615,16 @@ importers:
         version: 5.5.3
       vite:
         specifier: ^5.1.5
-        version: 5.3.4(@types/node@20.14.11)
+        version: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
       vite-plugin-pwa:
         specifier: ^0.19.2
-        version: 0.19.8(vite@5.3.4)(workbox-build@7.1.1)(workbox-window@7.1.0)
+        version: 0.19.8(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))(workbox-build@7.1.1(@types/babel__core@7.20.5))(workbox-window@7.1.0)
       vite-plugin-top-level-await:
         specifier: ^1.4.1
-        version: 1.4.1(rollup@2.79.1)(vite@5.3.4)
+        version: 1.4.1(@swc/helpers@0.5.5)(rollup@2.79.1)(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       vite-plugin-wasm:
         specifier: ^3.3.0
-        version: 3.3.0(vite@5.3.4)
+        version: 3.3.0(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
 
   demos/react-native-supabase-group-chat:
     dependencies:
@@ -636,7 +636,7 @@ importers:
         version: 8.3.1
       '@journeyapps/react-native-quick-sqlite':
         specifier: ^1.1.7
-        version: 1.1.8(react-native@0.74.1)(react@18.2.0)
+        version: 1.1.8(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@powersync/common':
         specifier: workspace:*
         version: link:../../packages/common
@@ -648,28 +648,28 @@ importers:
         version: link:../../packages/react-native
       '@react-native-async-storage/async-storage':
         specifier: 1.23.1
-        version: 1.23.1(react-native@0.74.1)
+        version: 1.23.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))
       '@shopify/flash-list':
         specifier: 1.6.4
-        version: 1.6.4(@babel/runtime@7.24.8)(react-native@0.74.1)(react@18.2.0)
+        version: 1.6.4(@babel/runtime@7.24.8)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@supabase/supabase-js':
         specifier: 2.39.0
         version: 2.39.0
       '@tamagui/animations-react-native':
         specifier: 1.79.6
-        version: 1.79.6(react-native@0.74.1)(react@18.2.0)
+        version: 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/babel-plugin':
         specifier: 1.79.6
-        version: 1.79.6(react-dom@18.2.0)(react@18.2.0)
+        version: 1.79.6(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tamagui/config':
         specifier: 1.79.6
-        version: 1.79.6(react-dom@18.2.0)(react-native-reanimated@3.10.1)(react-native@0.74.1)(react@18.2.0)
+        version: 1.79.6(react-dom@18.2.0(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/font-inter':
         specifier: 1.79.6
         version: 1.79.6(react@18.2.0)
       '@tamagui/lucide-icons':
         specifier: 1.79.6
-        version: 1.79.6(react-native-svg@15.2.0)(react@18.2.0)
+        version: 1.79.6(react-native-svg@15.2.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@tamagui/theme-base':
         specifier: 1.79.6
         version: 1.79.6
@@ -681,31 +681,31 @@ importers:
         version: 2.30.0
       expo:
         specifier: ~51.0.10
-        version: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+        version: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
       expo-build-properties:
         specifier: ~0.12.1
-        version: 0.12.3(expo@51.0.21)
+        version: 0.12.3(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       expo-crypto:
         specifier: ~13.0.2
-        version: 13.0.2(expo@51.0.21)
+        version: 13.0.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       expo-dev-client:
         specifier: ~4.0.15
-        version: 4.0.20(expo@51.0.21)
+        version: 4.0.20(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       expo-linking:
         specifier: ~6.3.1
-        version: 6.3.1(expo@51.0.21)
+        version: 6.3.1(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       expo-router:
         specifier: ^3.5.15
-        version: 3.5.15(expo-constants@16.0.2)(expo-linking@6.3.1)(expo-modules-autolinking@1.11.1)(expo-status-bar@1.12.1)(expo@51.0.21)(react-native-reanimated@3.10.1)(react-native-safe-area-context@4.10.1)(react-native-screens@3.31.1)(react-native@0.74.1)(react@18.2.0)(typescript@5.3.3)
+        version: 3.5.15(@react-navigation/drawer@6.7.2(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(encoding@0.1.13)(expo-constants@16.0.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)))(expo-linking@6.3.1(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)))(expo-modules-autolinking@1.11.1)(expo-status-bar@1.12.1)(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
       expo-splash-screen:
         specifier: ~0.27.4
-        version: 0.27.5(expo-modules-autolinking@1.11.1)(expo@51.0.21)
+        version: 0.27.5(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       expo-status-bar:
         specifier: ~1.12.1
         version: 1.12.1
       metro:
         specifier: ~0.80.5
-        version: 0.80.9
+        version: 0.80.9(encoding@0.1.13)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -714,40 +714,40 @@ importers:
         version: 18.2.0(react@18.2.0)
       react-native:
         specifier: 0.74.1
-        version: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+        version: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
       react-native-fetch-api:
         specifier: ^3.0.0
         version: 3.0.0
       react-native-gesture-handler:
         specifier: ~2.16.2
-        version: 2.16.2(react-native@0.74.1)(react@18.2.0)
+        version: 2.16.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-pager-view:
         specifier: 6.3.0
-        version: 6.3.0(react-native@0.74.1)(react@18.2.0)
+        version: 6.3.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-polyfill-globals:
         specifier: ^3.1.0
-        version: 3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0)(react-native-url-polyfill@2.0.0)(text-encoding@0.7.0)(web-streams-polyfill@3.2.1)
+        version: 3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)))(react-native-url-polyfill@2.0.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)))(text-encoding@0.7.0)(web-streams-polyfill@3.2.1)
       react-native-reanimated:
         specifier: ~3.10.1
-        version: 3.10.1(@babel/core@7.24.5)(react-native@0.74.1)(react@18.2.0)
+        version: 3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-safe-area-context:
         specifier: 4.10.1
-        version: 4.10.1(react-native@0.74.1)(react@18.2.0)
+        version: 4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-screens:
         specifier: ~3.31.1
-        version: 3.31.1(react-native@0.74.1)(react@18.2.0)
+        version: 3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-svg:
         specifier: 15.2.0
-        version: 15.2.0(react-native@0.74.1)(react@18.2.0)
+        version: 15.2.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-url-polyfill:
         specifier: ^2.0.0
-        version: 2.0.0(react-native@0.74.1)
+        version: 2.0.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))
       react-native-web:
         specifier: 0.19.12
-        version: 0.19.12(react-dom@18.2.0)(react@18.2.0)
+        version: 0.19.12(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       tamagui:
         specifier: 1.79.6
-        version: 1.79.6(@types/react@18.3.3)(react-dom@18.2.0)(react-native-web@0.19.12)(react-native@0.74.1)(react@18.2.0)
+        version: 1.79.6(@types/react@18.3.3)(immer@9.0.21)(react-dom@18.2.0(react@18.2.0))(react-native-web@0.19.12(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       text-encoding:
         specifier: ^0.7.0
         version: 0.7.0
@@ -766,13 +766,13 @@ importers:
         version: 18.3.3
       eas-cli:
         specifier: ^7.2.0
-        version: 7.8.5(@types/node@20.14.11)(expo-modules-autolinking@1.11.1)(typescript@5.3.3)
+        version: 7.8.5(@swc/core@1.6.13)(@types/node@20.14.11)(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(typescript@5.3.3)
       eslint:
         specifier: 8.55.0
         version: 8.55.0
       eslint-config-universe:
         specifier: 12.0.0
-        version: 12.0.0(eslint@8.55.0)(prettier@3.3.3)(typescript@5.3.3)
+        version: 12.0.0(@types/eslint@8.56.10)(eslint@8.55.0)(prettier@3.3.3)(typescript@5.3.3)
       prettier:
         specifier: ^3.1.0
         version: 3.3.3
@@ -787,13 +787,13 @@ importers:
         version: 1.0.2
       '@craftzdog/react-native-buffer':
         specifier: ^6.0.5
-        version: 6.0.5(react-native@0.74.1)(react@18.2.0)
+        version: 6.0.5(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@expo/vector-icons':
         specifier: ^14.0.0
         version: 14.0.2
       '@journeyapps/react-native-quick-sqlite':
         specifier: ^1.1.7
-        version: 1.1.8(react-native@0.74.1)(react@18.2.0)
+        version: 1.1.8(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@powersync/attachments':
         specifier: workspace:*
         version: link:../../packages/attachments
@@ -808,13 +808,13 @@ importers:
         version: link:../../packages/react-native
       '@react-native-community/masked-view':
         specifier: ^0.1.11
-        version: 0.1.11(react-native@0.74.1)(react@18.2.0)
+        version: 0.1.11(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@react-navigation/drawer':
         specifier: ^6.6.3
-        version: 6.7.2(@react-navigation/native@6.1.18)(react-native-gesture-handler@2.16.2)(react-native-reanimated@3.10.1)(react-native-safe-area-context@4.10.1)(react-native-screens@3.31.1)(react-native@0.74.1)(react@18.2.0)
+        version: 6.7.2(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@react-navigation/native':
         specifier: ^6.0.0
-        version: 6.1.18(react-native@0.74.1)(react@18.2.0)
+        version: 6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@supabase/supabase-js':
         specifier: ^2.33.1
         version: 2.44.4
@@ -826,34 +826,34 @@ importers:
         version: 1.0.2
       expo:
         specifier: ~51.0.10
-        version: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+        version: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
       expo-build-properties:
         specifier: ~0.12.1
-        version: 0.12.3(expo@51.0.21)
+        version: 0.12.3(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       expo-camera:
         specifier: ~15.0.10
-        version: 15.0.14(expo@51.0.21)
+        version: 15.0.14(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       expo-constants:
         specifier: ~16.0.2
-        version: 16.0.2(expo@51.0.21)
+        version: 16.0.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       expo-crypto:
         specifier: ~13.0.2
-        version: 13.0.2(expo@51.0.21)
+        version: 13.0.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       expo-file-system:
         specifier: ^17.0.1
-        version: 17.0.1(expo@51.0.21)
+        version: 17.0.1(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       expo-linking:
         specifier: ~6.3.1
-        version: 6.3.1(expo@51.0.21)
+        version: 6.3.1(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       expo-router:
         specifier: 3.5.15
-        version: 3.5.15(@react-navigation/drawer@6.7.2)(expo-constants@16.0.2)(expo-linking@6.3.1)(expo-modules-autolinking@1.11.1)(expo-status-bar@1.12.1)(expo@51.0.21)(react-native-reanimated@3.10.1)(react-native-safe-area-context@4.10.1)(react-native-screens@3.31.1)(react-native@0.74.1)(react@18.2.0)(typescript@5.5.3)
+        version: 3.5.15(@react-navigation/drawer@6.7.2(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(encoding@0.1.13)(expo-constants@16.0.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)))(expo-linking@6.3.1(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)))(expo-modules-autolinking@1.11.1)(expo-status-bar@1.12.1)(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)(typescript@5.5.3)
       expo-secure-store:
         specifier: ~13.0.1
-        version: 13.0.2(expo@51.0.21)
+        version: 13.0.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       expo-splash-screen:
         specifier: ~0.27.4
-        version: 0.27.5(expo-modules-autolinking@1.11.1)(expo@51.0.21)
+        version: 0.27.5(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       expo-status-bar:
         specifier: ~1.12.1
         version: 1.12.1
@@ -865,55 +865,52 @@ importers:
         version: 4.17.21
       metro:
         specifier: ~0.80.8
-        version: 0.80.9
+        version: 0.80.9(encoding@0.1.13)
       react:
         specifier: 18.2.0
         version: 18.2.0
       react-native:
         specifier: 0.74.1
-        version: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
+        version: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
       react-native-elements:
         specifier: ^3.4.3
-        version: 3.4.3(react-native-safe-area-context@4.10.1)(react-native-vector-icons@10.1.0)(react-native@0.74.1)(react@18.2.0)
-      react-native-encrypted-storage:
-        specifier: ^4.0.3
-        version: 4.0.3(react-native@0.74.1)(react@18.2.0)
+        version: 3.4.3(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-vector-icons@10.1.0)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-fetch-api:
         specifier: ^3.0.0
         version: 3.0.0
       react-native-gesture-handler:
         specifier: ~2.16.2
-        version: 2.16.2(react-native@0.74.1)(react@18.2.0)
+        version: 2.16.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-polyfill-globals:
         specifier: ^3.1.0
-        version: 3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0)(react-native-url-polyfill@2.0.0)(text-encoding@0.7.0)(web-streams-polyfill@3.3.3)
+        version: 3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)))(react-native-url-polyfill@2.0.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)))(text-encoding@0.7.0)(web-streams-polyfill@3.3.3)
       react-native-prompt-android:
         specifier: ^1.1.0
         version: 1.1.0
       react-native-reanimated:
         specifier: ~3.10.0
-        version: 3.10.1(@babel/core@7.24.5)(react-native@0.74.1)(react@18.2.0)
+        version: 3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-reanimated-table:
         specifier: ^0.0.2
-        version: 0.0.2(react-native@0.74.1)(react@18.2.0)
+        version: 0.0.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-safe-area-context:
         specifier: 4.10.1
-        version: 4.10.1(react-native@0.74.1)(react@18.2.0)
+        version: 4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-safe-area-view:
         specifier: ^1.1.1
-        version: 1.1.1(react-native-safe-area-context@4.10.1)(react-native@0.74.1)(react@18.2.0)
+        version: 1.1.1(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-screens:
         specifier: ~3.31.1
-        version: 3.31.1(react-native@0.74.1)(react@18.2.0)
+        version: 3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-url-polyfill:
         specifier: ^2.0.0
-        version: 2.0.0(react-native@0.74.1)
+        version: 2.0.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))
       react-native-vector-icons:
         specifier: ^10.0.0
         version: 10.1.0
       react-navigation-stack:
         specifier: ^2.10.4
-        version: 2.10.4(@react-native-community/masked-view@0.1.11)(react-native-gesture-handler@2.16.2)(react-native-safe-area-context@4.10.1)(react-native-screens@3.31.1)(react-native@0.74.1)(react-navigation@4.4.4)(react@18.2.0)
+        version: 2.10.4(@react-native-community/masked-view@0.1.11(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react-navigation@4.4.4(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0)
       text-encoding:
         specifier: ^0.7.0
         version: 0.7.0
@@ -938,7 +935,7 @@ importers:
         version: 18.2.79
       babel-preset-expo:
         specifier: ^11.0.5
-        version: 11.0.12(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+        version: 11.0.12(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))
       prettier:
         specifier: ^3.2.5
         version: 3.3.3
@@ -953,19 +950,19 @@ importers:
         version: 11.11.4(@types/react@18.3.3)(react@18.2.0)
       '@emotion/styled':
         specifier: 11.11.5
-        version: 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.2.0)
+        version: 11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0)
       '@journeyapps/wa-sqlite':
         specifier: ~0.2.0
         version: 0.2.0
       '@mui/icons-material':
         specifier: ^5.15.12
-        version: 5.16.4(@mui/material@5.16.4)(@types/react@18.3.3)(react@18.2.0)
+        version: 5.16.4(@mui/material@5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.3.3)(react@18.2.0)
       '@mui/material':
         specifier: ^5.15.12
-        version: 5.16.4(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
+        version: 5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@mui/x-data-grid':
         specifier: ^6.19.6
-        version: 6.20.3(@mui/material@5.16.4)(@mui/system@5.16.4)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
+        version: 6.20.3(@mui/material@5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@mui/system@5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@powersync/react':
         specifier: workspace:*
         version: link:../../packages/react
@@ -995,11 +992,11 @@ importers:
         version: 18.2.0(react@18.2.0)
       react-router-dom:
         specifier: ^6.22.3
-        version: 6.25.1(react-dom@18.2.0)(react@18.2.0)
+        version: 6.25.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@swc/core':
         specifier: ~1.6.0
-        version: 1.6.13
+        version: 1.6.13(@swc/helpers@0.5.5)
       '@types/lodash':
         specifier: ^4.14.202
         version: 4.17.7
@@ -1014,28 +1011,28 @@ importers:
         version: 18.3.0
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.3.1(vite@5.3.4)
+        version: 4.3.1(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       autoprefixer:
         specifier: ^10.4.18
         version: 10.4.19(postcss@8.4.39)
       babel-loader:
         specifier: ^9.1.3
-        version: 9.1.3(@babel/core@7.24.5)(webpack@5.93.0)
+        version: 9.1.3(@babel/core@7.24.7)(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5)))
       typescript:
         specifier: ^5.4.2
         version: 5.5.3
       vite:
         specifier: ^5.1.5
-        version: 5.3.4(@types/node@20.14.11)
+        version: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
       vite-plugin-pwa:
         specifier: ^0.19.2
-        version: 0.19.8(vite@5.3.4)(workbox-build@7.1.1)(workbox-window@7.1.0)
+        version: 0.19.8(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))(workbox-build@7.1.1(@types/babel__core@7.20.5))(workbox-window@7.1.0)
       vite-plugin-top-level-await:
         specifier: ^1.4.1
-        version: 1.4.1(rollup@2.79.1)(vite@5.3.4)
+        version: 1.4.1(@swc/helpers@0.5.5)(rollup@4.18.1)(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       vite-plugin-wasm:
         specifier: ^3.3.0
-        version: 3.3.0(vite@5.3.4)
+        version: 3.3.0(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
 
   demos/vue-supabase-todolist:
     dependencies:
@@ -1053,10 +1050,10 @@ importers:
         version: 2.44.4
       '@vuelidate/core':
         specifier: ^2.0.3
-        version: 2.0.3(vue@3.4.21)
+        version: 2.0.3(vue@3.4.21(typescript@5.5.3))
       '@vuelidate/validators':
         specifier: ^2.0.4
-        version: 2.0.4(vue@3.4.21)
+        version: 2.0.4(vue@3.4.21(typescript@5.5.3))
       js-logger:
         specifier: ^1.6.1
         version: 1.6.1
@@ -1065,20 +1062,20 @@ importers:
         version: 3.4.21(typescript@5.5.3)
       vue-router:
         specifier: '4'
-        version: 4.4.0(vue@3.4.21)
+        version: 4.4.0(vue@3.4.21(typescript@5.5.3))
       vuetify:
         specifier: 3.6.8
-        version: 3.6.8(typescript@5.5.3)(vite-plugin-vuetify@2.0.3)(vue@3.4.21)
+        version: 3.6.8(typescript@5.5.3)(vite-plugin-vuetify@2.0.3)(vue@3.4.21(typescript@5.5.3))
     devDependencies:
       '@swc/core':
         specifier: ~1.6.0
-        version: 1.6.13
+        version: 1.6.13(@swc/helpers@0.5.5)
       '@types/vuelidate':
         specifier: ^0.7.21
         version: 0.7.21
       '@vitejs/plugin-vue':
         specifier: ^5.0.4
-        version: 5.0.5(vite@5.3.4)(vue@3.4.21)
+        version: 5.0.5(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))(vue@3.4.21(typescript@5.5.3))
       sass:
         specifier: ^1.71.1
         version: 1.77.8
@@ -1087,25 +1084,25 @@ importers:
         version: 5.5.3
       unplugin-fonts:
         specifier: ^1.1.1
-        version: 1.1.1(vite@5.3.4)
+        version: 1.1.1(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       unplugin-vue-components:
         specifier: ^0.26.0
-        version: 0.26.0(rollup@2.79.1)(vue@3.4.21)
+        version: 0.26.0(@babel/parser@7.24.8)(rollup@4.18.1)(vue@3.4.21(typescript@5.5.3))
       vite:
         specifier: ^5.2.0
-        version: 5.3.4(sass@1.77.8)
+        version: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
       vite-plugin-pwa:
         specifier: ^0.19.2
-        version: 0.19.8(vite@5.3.4)(workbox-build@7.1.1)(workbox-window@7.1.0)
+        version: 0.19.8(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))(workbox-build@7.1.1(@types/babel__core@7.20.5))(workbox-window@7.1.0)
       vite-plugin-top-level-await:
         specifier: ^1.4.1
-        version: 1.4.1(rollup@2.79.1)(vite@5.3.4)
+        version: 1.4.1(@swc/helpers@0.5.5)(rollup@4.18.1)(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       vite-plugin-vuetify:
         specifier: ^2.0.3
-        version: 2.0.3(vite@5.3.4)(vue@3.4.21)(vuetify@3.6.8)
+        version: 2.0.3(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))(vue@3.4.21(typescript@5.5.3))(vuetify@3.6.8)
       vite-plugin-wasm:
         specifier: ^3.3.0
-        version: 3.3.0(vite@5.3.4)
+        version: 3.3.0(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       vue-tsc:
         specifier: ^2.0.6
         version: 2.0.26(typescript@5.5.3)
@@ -1117,7 +1114,7 @@ importers:
         version: 11.11.4(@types/react@18.3.3)(react@18.2.0)
       '@emotion/styled':
         specifier: ^11.11.0
-        version: 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.2.0)
+        version: 11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0)
       '@fontsource/roboto':
         specifier: ^5.0.12
         version: 5.0.13
@@ -1126,16 +1123,16 @@ importers:
         version: 0.1.1
       '@lexical/react':
         specifier: ^0.11.3
-        version: 0.11.3(lexical@0.11.3)(react-dom@18.2.0)(react@18.2.0)(yjs@13.6.18)
+        version: 0.11.3(lexical@0.11.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(yjs@13.6.18)
       '@mui/icons-material':
         specifier: ^5.15.12
-        version: 5.16.4(@mui/material@5.16.4)(@types/react@18.3.3)(react@18.2.0)
+        version: 5.16.4(@mui/material@5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.3.3)(react@18.2.0)
       '@mui/material':
         specifier: ^5.15.12
-        version: 5.16.4(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
+        version: 5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@mui/x-data-grid':
         specifier: ^6.19.6
-        version: 6.20.3(@mui/material@5.16.4)(@mui/system@5.16.4)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
+        version: 6.20.3(@mui/material@5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@mui/system@5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@powersync/react':
         specifier: workspace:*
         version: link:../../packages/react
@@ -1147,22 +1144,22 @@ importers:
         version: 2.44.4
       '@tiptap/extension-collaboration':
         specifier: 2.2.2
-        version: 2.2.2(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)(y-prosemirror@1.0.20)
+        version: 2.2.2(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)(y-prosemirror@1.0.20(prosemirror-model@1.22.1)(prosemirror-state@1.4.3)(prosemirror-view@1.33.8)(y-protocols@1.0.6(yjs@13.6.18))(yjs@13.6.18))
       '@tiptap/extension-collaboration-cursor':
         specifier: 2.2.2
-        version: 2.2.2(@tiptap/core@2.5.4)(y-prosemirror@1.0.20)
+        version: 2.2.2(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(y-prosemirror@1.0.20(prosemirror-model@1.22.1)(prosemirror-state@1.4.3)(prosemirror-view@1.33.8)(y-protocols@1.0.6(yjs@13.6.18))(yjs@13.6.18))
       '@tiptap/extension-highlight':
         specifier: 2.2.2
-        version: 2.2.2(@tiptap/core@2.5.4)
+        version: 2.2.2(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))
       '@tiptap/extension-task-item':
         specifier: 2.2.2
-        version: 2.2.2(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)
+        version: 2.2.2(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)
       '@tiptap/extension-task-list':
         specifier: 2.2.2
-        version: 2.2.2(@tiptap/core@2.5.4)
+        version: 2.2.2(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))
       '@tiptap/react':
         specifier: 2.2.2
-        version: 2.2.2(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)(react-dom@18.2.0)(react@18.2.0)
+        version: 2.2.2(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tiptap/starter-kit':
         specifier: 2.2.2
         version: 2.2.2(@tiptap/pm@2.5.4)
@@ -1207,7 +1204,7 @@ importers:
         version: 6.25.1(react@18.2.0)
       react-router-dom:
         specifier: ^6.22.3
-        version: 6.25.1(react-dom@18.2.0)(react@18.2.0)
+        version: 6.25.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       remixicon:
         specifier: ^2.5.0
         version: 2.5.0
@@ -1222,7 +1219,7 @@ importers:
         version: 9.0.1
       y-prosemirror:
         specifier: 1.0.20
-        version: 1.0.20(prosemirror-model@1.22.1)(prosemirror-state@1.4.3)(prosemirror-view@1.33.8)(y-protocols@1.0.6)(yjs@13.6.18)
+        version: 1.0.20(prosemirror-model@1.22.1)(prosemirror-state@1.4.3)(prosemirror-view@1.33.8)(y-protocols@1.0.6(yjs@13.6.18))(yjs@13.6.18)
       y-protocols:
         specifier: 1.0.6
         version: 1.0.6(yjs@13.6.18)
@@ -1232,7 +1229,7 @@ importers:
     devDependencies:
       '@swc/core':
         specifier: ~1.6.0
-        version: 1.6.13
+        version: 1.6.13(@swc/helpers@0.5.5)
       '@types/lodash':
         specifier: ^4.17.0
         version: 4.17.7
@@ -1256,31 +1253,31 @@ importers:
         version: 8.4.39
       style-loader:
         specifier: ^3.3.4
-        version: 3.3.4(webpack@5.93.0)
+        version: 3.3.4(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5)))
       supabase:
         specifier: 1.142.2
         version: 1.142.2
       vite:
         specifier: ^5.1.6
-        version: 5.3.4(@types/node@20.14.11)
+        version: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
       vite-plugin-pwa:
         specifier: ^0.19.2
-        version: 0.19.8(vite@5.3.4)(workbox-build@7.1.1)(workbox-window@7.1.0)
+        version: 0.19.8(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))(workbox-build@7.1.1(@types/babel__core@7.20.5))(workbox-window@7.1.0)
       vite-plugin-top-level-await:
         specifier: ^1.4.1
-        version: 1.4.1(rollup@2.79.1)(vite@5.3.4)
+        version: 1.4.1(@swc/helpers@0.5.5)(rollup@4.18.1)(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       vite-plugin-wasm:
         specifier: ^3.3.0
-        version: 3.3.0(vite@5.3.4)
+        version: 3.3.0(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
 
   docs:
     dependencies:
       '@docusaurus/core':
         specifier: ^3.4.0
-        version: 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
+        version: 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
       '@docusaurus/preset-classic':
         specifier: ^3.4.0
-        version: 3.4.0(@algolia/client-search@4.24.0)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.15.0)(typescript@5.4.5)
+        version: 3.4.0(@algolia/client-search@4.24.0)(@types/react@18.3.3)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.15.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
       '@mdx-js/react':
         specifier: ^3.0.1
         version: 3.0.1(@types/react@18.3.3)(react@18.2.0)
@@ -1299,28 +1296,28 @@ importers:
     devDependencies:
       '@docusaurus/module-type-aliases':
         specifier: ^3.4.0
-        version: 3.4.0(react-dom@18.2.0)(react@18.2.0)
+        version: 3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@docusaurus/theme-classic':
         specifier: ^3.4.0
-        version: 3.4.0(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
+        version: 3.4.0(@types/react@18.3.3)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
       '@docusaurus/tsconfig':
         specifier: 3.4.0
         version: 3.4.0
       '@docusaurus/types':
         specifier: 3.4.0
-        version: 3.4.0(react-dom@18.2.0)(react@18.2.0)
+        version: 3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/node':
         specifier: ^20.14.8
         version: 20.14.11
       docusaurus-plugin-typedoc:
         specifier: ^1.0.1
-        version: 1.0.3(typedoc-plugin-markdown@4.0.3)
+        version: 1.0.3(typedoc-plugin-markdown@4.0.3(typedoc@0.25.13(typescript@5.4.5)))
       typedoc:
         specifier: ^0.25.13
         version: 0.25.13(typescript@5.4.5)
       typedoc-plugin-markdown:
         specifier: ~4.0.3
-        version: 4.0.3(typedoc@0.25.13)
+        version: 4.0.3(typedoc@0.25.13(typescript@5.4.5))
       typescript:
         specifier: ~5.4.5
         version: 5.4.5
@@ -1328,7 +1325,7 @@ importers:
   packages/attachments:
     dependencies:
       '@powersync/common':
-        specifier: workspace:^1.9.0
+        specifier: workspace:^
         version: link:../common
 
   packages/common:
@@ -1344,7 +1341,7 @@ importers:
         version: 1.0.2
       cross-fetch:
         specifier: ^4.0.0
-        version: 4.0.0
+        version: 4.0.0(encoding@0.1.13)
       event-iterator:
         specifier: ^2.0.0
         version: 2.0.0
@@ -1378,12 +1375,12 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^1.5.2
-        version: 1.6.0(@types/node@20.14.11)(@vitest/browser@1.6.0)
+        version: 1.6.0(@types/node@20.14.11)(@vitest/browser@1.6.0)(jsdom@24.1.0)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
 
   packages/kysely-driver:
     dependencies:
       '@powersync/common':
-        specifier: workspace:^1.13.0
+        specifier: workspace:^
         version: link:../common
       kysely:
         specifier: ^0.27.2
@@ -1400,28 +1397,28 @@ importers:
         version: 20.14.11
       '@vitest/browser':
         specifier: ^1.3.1
-        version: 1.6.0(vitest@1.6.0)(webdriverio@8.39.1)
+        version: 1.6.0(vitest@1.6.0)(webdriverio@8.39.1(typescript@5.5.3))
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.1(typescript@5.5.3)(webpack@5.93.0)
+        version: 9.5.1(typescript@5.5.3)(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5)))
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@20.14.11)(typescript@5.5.3)
+        version: 10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.5.3)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
       vite:
         specifier: ^5.1.1
-        version: 5.3.4(@types/node@20.14.11)
+        version: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
       vite-plugin-top-level-await:
         specifier: ^1.4.1
-        version: 1.4.1(rollup@2.79.1)(vite@5.3.4)
+        version: 1.4.1(@swc/helpers@0.5.5)(rollup@4.18.1)(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       vite-plugin-wasm:
         specifier: ^3.3.0
-        version: 3.3.0(vite@5.3.4)
+        version: 3.3.0(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       vitest:
         specifier: ^1.3.0
-        version: 1.6.0(@types/node@20.14.11)(@vitest/browser@1.6.0)
+        version: 1.6.0(@types/node@20.14.11)(@vitest/browser@1.6.0)(jsdom@24.1.0)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
       webdriverio:
         specifier: ^8.32.3
         version: 8.39.1(typescript@5.5.3)
@@ -1429,12 +1426,12 @@ importers:
   packages/react:
     dependencies:
       '@powersync/common':
-        specifier: workspace:^1.9.0
+        specifier: workspace:^
         version: link:../common
     devDependencies:
       '@testing-library/react':
         specifier: ^15.0.2
-        version: 15.0.7(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
+        version: 15.0.7(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: ^18.2.34
         version: 18.3.3
@@ -1467,11 +1464,11 @@ importers:
         version: 3.0.0
       react-native-polyfill-globals:
         specifier: ^3.1.0
-        version: 3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0)(react-native-url-polyfill@2.0.0)(text-encoding@0.7.0)(web-streams-polyfill@3.3.3)
+        version: 3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0(react-native@0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)(react@18.2.0)))(react-native-url-polyfill@2.0.0(react-native@0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)(react@18.2.0)))(text-encoding@0.7.0)(web-streams-polyfill@3.3.3)
     devDependencies:
       '@journeyapps/react-native-quick-sqlite':
         specifier: ^1.1.8
-        version: 1.1.8(react-native@0.72.4)(react@18.2.0)
+        version: 1.1.8(react-native@0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@types/async-lock':
         specifier: ^1.4.0
         version: 1.4.2
@@ -1480,7 +1477,7 @@ importers:
         version: 18.2.0
       react-native:
         specifier: 0.72.4
-        version: 0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(react@18.2.0)
+        version: 0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)(react@18.2.0)
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1488,7 +1485,7 @@ importers:
   packages/vue:
     dependencies:
       '@powersync/common':
-        specifier: workspace:^1.10.0
+        specifier: workspace:^
         version: link:../common
     devDependencies:
       flush-promises:
@@ -1502,7 +1499,7 @@ importers:
         version: 5.5.3
       vitest:
         specifier: ^1.5.1
-        version: 1.6.0(jsdom@24.1.0)
+        version: 1.6.0(@types/node@20.14.11)(@vitest/browser@1.6.0)(jsdom@24.1.0)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
       vue:
         specifier: 3.4.21
         version: 3.4.21(typescript@5.5.3)
@@ -1542,7 +1539,7 @@ importers:
         version: 9.0.8
       '@vitest/browser':
         specifier: ^1.3.1
-        version: 1.6.0(vitest@1.6.0)(webdriverio@8.39.1)
+        version: 1.6.0(vitest@1.6.0)(webdriverio@8.39.1(typescript@5.5.3))
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -1551,16 +1548,16 @@ importers:
         version: 9.0.1
       vite:
         specifier: ^5.1.1
-        version: 5.3.4(sass@1.77.8)
+        version: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
       vite-plugin-top-level-await:
         specifier: ^1.4.1
-        version: 1.4.1(rollup@2.79.1)(vite@5.3.4)
+        version: 1.4.1(@swc/helpers@0.5.5)(rollup@4.18.1)(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       vite-plugin-wasm:
         specifier: ^3.3.0
-        version: 3.3.0(vite@5.3.4)
+        version: 3.3.0(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       vitest:
         specifier: ^1.3.1
-        version: 1.6.0(@vitest/browser@1.6.0)
+        version: 1.6.0(@types/node@20.14.11)(@vitest/browser@1.6.0)(jsdom@24.1.0)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
       webdriverio:
         specifier: ^8.32.3
         version: 8.39.1(typescript@5.5.3)
@@ -1572,10 +1569,10 @@ importers:
         version: 0.1.1
       '@mui/material':
         specifier: ^5.15.12
-        version: 5.16.4(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
+        version: 5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@mui/x-data-grid':
         specifier: ^6.19.6
-        version: 6.20.3(@mui/material@5.16.4)(@mui/system@5.16.4)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
+        version: 6.20.3(@mui/material@5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@mui/system@5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@powersync/react':
         specifier: workspace:*
         version: link:../../packages/react
@@ -1596,11 +1593,11 @@ importers:
         version: 18.2.0(react@18.2.0)
       react-router-dom:
         specifier: ^6.22.3
-        version: 6.25.1(react-dom@18.2.0)(react@18.2.0)
+        version: 6.25.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@swc/core':
         specifier: ~1.6.0
-        version: 1.6.13
+        version: 1.6.13(@swc/helpers@0.5.5)
       '@types/lodash':
         specifier: ^4.14.202
         version: 4.17.7
@@ -1615,28 +1612,28 @@ importers:
         version: 18.3.0
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.3.1(vite@5.3.4)
+        version: 4.3.1(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       autoprefixer:
         specifier: ^10.4.18
         version: 10.4.19(postcss@8.4.39)
       babel-loader:
         specifier: ^9.1.3
-        version: 9.1.3(@babel/core@7.24.5)(webpack@5.93.0)
+        version: 9.1.3(@babel/core@7.24.7)(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5)))
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
       vite:
         specifier: ^5.1.5
-        version: 5.3.4(@types/node@20.14.11)
+        version: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
       vite-plugin-pwa:
         specifier: ^0.19.2
-        version: 0.19.8(vite@5.3.4)(workbox-build@7.1.1)(workbox-window@7.1.0)
+        version: 0.19.8(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))(workbox-build@7.1.1(@types/babel__core@7.20.5))(workbox-window@7.1.0)
       vite-plugin-top-level-await:
         specifier: ^1.4.1
-        version: 1.4.1(rollup@2.79.1)(vite@5.3.4)
+        version: 1.4.1(@swc/helpers@0.5.5)(rollup@4.18.1)(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
       vite-plugin-wasm:
         specifier: ^3.3.0
-        version: 3.3.0(vite@5.3.4)
+        version: 3.3.0(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))
 
 packages:
 
@@ -16047,7 +16044,7 @@ packages:
 snapshots:
 
   '@0no-co/graphql.web@1.0.7(graphql@16.8.1)':
-    dependencies:
+    optionalDependencies:
       graphql: 16.8.1
 
   '@algolia/autocomplete-core@1.9.3(@algolia/client-search@4.24.0)(algoliasearch@4.24.0)(search-insights@2.15.0)':
@@ -16163,10 +16160,10 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@angular-builders/common@2.0.0(@types/node@20.14.11)(typescript@5.5.3)':
+  '@angular-builders/common@2.0.0(@swc/core@1.6.13)(@types/node@20.14.11)(chokidar@3.6.0)(typescript@5.5.3)':
     dependencies:
-      '@angular-devkit/core': 18.1.1
-      ts-node: 10.9.2(@types/node@20.14.11)(typescript@5.5.3)
+      '@angular-devkit/core': 18.1.1(chokidar@3.6.0)
+      ts-node: 10.9.2(@swc/core@1.6.13)(@types/node@20.14.11)(typescript@5.5.3)
       tsconfig-paths: 4.2.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -16175,13 +16172,13 @@ snapshots:
       - chokidar
       - typescript
 
-  '@angular-builders/custom-webpack@18.0.0(@angular/compiler-cli@18.1.1)(@angular/service-worker@18.1.1)(@types/node@20.14.11)(typescript@5.5.3)':
+  '@angular-builders/custom-webpack@18.0.0(@angular/compiler-cli@18.1.1(@angular/compiler@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(typescript@5.5.3))(@angular/service-worker@18.1.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@swc/core@1.6.13)(@types/node@20.14.11)(chokidar@3.6.0)(html-webpack-plugin@5.6.0(webpack@5.92.1(@swc/core@1.6.13)))(tailwindcss@3.4.6)(typescript@5.5.3)':
     dependencies:
-      '@angular-builders/common': 2.0.0(@types/node@20.14.11)(typescript@5.5.3)
-      '@angular-devkit/architect': 0.1801.1
-      '@angular-devkit/build-angular': 18.1.1(@angular/compiler-cli@18.1.1)(@angular/service-worker@18.1.1)(@types/node@20.14.11)(typescript@5.5.3)
-      '@angular-devkit/core': 18.1.1
-      '@angular/compiler-cli': 18.1.1(@angular/compiler@18.1.1)(typescript@5.5.3)
+      '@angular-builders/common': 2.0.0(@swc/core@1.6.13)(@types/node@20.14.11)(chokidar@3.6.0)(typescript@5.5.3)
+      '@angular-devkit/architect': 0.1801.1(chokidar@3.6.0)
+      '@angular-devkit/build-angular': 18.1.1(@angular/compiler-cli@18.1.1(@angular/compiler@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(typescript@5.5.3))(@angular/service-worker@18.1.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@swc/core@1.6.13)(@types/node@20.14.11)(chokidar@3.6.0)(html-webpack-plugin@5.6.0(webpack@5.92.1(@swc/core@1.6.13)))(tailwindcss@3.4.6)(typescript@5.5.3)
+      '@angular-devkit/core': 18.1.1(chokidar@3.6.0)
+      '@angular/compiler-cli': 18.1.1(@angular/compiler@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(typescript@5.5.3)
       lodash: 4.17.21
       webpack-merge: 5.10.0
     transitivePeerDependencies:
@@ -16215,22 +16212,21 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@angular-devkit/architect@0.1801.1':
+  '@angular-devkit/architect@0.1801.1(chokidar@3.6.0)':
     dependencies:
-      '@angular-devkit/core': 18.1.1
+      '@angular-devkit/core': 18.1.1(chokidar@3.6.0)
       rxjs: 7.8.1
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@18.1.1(@angular/compiler-cli@18.1.1)(@angular/service-worker@18.1.1)(@types/node@20.14.11)(typescript@5.5.3)':
+  '@angular-devkit/build-angular@18.1.1(@angular/compiler-cli@18.1.1(@angular/compiler@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(typescript@5.5.3))(@angular/service-worker@18.1.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@swc/core@1.6.13)(@types/node@20.14.11)(chokidar@3.6.0)(html-webpack-plugin@5.6.0(webpack@5.92.1(@swc/core@1.6.13)))(tailwindcss@3.4.6)(typescript@5.5.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.1801.1
-      '@angular-devkit/build-webpack': 0.1801.1(webpack-dev-server@5.0.4)(webpack@5.92.1)
-      '@angular-devkit/core': 18.1.1
-      '@angular/build': 18.1.1(@angular/compiler-cli@18.1.1)(@angular/service-worker@18.1.1)(@types/node@20.14.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.2)(typescript@5.5.3)
-      '@angular/compiler-cli': 18.1.1(@angular/compiler@18.1.1)(typescript@5.5.3)
-      '@angular/service-worker': 18.1.1(@angular/common@18.1.1)(@angular/core@18.1.1)
+      '@angular-devkit/architect': 0.1801.1(chokidar@3.6.0)
+      '@angular-devkit/build-webpack': 0.1801.1(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)))(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))
+      '@angular-devkit/core': 18.1.1(chokidar@3.6.0)
+      '@angular/build': 18.1.1(@angular/compiler-cli@18.1.1(@angular/compiler@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(typescript@5.5.3))(@angular/service-worker@18.1.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@types/node@20.14.11)(chokidar@3.6.0)(less@4.2.0)(postcss@8.4.38)(tailwindcss@3.4.6)(terser@5.29.2)(typescript@5.5.3)
+      '@angular/compiler-cli': 18.1.1(@angular/compiler@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(typescript@5.5.3)
       '@babel/core': 7.24.7
       '@babel/generator': 7.24.7
       '@babel/helper-annotate-as-pure': 7.24.7
@@ -16241,15 +16237,15 @@ snapshots:
       '@babel/preset-env': 7.24.7(@babel/core@7.24.7)
       '@babel/runtime': 7.24.7
       '@discoveryjs/json-ext': 0.5.7
-      '@ngtools/webpack': 18.1.1(@angular/compiler-cli@18.1.1)(typescript@5.5.3)(webpack@5.92.1)
-      '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.3.2)
+      '@ngtools/webpack': 18.1.1(@angular/compiler-cli@18.1.1(@angular/compiler@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))
+      '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.3.2(@types/node@20.14.11)(less@4.2.0)(sass@1.77.6)(terser@5.29.2))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.19(postcss@8.4.38)
-      babel-loader: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1)
+      babel-loader: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))
       browserslist: 4.23.2
-      copy-webpack-plugin: 12.0.2(webpack@5.92.1)
+      copy-webpack-plugin: 12.0.2(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))
       critters: 0.0.24
-      css-loader: 7.1.2(webpack@5.92.1)
+      css-loader: 7.1.2(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))
       esbuild-wasm: 0.21.5
       fast-glob: 3.3.2
       http-proxy-middleware: 3.0.0
@@ -16258,11 +16254,11 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.2.0
-      less-loader: 12.2.0(less@4.2.0)(webpack@5.92.1)
-      license-webpack-plugin: 4.0.2(webpack@5.92.1)
+      less-loader: 12.2.0(less@4.2.0)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))
+      license-webpack-plugin: 4.0.2(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))
       loader-utils: 3.3.1
       magic-string: 0.30.10
-      mini-css-extract-plugin: 2.9.0(webpack@5.92.1)
+      mini-css-extract-plugin: 2.9.0(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))
       mrmime: 2.0.0
       open: 10.1.0
       ora: 5.4.1
@@ -16270,13 +16266,13 @@ snapshots:
       picomatch: 4.0.2
       piscina: 4.6.1
       postcss: 8.4.38
-      postcss-loader: 8.1.1(postcss@8.4.38)(typescript@5.5.3)(webpack@5.92.1)
+      postcss-loader: 8.1.1(postcss@8.4.38)(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.1
       sass: 1.77.6
-      sass-loader: 14.2.1(sass@1.77.6)(webpack@5.92.1)
+      sass-loader: 14.2.1(sass@1.77.6)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))
       semver: 7.6.2
-      source-map-loader: 5.0.0(webpack@5.92.1)
+      source-map-loader: 5.0.0(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))
       source-map-support: 0.5.21
       terser: 5.29.2
       tree-kill: 1.2.2
@@ -16285,13 +16281,15 @@ snapshots:
       undici: 6.19.2
       vite: 5.3.2(@types/node@20.14.11)(less@4.2.0)(sass@1.77.6)(terser@5.29.2)
       watchpack: 2.4.1
-      webpack: 5.92.1(esbuild@0.21.5)
-      webpack-dev-middleware: 7.2.1(webpack@5.92.1)
-      webpack-dev-server: 5.0.4(webpack@5.92.1)
+      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)
+      webpack-dev-middleware: 7.2.1(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))
+      webpack-dev-server: 5.0.4(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))
       webpack-merge: 5.10.0
-      webpack-subresource-integrity: 5.1.0(webpack@5.92.1)
+      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.0(webpack@5.92.1(@swc/core@1.6.13)))(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))
     optionalDependencies:
+      '@angular/service-worker': 18.1.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))
       esbuild: 0.21.5
+      tailwindcss: 3.4.6(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -16310,16 +16308,16 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  '@angular-devkit/build-webpack@0.1801.1(webpack-dev-server@5.0.4)(webpack@5.92.1)':
+  '@angular-devkit/build-webpack@0.1801.1(chokidar@3.6.0)(webpack-dev-server@5.0.4(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)))(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))':
     dependencies:
-      '@angular-devkit/architect': 0.1801.1
+      '@angular-devkit/architect': 0.1801.1(chokidar@3.6.0)
       rxjs: 7.8.1
-      webpack: 5.92.1(esbuild@0.21.5)
-      webpack-dev-server: 5.0.4(webpack@5.92.1)
+      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)
+      webpack-dev-server: 5.0.4(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/core@18.1.1':
+  '@angular-devkit/core@18.1.1(chokidar@3.6.0)':
     dependencies:
       ajv: 8.16.0
       ajv-formats: 3.0.1(ajv@8.16.0)
@@ -16327,10 +16325,12 @@ snapshots:
       picomatch: 4.0.2
       rxjs: 7.8.1
       source-map: 0.7.4
+    optionalDependencies:
+      chokidar: 3.6.0
 
-  '@angular-devkit/schematics@18.1.1':
+  '@angular-devkit/schematics@18.1.1(chokidar@3.6.0)':
     dependencies:
-      '@angular-devkit/core': 18.1.1
+      '@angular-devkit/core': 18.1.1(chokidar@3.6.0)
       jsonc-parser: 3.3.1
       magic-string: 0.30.10
       ora: 5.4.1
@@ -16338,30 +16338,28 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular/animations@18.1.1(@angular/core@18.1.1)':
+  '@angular/animations@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))':
     dependencies:
       '@angular/core': 18.1.1(rxjs@7.8.1)(zone.js@0.14.8)
       tslib: 2.6.3
 
-  '@angular/build@18.1.1(@angular/compiler-cli@18.1.1)(@angular/service-worker@18.1.1)(@types/node@20.14.11)(less@4.2.0)(postcss@8.4.38)(terser@5.29.2)(typescript@5.5.3)':
+  '@angular/build@18.1.1(@angular/compiler-cli@18.1.1(@angular/compiler@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(typescript@5.5.3))(@angular/service-worker@18.1.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@types/node@20.14.11)(chokidar@3.6.0)(less@4.2.0)(postcss@8.4.38)(tailwindcss@3.4.6)(terser@5.29.2)(typescript@5.5.3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.1801.1
-      '@angular/compiler-cli': 18.1.1(@angular/compiler@18.1.1)(typescript@5.5.3)
-      '@angular/service-worker': 18.1.1(@angular/common@18.1.1)(@angular/core@18.1.1)
+      '@angular-devkit/architect': 0.1801.1(chokidar@3.6.0)
+      '@angular/compiler-cli': 18.1.1(@angular/compiler@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(typescript@5.5.3)
       '@babel/core': 7.24.7
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-split-export-declaration': 7.24.7
       '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.24.7)
       '@inquirer/confirm': 3.1.11
-      '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.3.2)
+      '@vitejs/plugin-basic-ssl': 1.1.0(vite@5.3.2(@types/node@20.14.11)(less@4.2.0)(sass@1.77.6)(terser@5.29.2))
       ansi-colors: 4.1.3
       browserslist: 4.23.2
       critters: 0.0.24
       esbuild: 0.21.5
       fast-glob: 3.3.2
       https-proxy-agent: 7.0.5
-      less: 4.2.0
       lmdb: 3.0.12
       magic-string: 0.30.10
       mrmime: 2.0.0
@@ -16369,7 +16367,6 @@ snapshots:
       parse5-html-rewriting-stream: 7.0.0
       picomatch: 4.0.2
       piscina: 4.6.1
-      postcss: 8.4.38
       rollup: 4.18.0
       sass: 1.77.6
       semver: 7.6.2
@@ -16377,6 +16374,11 @@ snapshots:
       undici: 6.19.2
       vite: 5.3.2(@types/node@20.14.11)(less@4.2.0)(sass@1.77.6)(terser@5.29.2)
       watchpack: 2.4.1
+    optionalDependencies:
+      '@angular/service-worker': 18.1.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))
+      less: 4.2.0
+      postcss: 8.4.38
+      tailwindcss: 3.4.6(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
     transitivePeerDependencies:
       - '@types/node'
       - chokidar
@@ -16386,14 +16388,14 @@ snapshots:
       - supports-color
       - terser
 
-  '@angular/cli@18.1.1':
+  '@angular/cli@18.1.1(chokidar@3.6.0)':
     dependencies:
-      '@angular-devkit/architect': 0.1801.1
-      '@angular-devkit/core': 18.1.1
-      '@angular-devkit/schematics': 18.1.1
+      '@angular-devkit/architect': 0.1801.1(chokidar@3.6.0)
+      '@angular-devkit/core': 18.1.1(chokidar@3.6.0)
+      '@angular-devkit/schematics': 18.1.1(chokidar@3.6.0)
       '@inquirer/prompts': 5.0.7
       '@listr2/prompt-adapter-inquirer': 2.0.13(@inquirer/prompts@5.0.7)
-      '@schematics/angular': 18.1.1
+      '@schematics/angular': 18.1.1(chokidar@3.6.0)
       '@yarnpkg/lockfile': 1.1.0
       ini: 4.1.3
       jsonc-parser: 3.3.1
@@ -16410,15 +16412,15 @@ snapshots:
       - chokidar
       - supports-color
 
-  '@angular/common@18.1.1(@angular/core@18.1.1)(rxjs@7.8.1)':
+  '@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1)':
     dependencies:
       '@angular/core': 18.1.1(rxjs@7.8.1)(zone.js@0.14.8)
       rxjs: 7.8.1
       tslib: 2.6.3
 
-  '@angular/compiler-cli@18.1.1(@angular/compiler@18.1.1)(typescript@5.5.3)':
+  '@angular/compiler-cli@18.1.1(@angular/compiler@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(typescript@5.5.3)':
     dependencies:
-      '@angular/compiler': 18.1.1(@angular/core@18.1.1)
+      '@angular/compiler': 18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))
       '@babel/core': 7.24.7
       '@jridgewell/sourcemap-codec': 1.5.0
       chokidar: 3.6.0
@@ -16431,10 +16433,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@angular/compiler@18.1.1(@angular/core@18.1.1)':
+  '@angular/compiler@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))':
     dependencies:
-      '@angular/core': 18.1.1(rxjs@7.8.1)(zone.js@0.14.8)
       tslib: 2.6.3
+    optionalDependencies:
+      '@angular/core': 18.1.1(rxjs@7.8.1)(zone.js@0.14.8)
 
   '@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)':
     dependencies:
@@ -16442,40 +16445,41 @@ snapshots:
       tslib: 2.6.3
       zone.js: 0.14.8
 
-  '@angular/forms@18.1.1(@angular/common@18.1.1)(@angular/core@18.1.1)(@angular/platform-browser@18.1.1)(rxjs@7.8.1)':
+  '@angular/forms@18.1.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(@angular/platform-browser@18.1.1(@angular/animations@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(rxjs@7.8.1)':
     dependencies:
-      '@angular/common': 18.1.1(@angular/core@18.1.1)(rxjs@7.8.1)
+      '@angular/common': 18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1)
       '@angular/core': 18.1.1(rxjs@7.8.1)(zone.js@0.14.8)
-      '@angular/platform-browser': 18.1.1(@angular/animations@18.1.1)(@angular/common@18.1.1)(@angular/core@18.1.1)
+      '@angular/platform-browser': 18.1.1(@angular/animations@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))
       rxjs: 7.8.1
       tslib: 2.6.3
 
-  '@angular/platform-browser-dynamic@18.1.1(@angular/common@18.1.1)(@angular/compiler@18.1.1)(@angular/core@18.1.1)(@angular/platform-browser@18.1.1)':
+  '@angular/platform-browser-dynamic@18.1.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/compiler@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(@angular/platform-browser@18.1.1(@angular/animations@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))':
     dependencies:
-      '@angular/common': 18.1.1(@angular/core@18.1.1)(rxjs@7.8.1)
-      '@angular/compiler': 18.1.1(@angular/core@18.1.1)
+      '@angular/common': 18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1)
+      '@angular/compiler': 18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))
       '@angular/core': 18.1.1(rxjs@7.8.1)(zone.js@0.14.8)
-      '@angular/platform-browser': 18.1.1(@angular/animations@18.1.1)(@angular/common@18.1.1)(@angular/core@18.1.1)
+      '@angular/platform-browser': 18.1.1(@angular/animations@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))
       tslib: 2.6.3
 
-  '@angular/platform-browser@18.1.1(@angular/animations@18.1.1)(@angular/common@18.1.1)(@angular/core@18.1.1)':
+  '@angular/platform-browser@18.1.1(@angular/animations@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))':
     dependencies:
-      '@angular/animations': 18.1.1(@angular/core@18.1.1)
-      '@angular/common': 18.1.1(@angular/core@18.1.1)(rxjs@7.8.1)
+      '@angular/common': 18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1)
       '@angular/core': 18.1.1(rxjs@7.8.1)(zone.js@0.14.8)
       tslib: 2.6.3
+    optionalDependencies:
+      '@angular/animations': 18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))
 
-  '@angular/router@18.1.1(@angular/common@18.1.1)(@angular/core@18.1.1)(@angular/platform-browser@18.1.1)(rxjs@7.8.1)':
+  '@angular/router@18.1.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(@angular/platform-browser@18.1.1(@angular/animations@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(rxjs@7.8.1)':
     dependencies:
-      '@angular/common': 18.1.1(@angular/core@18.1.1)(rxjs@7.8.1)
+      '@angular/common': 18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1)
       '@angular/core': 18.1.1(rxjs@7.8.1)(zone.js@0.14.8)
-      '@angular/platform-browser': 18.1.1(@angular/animations@18.1.1)(@angular/common@18.1.1)(@angular/core@18.1.1)
+      '@angular/platform-browser': 18.1.1(@angular/animations@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))
       rxjs: 7.8.1
       tslib: 2.6.3
 
-  '@angular/service-worker@18.1.1(@angular/common@18.1.1)(@angular/core@18.1.1)':
+  '@angular/service-worker@18.1.1(@angular/common@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1))(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))':
     dependencies:
-      '@angular/common': 18.1.1(@angular/core@18.1.1)(rxjs@7.8.1)
+      '@angular/common': 18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8))(rxjs@7.8.1)
       '@angular/core': 18.1.1(rxjs@7.8.1)(zone.js@0.14.8)
       tslib: 2.6.3
 
@@ -16855,10 +16859,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-remap-async-to-generator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-create-class-features-plugin': 7.24.8(@babel/core@7.24.5)
+      '@babel/helper-plugin-utils': 7.24.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.24.8(@babel/core@7.24.7)
       '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
       - supports-color
@@ -16872,11 +16894,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-proposal-decorators@7.24.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.24.8(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-decorators': 7.24.7(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-proposal-export-default-from@7.24.7(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-export-default-from': 7.24.7(@babel/core@7.24.5)
+
+  '@babel/plugin-proposal-export-default-from@7.24.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-export-default-from': 7.24.7(@babel/core@7.24.7)
 
   '@babel/plugin-proposal-logical-assignment-operators@7.20.7(@babel/core@7.24.5)':
     dependencies:
@@ -16884,17 +16921,35 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.5)
 
+  '@babel/plugin-proposal-logical-assignment-operators@7.20.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.7)
+
   '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.5)
 
+  '@babel/plugin-proposal-nullish-coalescing-operator@7.18.6(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.7)
+
   '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.5)
+
+  '@babel/plugin-proposal-numeric-separator@7.18.6(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.7)
 
   '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.24.5)':
     dependencies:
@@ -16905,11 +16960,26 @@ snapshots:
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.5)
       '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.5)
 
+  '@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/compat-data': 7.24.9
+      '@babel/core': 7.24.7
+      '@babel/helper-compilation-targets': 7.24.8
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.7)
+
   '@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.5)
+
+  '@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.7)
 
   '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.24.5)':
     dependencies:
@@ -16917,6 +16987,15 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.5)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -16963,6 +17042,11 @@ snapshots:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-syntax-decorators@7.24.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
@@ -16978,6 +17062,11 @@ snapshots:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-syntax-export-default-from@7.24.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
@@ -16991,6 +17080,11 @@ snapshots:
   '@babel/plugin-syntax-flow@7.24.7(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-syntax-flow@7.24.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-import-assertions@7.24.7(@babel/core@7.24.5)':
@@ -17036,6 +17130,11 @@ snapshots:
   '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.5)':
@@ -17121,6 +17220,11 @@ snapshots:
   '@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.24.5)':
@@ -17354,6 +17458,12 @@ snapshots:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-flow': 7.24.7(@babel/core@7.24.5)
+
+  '@babel/plugin-transform-flow-strip-types@7.24.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-flow': 7.24.7(@babel/core@7.24.7)
 
   '@babel/plugin-transform-for-of@7.24.7(@babel/core@7.24.5)':
     dependencies:
@@ -17673,10 +17783,22 @@ snapshots:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-react-display-name@7.24.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-react-jsx-development@7.24.7(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
       '@babel/plugin-transform-react-jsx': 7.24.7(@babel/core@7.24.5)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-react-jsx-development@7.24.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/plugin-transform-react-jsx': 7.24.7(@babel/core@7.24.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -17685,9 +17807,19 @@ snapshots:
       '@babel/core': 7.24.5
       '@babel/helper-plugin-utils': 7.24.8
 
+  '@babel/plugin-transform-react-jsx-self@7.24.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-transform-react-jsx-source@7.24.7(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-react-jsx-source@7.24.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.24.5)':
@@ -17701,9 +17833,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-react-jsx@7.24.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.24.7)
+      '@babel/types': 7.24.9
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-react-pure-annotations@7.24.7(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+
+  '@babel/plugin-transform-react-pure-annotations@7.24.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
       '@babel/helper-annotate-as-pure': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
 
@@ -17816,6 +17965,16 @@ snapshots:
       '@babel/helper-create-class-features-plugin': 7.24.8(@babel/core@7.24.5)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.24.5)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-typescript@7.24.8(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-annotate-as-pure': 7.24.7
+      '@babel/helper-create-class-features-plugin': 7.24.8(@babel/core@7.24.7)
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.24.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -18039,6 +18198,93 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/preset-env@7.24.8(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/compat-data': 7.24.9
+      '@babel/core': 7.24.7
+      '@babel/helper-compilation-targets': 7.24.8
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-validator-option': 7.24.8
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.7)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.7)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.7)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-import-assertions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.7)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.7)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.7)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.24.7)
+      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-async-generator-functions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-block-scoped-functions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-block-scoping': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-class-properties': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-class-static-block': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-classes': 7.24.8(@babel/core@7.24.7)
+      '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-destructuring': 7.24.8(@babel/core@7.24.7)
+      '@babel/plugin-transform-dotall-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-duplicate-keys': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-dynamic-import': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-exponentiation-operator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-export-namespace-from': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-for-of': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-function-name': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-json-strings': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-literals': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-logical-assignment-operators': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-member-expression-literals': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-modules-amd': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.24.7)
+      '@babel/plugin-transform-modules-systemjs': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-modules-umd': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-new-target': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-numeric-separator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-object-rest-spread': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-object-super': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-optional-catch-binding': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-optional-chaining': 7.24.8(@babel/core@7.24.7)
+      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-private-methods': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-private-property-in-object': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-property-literals': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-regenerator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-reserved-words': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-sticky-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-template-literals': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-typeof-symbol': 7.24.8(@babel/core@7.24.7)
+      '@babel/plugin-transform-unicode-escapes': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-unicode-property-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-unicode-sets-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.24.7)
+      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.24.7)
+      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.7)
+      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.24.7)
+      core-js-compat: 3.37.1
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/preset-flow@7.24.7(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
@@ -18072,6 +18318,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/preset-react@7.24.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-validator-option': 7.24.8
+      '@babel/plugin-transform-react-display-name': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-react-jsx': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-react-jsx-development': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-react-pure-annotations': 7.24.7(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/preset-typescript@7.24.7(@babel/core@7.24.5)':
     dependencies:
       '@babel/core': 7.24.5
@@ -18080,6 +18338,17 @@ snapshots:
       '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.24.5)
       '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.24.5)
       '@babel/plugin-transform-typescript': 7.24.8(@babel/core@7.24.5)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-typescript@7.24.7(@babel/core@7.24.7)':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-plugin-utils': 7.24.8
+      '@babel/helper-validator-option': 7.24.8
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.24.7)
+      '@babel/plugin-transform-typescript': 7.24.8(@babel/core@7.24.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -18332,10 +18601,18 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@craftzdog/react-native-buffer@6.0.5(react-native@0.74.1)(react@18.2.0)':
+  '@craftzdog/react-native-buffer@6.0.5(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       ieee754: 1.2.1
-      react-native-quick-base64: 2.1.2(react-native@0.74.1)(react@18.2.0)
+      react-native-quick-base64: 2.1.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+    transitivePeerDependencies:
+      - react
+      - react-native
+
+  '@craftzdog/react-native-buffer@6.0.5(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      ieee754: 1.2.1
+      react-native-quick-base64: 2.1.2(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - react
       - react-native
@@ -18348,20 +18625,21 @@ snapshots:
 
   '@docsearch/css@3.6.1': {}
 
-  '@docsearch/react@3.6.1(@algolia/client-search@4.24.0)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.15.0)':
+  '@docsearch/react@3.6.1(@algolia/client-search@4.24.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.15.0)':
     dependencies:
       '@algolia/autocomplete-core': 1.9.3(@algolia/client-search@4.24.0)(algoliasearch@4.24.0)(search-insights@2.15.0)
       '@algolia/autocomplete-preset-algolia': 1.9.3(@algolia/client-search@4.24.0)(algoliasearch@4.24.0)
       '@docsearch/css': 3.6.1
-      '@types/react': 18.3.3
       algoliasearch: 4.24.0
+    optionalDependencies:
+      '@types/react': 18.3.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       search-insights: 2.15.0
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/core@3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)':
+  '@docusaurus/core@3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)':
     dependencies:
       '@babel/core': 7.24.5
       '@babel/generator': 7.24.10
@@ -18375,10 +18653,10 @@ snapshots:
       '@babel/traverse': 7.24.8
       '@docusaurus/cssnano-preset': 3.4.0
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
       autoprefixer: 10.4.19(postcss@8.4.39)
       babel-loader: 9.1.3(@babel/core@7.24.5)(webpack@5.93.0)
       babel-plugin-dynamic-import-node: 2.3.3
@@ -18412,13 +18690,13 @@ snapshots:
       postcss-loader: 7.3.4(postcss@8.4.39)(typescript@5.4.5)(webpack@5.93.0)
       prompts: 2.4.2
       react: 18.2.0
-      react-dev-utils: 12.0.1(typescript@5.4.5)(webpack@5.93.0)
+      react-dev-utils: 12.0.1(eslint@8.57.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)(webpack@5.93.0)
       react-dom: 18.2.0(react@18.2.0)
-      react-helmet-async: 1.3.0(react-dom@18.2.0)(react@18.2.0)
+      react-helmet-async: 1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.2.0)'
-      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0)(webpack@5.93.0)
+      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0(react@18.2.0))(webpack@5.93.0)
       react-router: 5.3.4(react@18.2.0)
-      react-router-config: 5.1.1(react-router@5.3.4)(react@18.2.0)
+      react-router-config: 5.1.1(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       react-router-dom: 5.3.4(react@18.2.0)
       rtl-detect: 1.1.2
       semver: 7.6.3
@@ -18427,8 +18705,8 @@ snapshots:
       terser-webpack-plugin: 5.3.10(webpack@5.93.0)
       tslib: 2.6.3
       update-notifier: 6.0.2
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.93.0)
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.93.0))(webpack@5.93.0)
+      webpack: 5.93.0
       webpack-bundle-analyzer: 4.10.2
       webpack-dev-server: 4.15.2(webpack@5.93.0)
       webpack-merge: 5.10.0
@@ -18464,11 +18742,11 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.6.3
 
-  '@docusaurus/mdx-loader@3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)':
+  '@docusaurus/mdx-loader@3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)':
     dependencies:
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
       '@mdx-js/mdx': 3.0.1
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
@@ -18489,9 +18767,9 @@ snapshots:
       tslib: 2.6.3
       unified: 11.0.5
       unist-util-visit: 5.0.0
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.93.0)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.93.0))(webpack@5.93.0)
       vfile: 6.0.2
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0
     transitivePeerDependencies:
       - '@docusaurus/types'
       - '@swc/core'
@@ -18501,9 +18779,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.4.0(react-dom@18.2.0)(react@18.2.0)':
+  '@docusaurus/module-type-aliases@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@docusaurus/types': 3.4.0(react-dom@18.2.0)(react@18.2.0)
+      '@docusaurus/types': 3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/history': 4.7.11
       '@types/react': 18.3.3
       '@types/react-router-config': 5.0.11
@@ -18519,15 +18797,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)':
+  '@docusaurus/plugin-content-blog@3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/types': 3.4.0(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
+      '@docusaurus/types': 3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.2.0
@@ -18539,7 +18817,7 @@ snapshots:
       tslib: 2.6.3
       unist-util-visit: 5.0.0
       utility-types: 3.11.0
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -18558,16 +18836,16 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)':
+  '@docusaurus/plugin-content-docs@3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/module-type-aliases': 3.4.0(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/types': 3.4.0(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
+      '@docusaurus/module-type-aliases': 3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/types': 3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.2.0
@@ -18577,7 +18855,7 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.6.3
       utility-types: 3.11.0
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -18596,18 +18874,18 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)':
+  '@docusaurus/plugin-content-pages@3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/types': 3.4.0(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
+      '@docusaurus/types': 3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
       fs-extra: 11.2.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.6.3
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0
     transitivePeerDependencies:
       - '@parcel/css'
       - '@rspack/core'
@@ -18626,11 +18904,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)':
+  '@docusaurus/plugin-debug@3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/types': 3.4.0(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/types': 3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
       fs-extra: 11.2.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -18654,11 +18932,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)':
+  '@docusaurus/plugin-google-analytics@3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/types': 3.4.0(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/types': 3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.6.3
@@ -18680,11 +18958,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)':
+  '@docusaurus/plugin-google-gtag@3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/types': 3.4.0(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/types': 3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
       '@types/gtag.js': 0.0.12
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -18707,11 +18985,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)':
+  '@docusaurus/plugin-google-tag-manager@3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/types': 3.4.0(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/types': 3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.6.3
@@ -18733,14 +19011,14 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)':
+  '@docusaurus/plugin-sitemap@3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/types': 3.4.0(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
+      '@docusaurus/types': 3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
       fs-extra: 11.2.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -18764,21 +19042,21 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.4.0(@algolia/client-search@4.24.0)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.15.0)(typescript@5.4.5)':
+  '@docusaurus/preset-classic@3.4.0(@algolia/client-search@4.24.0)(@types/react@18.3.3)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.15.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/plugin-content-blog': 3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/plugin-content-docs': 3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/plugin-content-pages': 3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/plugin-debug': 3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/plugin-google-analytics': 3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/plugin-google-gtag': 3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/plugin-google-tag-manager': 3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/plugin-sitemap': 3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/theme-classic': 3.4.0(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/theme-search-algolia': 3.4.0(@algolia/client-search@4.24.0)(@docusaurus/types@3.4.0)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.15.0)(typescript@5.4.5)
-      '@docusaurus/types': 3.4.0(react-dom@18.2.0)(react@18.2.0)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-blog': 3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-docs': 3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-pages': 3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-debug': 3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-google-analytics': 3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-google-gtag': 3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-google-tag-manager': 3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-sitemap': 3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/theme-classic': 3.4.0(@types/react@18.3.3)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/theme-search-algolia': 3.4.0(@algolia/client-search@4.24.0)(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.3.3)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.15.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/types': 3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -18807,20 +19085,20 @@ snapshots:
       '@types/react': 18.3.3
       react: 18.2.0
 
-  '@docusaurus/theme-classic@3.4.0(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)':
+  '@docusaurus/theme-classic@3.4.0(@types/react@18.3.3)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/module-type-aliases': 3.4.0(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/plugin-content-blog': 3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/plugin-content-docs': 3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/plugin-content-pages': 3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
+      '@docusaurus/module-type-aliases': 3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/plugin-content-blog': 3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-docs': 3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-pages': 3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
       '@docusaurus/theme-translations': 3.4.0
-      '@docusaurus/types': 3.4.0(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
+      '@docusaurus/types': 3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
       '@mdx-js/react': 3.0.1(@types/react@18.3.3)(react@18.2.0)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.0
@@ -18855,15 +19133,15 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)':
+  '@docusaurus/theme-common@3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/module-type-aliases': 3.4.0(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/plugin-content-blog': 3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/plugin-content-docs': 3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/plugin-content-pages': 3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)
+      '@docusaurus/module-type-aliases': 3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@docusaurus/plugin-content-blog': 3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-docs': 3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/plugin-content-pages': 3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@types/history': 4.7.11
       '@types/react': 18.3.3
       '@types/react-router-config': 5.0.11
@@ -18893,16 +19171,16 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.4.0(@algolia/client-search@4.24.0)(@docusaurus/types@3.4.0)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.15.0)(typescript@5.4.5)':
+  '@docusaurus/theme-search-algolia@3.4.0(@algolia/client-search@4.24.0)(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.3.3)(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.15.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)':
     dependencies:
-      '@docsearch/react': 3.6.1(@algolia/client-search@4.24.0)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)(search-insights@2.15.0)
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
+      '@docsearch/react': 3.6.1(@algolia/client-search@4.24.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(search-insights@2.15.0)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/plugin-content-docs': 3.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)
+      '@docusaurus/plugin-content-docs': 3.4.0(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
+      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(eslint@8.57.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)
       '@docusaurus/theme-translations': 3.4.0
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
       algoliasearch: 4.24.0
       algoliasearch-helper: 3.22.3(algoliasearch@4.24.0)
       clsx: 2.1.1
@@ -18942,7 +19220,7 @@ snapshots:
 
   '@docusaurus/tsconfig@3.4.0': {}
 
-  '@docusaurus/types@3.4.0(react-dom@18.2.0)(react@18.2.0)':
+  '@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@mdx-js/mdx': 3.0.1
       '@types/history': 4.7.11
@@ -18951,9 +19229,9 @@ snapshots:
       joi: 17.13.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-helmet-async: 1.3.0(react-dom@18.2.0)(react@18.2.0)
+      react-helmet-async: 1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       utility-types: 3.11.0
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -18962,16 +19240,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.4.0(@docusaurus/types@3.4.0)':
+  '@docusaurus/utils-common@3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
-      '@docusaurus/types': 3.4.0(react-dom@18.2.0)(react@18.2.0)
       tslib: 2.6.3
+    optionalDependencies:
+      '@docusaurus/types': 3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  '@docusaurus/utils-validation@3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)':
+  '@docusaurus/utils-validation@3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)':
     dependencies:
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       fs-extra: 11.2.0
       joi: 17.13.3
       js-yaml: 4.1.0
@@ -18986,11 +19265,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.4.0(@docusaurus/types@3.4.0)(typescript@5.4.5)':
+  '@docusaurus/utils@3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.4.5)':
     dependencies:
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/types': 3.4.0(react-dom@18.2.0)(react@18.2.0)
-      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0)
+      '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@svgr/webpack': 8.1.0(typescript@5.4.5)
       escape-string-regexp: 4.0.0
       file-loader: 6.2.0(webpack@5.93.0)
@@ -19006,9 +19284,11 @@ snapshots:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.6.3
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.93.0)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.93.0))(webpack@5.93.0)
       utility-types: 3.11.0
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0
+    optionalDependencies:
+      '@docusaurus/types': 3.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -19021,9 +19301,9 @@ snapshots:
     dependencies:
       '@types/hammerjs': 2.0.45
 
-  '@electron-forge/cli@7.4.0':
+  '@electron-forge/cli@7.4.0(encoding@0.1.13)':
     dependencies:
-      '@electron-forge/core': 7.4.0
+      '@electron-forge/core': 7.4.0(encoding@0.1.13)
       '@electron-forge/shared-types': 7.4.0
       '@electron/get': 3.1.0
       chalk: 4.1.2
@@ -19053,7 +19333,7 @@ snapshots:
       - bluebird
       - supports-color
 
-  '@electron-forge/core@7.4.0':
+  '@electron-forge/core@7.4.0(encoding@0.1.13)':
     dependencies:
       '@electron-forge/core-utils': 7.4.0
       '@electron-forge/maker-base': 7.4.0
@@ -19081,7 +19361,7 @@ snapshots:
       listr2: 7.0.2
       lodash: 4.17.21
       log-symbols: 4.1.0
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
       progress: 2.0.3
       rechoir: 0.8.0
       resolve-package: 1.0.1
@@ -19440,9 +19720,10 @@ snapshots:
       '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
       '@emotion/utils': 1.2.1
       '@emotion/weak-memoize': 0.3.1
-      '@types/react': 18.3.3
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.3.3
     transitivePeerDependencies:
       - supports-color
 
@@ -19456,7 +19737,7 @@ snapshots:
 
   '@emotion/sheet@1.2.2': {}
 
-  '@emotion/styled@11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.2.0)':
+  '@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@emotion/babel-plugin': 11.11.0
@@ -19465,8 +19746,9 @@ snapshots:
       '@emotion/serialize': 1.1.4
       '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
       '@emotion/utils': 1.2.1
-      '@types/react': 18.3.3
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.3.3
     transitivePeerDependencies:
       - supports-color
 
@@ -19657,7 +19939,7 @@ snapshots:
       mv: 2.1.1
       safe-json-stringify: 1.2.0
 
-  '@expo/cli@0.18.25(expo-modules-autolinking@1.11.1)':
+  '@expo/cli@0.18.25(encoding@0.1.13)(expo-modules-autolinking@1.11.1)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@expo/code-signing-certificates': 0.0.5
@@ -19665,17 +19947,17 @@ snapshots:
       '@expo/config-plugins': 8.0.8
       '@expo/devcert': 1.1.2
       '@expo/env': 0.3.0
-      '@expo/image-utils': 0.5.1
+      '@expo/image-utils': 0.5.1(encoding@0.1.13)
       '@expo/json-file': 8.3.3
       '@expo/metro-config': 0.18.8
       '@expo/osascript': 2.1.3
       '@expo/package-manager': 1.5.2
       '@expo/plist': 0.1.3
-      '@expo/prebuild-config': 7.0.8(expo-modules-autolinking@1.11.1)
-      '@expo/rudder-sdk-node': 1.1.1
+      '@expo/prebuild-config': 7.0.8(encoding@0.1.13)(expo-modules-autolinking@1.11.1)
+      '@expo/rudder-sdk-node': 1.1.1(encoding@0.1.13)
       '@expo/spawn-async': 1.7.2
       '@expo/xcpretty': 4.3.1
-      '@react-native/dev-middleware': 0.74.85
+      '@react-native/dev-middleware': 0.74.85(encoding@0.1.13)
       '@urql/core': 2.3.6(graphql@15.8.0)
       '@urql/exchange-retry': 0.3.0(graphql@15.8.0)
       accepts: 1.3.8
@@ -19707,7 +19989,7 @@ snapshots:
       lodash.debounce: 4.0.8
       md5hex: 1.0.0
       minimatch: 3.1.2
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
       node-forge: 1.3.1
       npm-package-arg: 7.0.0
       open: 8.4.2
@@ -19887,14 +20169,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/image-utils@0.4.2':
+  '@expo/image-utils@0.4.2(encoding@0.1.13)':
     dependencies:
       '@expo/spawn-async': 1.5.0
       chalk: 4.1.2
       fs-extra: 9.0.0
       getenv: 1.0.0
       jimp-compact: 0.16.1
-      node-fetch: 2.6.7
+      node-fetch: 2.6.7(encoding@0.1.13)
       parse-png: 2.1.0
       resolve-from: 5.0.0
       semver: 7.3.2
@@ -19902,14 +20184,14 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@expo/image-utils@0.5.1':
+  '@expo/image-utils@0.5.1(encoding@0.1.13)':
     dependencies:
       '@expo/spawn-async': 1.7.2
       chalk: 4.1.2
       fs-extra: 9.0.0
       getenv: 1.0.0
       jimp-compact: 0.16.1
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
       parse-png: 2.1.0
       resolve-from: 5.0.0
       semver: 7.6.3
@@ -19957,9 +20239,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/metro-runtime@3.2.1(react-native@0.74.1)':
+  '@expo/metro-runtime@3.2.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))':
     dependencies:
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+
+  '@expo/metro-runtime@3.2.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))':
+    dependencies:
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
+
+  '@expo/metro-runtime@3.2.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))':
+    dependencies:
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
 
   '@expo/multipart-body-parser@1.1.0':
     dependencies:
@@ -20022,18 +20312,18 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 14.0.0
 
-  '@expo/plugin-help@5.1.23(@types/node@20.14.11)(typescript@5.3.3)':
+  '@expo/plugin-help@5.1.23(@swc/core@1.6.13)(@types/node@20.14.11)(typescript@5.3.3)':
     dependencies:
-      '@oclif/core': 2.16.0(@types/node@20.14.11)(typescript@5.3.3)
+      '@oclif/core': 2.16.0(@swc/core@1.6.13)(@types/node@20.14.11)(typescript@5.3.3)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
       - typescript
 
-  '@expo/plugin-warn-if-update-available@2.5.1(@types/node@20.14.11)(typescript@5.3.3)':
+  '@expo/plugin-warn-if-update-available@2.5.1(@swc/core@1.6.13)(@types/node@20.14.11)(typescript@5.3.3)':
     dependencies:
-      '@oclif/core': 2.16.0(@types/node@20.14.11)(typescript@5.3.3)
+      '@oclif/core': 2.16.0(@swc/core@1.6.13)(@types/node@20.14.11)(typescript@5.3.3)
       chalk: 4.1.2
       debug: 4.3.5(supports-color@8.1.1)
       ejs: 3.1.10
@@ -20048,12 +20338,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@expo/prebuild-config@6.7.3(expo-modules-autolinking@1.11.1)':
+  '@expo/prebuild-config@6.7.3(encoding@0.1.13)(expo-modules-autolinking@1.11.1)':
     dependencies:
       '@expo/config': 8.5.4
       '@expo/config-plugins': 7.8.4
       '@expo/config-types': 50.0.0
-      '@expo/image-utils': 0.4.2
+      '@expo/image-utils': 0.4.2(encoding@0.1.13)
       '@expo/json-file': 8.2.37
       debug: 4.3.5(supports-color@8.1.1)
       expo-modules-autolinking: 1.11.1
@@ -20065,12 +20355,12 @@ snapshots:
       - encoding
       - supports-color
 
-  '@expo/prebuild-config@7.0.3(expo-modules-autolinking@1.11.1)':
+  '@expo/prebuild-config@7.0.3(encoding@0.1.13)(expo-modules-autolinking@1.11.1)':
     dependencies:
       '@expo/config': 9.0.3
       '@expo/config-plugins': 8.0.8
       '@expo/config-types': 51.0.2
-      '@expo/image-utils': 0.5.1
+      '@expo/image-utils': 0.5.1(encoding@0.1.13)
       '@expo/json-file': 8.3.3
       '@react-native/normalize-colors': 0.74.85
       debug: 4.3.5(supports-color@8.1.1)
@@ -20083,12 +20373,12 @@ snapshots:
       - encoding
       - supports-color
 
-  '@expo/prebuild-config@7.0.6(expo-modules-autolinking@1.11.1)':
+  '@expo/prebuild-config@7.0.6(encoding@0.1.13)(expo-modules-autolinking@1.11.1)':
     dependencies:
       '@expo/config': 9.0.3
       '@expo/config-plugins': 8.0.8
       '@expo/config-types': 51.0.2
-      '@expo/image-utils': 0.5.1
+      '@expo/image-utils': 0.5.1(encoding@0.1.13)
       '@expo/json-file': 8.3.3
       '@react-native/normalize-colors': 0.74.84
       debug: 4.3.5(supports-color@8.1.1)
@@ -20101,12 +20391,12 @@ snapshots:
       - encoding
       - supports-color
 
-  '@expo/prebuild-config@7.0.8(expo-modules-autolinking@1.11.1)':
+  '@expo/prebuild-config@7.0.8(encoding@0.1.13)(expo-modules-autolinking@1.11.1)':
     dependencies:
       '@expo/config': 9.0.3
       '@expo/config-plugins': 8.0.8
       '@expo/config-types': 51.0.2
-      '@expo/image-utils': 0.5.1
+      '@expo/image-utils': 0.5.1(encoding@0.1.13)
       '@expo/json-file': 8.3.3
       '@react-native/normalize-colors': 0.74.85
       debug: 4.3.5(supports-color@8.1.1)
@@ -20121,13 +20411,13 @@ snapshots:
 
   '@expo/results@1.0.0': {}
 
-  '@expo/rudder-sdk-node@1.1.1':
+  '@expo/rudder-sdk-node@1.1.1(encoding@0.1.13)':
     dependencies:
       '@expo/bunyan': 4.0.0
       '@segment/loosely-validate-event': 2.0.0
       fetch-retry: 4.1.1
       md5: 2.3.0
-      node-fetch: 2.6.7
+      node-fetch: 2.6.7(encoding@0.1.13)
       remove-trailing-slash: 0.1.1
       uuid: 8.3.2
     transitivePeerDependencies:
@@ -20206,21 +20496,21 @@ snapshots:
       '@floating-ui/core': 1.6.4
       '@floating-ui/utils': 0.2.4
 
-  '@floating-ui/react-dom@2.1.1(react-dom@18.2.0)(react@18.2.0)':
+  '@floating-ui/react-dom@2.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@floating-ui/dom': 1.6.7
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@floating-ui/react-native@0.10.6(react-native@0.74.1)(react@18.2.0)':
+  '@floating-ui/react-native@0.10.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@floating-ui/core': 1.6.4
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
 
-  '@floating-ui/react@0.24.8(react-dom@18.2.0)(react@18.2.0)':
+  '@floating-ui/react@0.24.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.1(react-dom@18.2.0)(react@18.2.0)
+      '@floating-ui/react-dom': 2.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       aria-hidden: 1.2.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -20547,15 +20837,25 @@ snapshots:
       '@types/yargs': 17.0.32
       chalk: 4.1.2
 
-  '@journeyapps/react-native-quick-sqlite@1.1.8(react-native@0.72.4)(react@18.2.0)':
+  '@journeyapps/react-native-quick-sqlite@1.1.8(react-native@0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       react: 18.2.0
-      react-native: 0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(react@18.2.0)
+      react-native: 0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)(react@18.2.0)
 
-  '@journeyapps/react-native-quick-sqlite@1.1.8(react-native@0.74.1)(react@18.2.0)':
+  '@journeyapps/react-native-quick-sqlite@1.1.8(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+
+  '@journeyapps/react-native-quick-sqlite@1.1.8(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
+
+  '@journeyapps/react-native-quick-sqlite@1.1.8(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
 
   '@journeyapps/wa-sqlite@0.1.1': {}
 
@@ -20634,7 +20934,7 @@ snapshots:
       lexical: 0.15.0
       prismjs: 1.29.0
 
-  '@lexical/devtools-core@0.15.0(react-dom@18.2.0)(react@18.2.0)':
+  '@lexical/devtools-core@0.15.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@lexical/html': 0.15.0
       '@lexical/link': 0.15.0
@@ -20714,12 +21014,12 @@ snapshots:
       '@lexical/utils': 0.15.0
       lexical: 0.15.0
 
-  '@lexical/markdown@0.11.3(@lexical/clipboard@0.11.3)(@lexical/selection@0.11.3)(lexical@0.11.3)':
+  '@lexical/markdown@0.11.3(@lexical/clipboard@0.11.3(lexical@0.11.3))(@lexical/selection@0.11.3(lexical@0.11.3))(lexical@0.11.3)':
     dependencies:
       '@lexical/code': 0.11.3(lexical@0.11.3)
       '@lexical/link': 0.11.3(lexical@0.11.3)
       '@lexical/list': 0.11.3(lexical@0.11.3)
-      '@lexical/rich-text': 0.11.3(@lexical/clipboard@0.11.3)(@lexical/selection@0.11.3)(@lexical/utils@0.11.3)(lexical@0.11.3)
+      '@lexical/rich-text': 0.11.3(@lexical/clipboard@0.11.3(lexical@0.11.3))(@lexical/selection@0.11.3(lexical@0.11.3))(@lexical/utils@0.11.3(lexical@0.11.3))(lexical@0.11.3)
       '@lexical/text': 0.11.3(lexical@0.11.3)
       '@lexical/utils': 0.11.3(lexical@0.11.3)
       lexical: 0.11.3
@@ -20753,7 +21053,7 @@ snapshots:
     dependencies:
       lexical: 0.15.0
 
-  '@lexical/plain-text@0.11.3(@lexical/clipboard@0.11.3)(@lexical/selection@0.11.3)(@lexical/utils@0.11.3)(lexical@0.11.3)':
+  '@lexical/plain-text@0.11.3(@lexical/clipboard@0.11.3(lexical@0.11.3))(@lexical/selection@0.11.3(lexical@0.11.3))(@lexical/utils@0.11.3(lexical@0.11.3))(lexical@0.11.3)':
     dependencies:
       '@lexical/clipboard': 0.11.3(lexical@0.11.3)
       '@lexical/selection': 0.11.3(lexical@0.11.3)
@@ -20767,7 +21067,7 @@ snapshots:
       '@lexical/utils': 0.15.0
       lexical: 0.15.0
 
-  '@lexical/react@0.11.3(lexical@0.11.3)(react-dom@18.2.0)(react@18.2.0)(yjs@13.6.18)':
+  '@lexical/react@0.11.3(lexical@0.11.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(yjs@13.6.18)':
     dependencies:
       '@lexical/clipboard': 0.11.3(lexical@0.11.3)
       '@lexical/code': 0.11.3(lexical@0.11.3)
@@ -20777,10 +21077,10 @@ snapshots:
       '@lexical/link': 0.11.3(lexical@0.11.3)
       '@lexical/list': 0.11.3(lexical@0.11.3)
       '@lexical/mark': 0.11.3(lexical@0.11.3)
-      '@lexical/markdown': 0.11.3(@lexical/clipboard@0.11.3)(@lexical/selection@0.11.3)(lexical@0.11.3)
+      '@lexical/markdown': 0.11.3(@lexical/clipboard@0.11.3(lexical@0.11.3))(@lexical/selection@0.11.3(lexical@0.11.3))(lexical@0.11.3)
       '@lexical/overflow': 0.11.3(lexical@0.11.3)
-      '@lexical/plain-text': 0.11.3(@lexical/clipboard@0.11.3)(@lexical/selection@0.11.3)(@lexical/utils@0.11.3)(lexical@0.11.3)
-      '@lexical/rich-text': 0.11.3(@lexical/clipboard@0.11.3)(@lexical/selection@0.11.3)(@lexical/utils@0.11.3)(lexical@0.11.3)
+      '@lexical/plain-text': 0.11.3(@lexical/clipboard@0.11.3(lexical@0.11.3))(@lexical/selection@0.11.3(lexical@0.11.3))(@lexical/utils@0.11.3(lexical@0.11.3))(lexical@0.11.3)
+      '@lexical/rich-text': 0.11.3(@lexical/clipboard@0.11.3(lexical@0.11.3))(@lexical/selection@0.11.3(lexical@0.11.3))(@lexical/utils@0.11.3(lexical@0.11.3))(lexical@0.11.3)
       '@lexical/selection': 0.11.3(lexical@0.11.3)
       '@lexical/table': 0.11.3(lexical@0.11.3)
       '@lexical/text': 0.11.3(lexical@0.11.3)
@@ -20793,11 +21093,11 @@ snapshots:
     transitivePeerDependencies:
       - yjs
 
-  '@lexical/react@0.15.0(react-dom@18.2.0)(react@18.2.0)(yjs@13.6.18)':
+  '@lexical/react@0.15.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(yjs@13.6.18)':
     dependencies:
       '@lexical/clipboard': 0.15.0
       '@lexical/code': 0.15.0
-      '@lexical/devtools-core': 0.15.0(react-dom@18.2.0)(react@18.2.0)
+      '@lexical/devtools-core': 0.15.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@lexical/dragon': 0.15.0
       '@lexical/hashtag': 0.15.0
       '@lexical/history': 0.15.0
@@ -20820,7 +21120,7 @@ snapshots:
     transitivePeerDependencies:
       - yjs
 
-  '@lexical/rich-text@0.11.3(@lexical/clipboard@0.11.3)(@lexical/selection@0.11.3)(@lexical/utils@0.11.3)(lexical@0.11.3)':
+  '@lexical/rich-text@0.11.3(@lexical/clipboard@0.11.3(lexical@0.11.3))(@lexical/selection@0.11.3(lexical@0.11.3))(@lexical/utils@0.11.3(lexical@0.11.3))(lexical@0.11.3)':
     dependencies:
       '@lexical/clipboard': 0.11.3(lexical@0.11.3)
       '@lexical/selection': 0.11.3(lexical@0.11.3)
@@ -21025,24 +21325,22 @@ snapshots:
 
   '@mui/core-downloads-tracker@5.16.4': {}
 
-  '@mui/icons-material@5.16.4(@mui/material@5.16.4)(@types/react@18.3.3)(react@18.2.0)':
+  '@mui/icons-material@5.16.4(@mui/material@5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.3.3)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@mui/material': 5.16.4(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
-      '@types/react': 18.3.3
+      '@mui/material': 5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.3.3
 
-  '@mui/material@5.16.4(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)':
+  '@mui/material@5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@emotion/react': 11.11.4(@types/react@18.3.3)(react@18.2.0)
-      '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.2.0)
       '@mui/core-downloads-tracker': 5.16.4
-      '@mui/system': 5.16.4(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react@18.2.0)
+      '@mui/system': 5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0)
       '@mui/types': 7.2.15(@types/react@18.3.3)
       '@mui/utils': 5.16.4(@types/react@18.3.3)(react@18.2.0)
       '@popperjs/core': 2.11.8
-      '@types/react': 18.3.3
       '@types/react-transition-group': 4.4.10
       clsx: 2.1.1
       csstype: 3.1.3
@@ -21050,60 +21348,68 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-is: 18.3.1
-      react-transition-group: 4.4.5(react-dom@18.2.0)(react@18.2.0)
+      react-transition-group: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+    optionalDependencies:
+      '@emotion/react': 11.11.4(@types/react@18.3.3)(react@18.2.0)
+      '@emotion/styled': 11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0)
+      '@types/react': 18.3.3
 
   '@mui/private-theming@5.16.4(@types/react@18.3.3)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@mui/utils': 5.16.4(@types/react@18.3.3)(react@18.2.0)
-      '@types/react': 18.3.3
       prop-types: 15.8.1
       react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.3.3
 
-  '@mui/styled-engine@5.16.4(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(react@18.2.0)':
+  '@mui/styled-engine@5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@emotion/cache': 11.11.0
-      '@emotion/react': 11.11.4(@types/react@18.3.3)(react@18.2.0)
-      '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.2.0)
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.2.0
+    optionalDependencies:
+      '@emotion/react': 11.11.4(@types/react@18.3.3)(react@18.2.0)
+      '@emotion/styled': 11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0)
 
-  '@mui/system@5.16.4(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react@18.2.0)':
+  '@mui/system@5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@emotion/react': 11.11.4(@types/react@18.3.3)(react@18.2.0)
-      '@emotion/styled': 11.11.5(@emotion/react@11.11.4)(@types/react@18.3.3)(react@18.2.0)
       '@mui/private-theming': 5.16.4(@types/react@18.3.3)(react@18.2.0)
-      '@mui/styled-engine': 5.16.4(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(react@18.2.0)
+      '@mui/styled-engine': 5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(react@18.2.0)
       '@mui/types': 7.2.15(@types/react@18.3.3)
       '@mui/utils': 5.16.4(@types/react@18.3.3)(react@18.2.0)
-      '@types/react': 18.3.3
       clsx: 2.1.1
       csstype: 3.1.3
       prop-types: 15.8.1
       react: 18.2.0
+    optionalDependencies:
+      '@emotion/react': 11.11.4(@types/react@18.3.3)(react@18.2.0)
+      '@emotion/styled': 11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0)
+      '@types/react': 18.3.3
 
   '@mui/types@7.2.15(@types/react@18.3.3)':
-    dependencies:
+    optionalDependencies:
       '@types/react': 18.3.3
 
   '@mui/utils@5.16.4(@types/react@18.3.3)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@types/prop-types': 15.7.12
-      '@types/react': 18.3.3
       clsx: 2.1.1
       prop-types: 15.8.1
       react: 18.2.0
       react-is: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.3
 
-  '@mui/x-data-grid@6.20.3(@mui/material@5.16.4)(@mui/system@5.16.4)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)':
+  '@mui/x-data-grid@6.20.3(@mui/material@5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@mui/system@5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.8
-      '@mui/material': 5.16.4(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
-      '@mui/system': 5.16.4(@emotion/react@11.11.4)(@emotion/styled@11.11.5)(@types/react@18.3.3)(react@18.2.0)
+      '@mui/material': 5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@mui/system': 5.16.4(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0))(@types/react@18.3.3)(react@18.2.0)
       '@mui/utils': 5.16.4(@types/react@18.3.3)(react@18.2.0)
       clsx: 2.1.1
       prop-types: 15.8.1
@@ -21146,11 +21452,11 @@ snapshots:
   '@next/swc-win32-x64-msvc@14.2.3':
     optional: true
 
-  '@ngtools/webpack@18.1.1(@angular/compiler-cli@18.1.1)(typescript@5.5.3)(webpack@5.92.1)':
+  '@ngtools/webpack@18.1.1(@angular/compiler-cli@18.1.1(@angular/compiler@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))':
     dependencies:
-      '@angular/compiler-cli': 18.1.1(@angular/compiler@18.1.1)(typescript@5.5.3)
+      '@angular/compiler-cli': 18.1.1(@angular/compiler@18.1.1(@angular/core@18.1.1(rxjs@7.8.1)(zone.js@0.14.8)))(typescript@5.5.3)
       typescript: 5.5.3
-      webpack: 5.92.1(esbuild@0.21.5)
+      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -21270,7 +21576,7 @@ snapshots:
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
 
-  '@oclif/core@2.16.0(@types/node@20.14.11)(typescript@5.3.3)':
+  '@oclif/core@2.16.0(@swc/core@1.6.13)(@types/node@20.14.11)(typescript@5.3.3)':
     dependencies:
       '@types/cli-progress': 3.11.6
       ansi-escapes: 4.3.2
@@ -21295,7 +21601,7 @@ snapshots:
       strip-ansi: 6.0.1
       supports-color: 8.1.1
       supports-hyperlinks: 2.3.0
-      ts-node: 10.9.2(@types/node@20.14.11)(typescript@5.3.3)
+      ts-node: 10.9.2(@swc/core@1.6.13)(@types/node@20.14.11)(typescript@5.3.3)
       tslib: 2.6.3
       widest-line: 3.1.0
       wordwrap: 1.0.0
@@ -21308,9 +21614,9 @@ snapshots:
 
   '@oclif/linewrap@1.0.0': {}
 
-  '@oclif/plugin-autocomplete@2.3.10(@types/node@20.14.11)(typescript@5.3.3)':
+  '@oclif/plugin-autocomplete@2.3.10(@swc/core@1.6.13)(@types/node@20.14.11)(typescript@5.3.3)':
     dependencies:
-      '@oclif/core': 2.16.0(@types/node@20.14.11)(typescript@5.3.3)
+      '@oclif/core': 2.16.0(@swc/core@1.6.13)(@types/node@20.14.11)(typescript@5.3.3)
       chalk: 4.1.2
       debug: 4.3.5(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -21354,9 +21660,10 @@ snapshots:
       progress: 2.0.3
       proxy-agent: 6.3.0
       tar-fs: 3.0.4
-      typescript: 5.5.3
       unbzip2-stream: 1.4.3
       yargs: 17.7.1
+    optionalDependencies:
+      typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
 
@@ -21383,38 +21690,38 @@ snapshots:
       '@radix-ui/react-compose-refs': 1.0.0(react@18.2.0)
       react: 18.2.0
 
-  '@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1)':
+  '@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))':
     dependencies:
       merge-options: 3.0.4
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
 
-  '@react-native-community/async-storage@1.12.1(react-native@0.74.1)(react@18.2.0)':
+  '@react-native-community/async-storage@1.12.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       deep-assign: 3.0.0
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
 
-  '@react-native-community/cli-clean@11.3.6':
+  '@react-native-community/cli-clean@11.3.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-tools': 11.3.6
+      '@react-native-community/cli-tools': 11.3.6(encoding@0.1.13)
       chalk: 4.1.2
       execa: 5.1.1
       prompts: 2.4.2
     transitivePeerDependencies:
       - encoding
 
-  '@react-native-community/cli-clean@13.6.6':
+  '@react-native-community/cli-clean@13.6.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-tools': 13.6.6
+      '@react-native-community/cli-tools': 13.6.6(encoding@0.1.13)
       chalk: 4.1.2
       execa: 5.1.1
       fast-glob: 3.3.2
     transitivePeerDependencies:
       - encoding
 
-  '@react-native-community/cli-config@11.3.6':
+  '@react-native-community/cli-config@11.3.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-tools': 11.3.6
+      '@react-native-community/cli-tools': 11.3.6(encoding@0.1.13)
       chalk: 4.1.2
       cosmiconfig: 5.2.1
       deepmerge: 4.3.1
@@ -21423,9 +21730,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@react-native-community/cli-config@13.6.6':
+  '@react-native-community/cli-config@13.6.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-tools': 13.6.6
+      '@react-native-community/cli-tools': 13.6.6(encoding@0.1.13)
       chalk: 4.1.2
       cosmiconfig: 5.2.1
       deepmerge: 4.3.1
@@ -21446,12 +21753,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native-community/cli-doctor@11.3.6':
+  '@react-native-community/cli-doctor@11.3.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-config': 11.3.6
-      '@react-native-community/cli-platform-android': 11.3.6
-      '@react-native-community/cli-platform-ios': 11.3.6
-      '@react-native-community/cli-tools': 11.3.6
+      '@react-native-community/cli-config': 11.3.6(encoding@0.1.13)
+      '@react-native-community/cli-platform-android': 11.3.6(encoding@0.1.13)
+      '@react-native-community/cli-platform-ios': 11.3.6(encoding@0.1.13)
+      '@react-native-community/cli-tools': 11.3.6(encoding@0.1.13)
       chalk: 4.1.2
       command-exists: 1.2.9
       envinfo: 7.13.0
@@ -21469,13 +21776,13 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@react-native-community/cli-doctor@13.6.6':
+  '@react-native-community/cli-doctor@13.6.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-config': 13.6.6
-      '@react-native-community/cli-platform-android': 13.6.6
-      '@react-native-community/cli-platform-apple': 13.6.6
-      '@react-native-community/cli-platform-ios': 13.6.6
-      '@react-native-community/cli-tools': 13.6.6
+      '@react-native-community/cli-config': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-platform-android': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-platform-apple': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-platform-ios': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-tools': 13.6.6(encoding@0.1.13)
       chalk: 4.1.2
       command-exists: 1.2.9
       deepmerge: 4.3.1
@@ -21491,28 +21798,28 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@react-native-community/cli-hermes@11.3.6':
+  '@react-native-community/cli-hermes@11.3.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-platform-android': 11.3.6
-      '@react-native-community/cli-tools': 11.3.6
+      '@react-native-community/cli-platform-android': 11.3.6(encoding@0.1.13)
+      '@react-native-community/cli-tools': 11.3.6(encoding@0.1.13)
       chalk: 4.1.2
       hermes-profile-transformer: 0.0.6
       ip: 1.1.9
     transitivePeerDependencies:
       - encoding
 
-  '@react-native-community/cli-hermes@13.6.6':
+  '@react-native-community/cli-hermes@13.6.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-platform-android': 13.6.6
-      '@react-native-community/cli-tools': 13.6.6
+      '@react-native-community/cli-platform-android': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-tools': 13.6.6(encoding@0.1.13)
       chalk: 4.1.2
       hermes-profile-transformer: 0.0.6
     transitivePeerDependencies:
       - encoding
 
-  '@react-native-community/cli-platform-android@11.3.6':
+  '@react-native-community/cli-platform-android@11.3.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-tools': 11.3.6
+      '@react-native-community/cli-tools': 11.3.6(encoding@0.1.13)
       chalk: 4.1.2
       execa: 5.1.1
       glob: 7.2.3
@@ -21520,9 +21827,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@react-native-community/cli-platform-android@13.6.6':
+  '@react-native-community/cli-platform-android@13.6.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-tools': 13.6.6
+      '@react-native-community/cli-tools': 13.6.6(encoding@0.1.13)
       chalk: 4.1.2
       execa: 5.1.1
       fast-glob: 3.3.2
@@ -21531,9 +21838,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@react-native-community/cli-platform-apple@13.6.6':
+  '@react-native-community/cli-platform-apple@13.6.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-tools': 13.6.6
+      '@react-native-community/cli-tools': 13.6.6(encoding@0.1.13)
       chalk: 4.1.2
       execa: 5.1.1
       fast-glob: 3.3.2
@@ -21542,9 +21849,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@react-native-community/cli-platform-ios@11.3.6':
+  '@react-native-community/cli-platform-ios@11.3.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-tools': 11.3.6
+      '@react-native-community/cli-tools': 11.3.6(encoding@0.1.13)
       chalk: 4.1.2
       execa: 5.1.1
       fast-xml-parser: 4.4.0
@@ -21553,20 +21860,20 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@react-native-community/cli-platform-ios@13.6.6':
+  '@react-native-community/cli-platform-ios@13.6.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-platform-apple': 13.6.6
+      '@react-native-community/cli-platform-apple': 13.6.6(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
-  '@react-native-community/cli-plugin-metro@11.3.6(@babel/core@7.24.5)':
+  '@react-native-community/cli-plugin-metro@11.3.6(@babel/core@7.24.5)(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-server-api': 11.3.6
-      '@react-native-community/cli-tools': 11.3.6
+      '@react-native-community/cli-server-api': 11.3.6(encoding@0.1.13)
+      '@react-native-community/cli-tools': 11.3.6(encoding@0.1.13)
       chalk: 4.1.2
       execa: 5.1.1
-      metro: 0.76.7
-      metro-config: 0.76.7
+      metro: 0.76.7(encoding@0.1.13)
+      metro-config: 0.76.7(encoding@0.1.13)
       metro-core: 0.76.7
       metro-react-native-babel-transformer: 0.76.7(@babel/core@7.24.5)
       metro-resolver: 0.76.7
@@ -21579,10 +21886,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@react-native-community/cli-server-api@11.3.6':
+  '@react-native-community/cli-server-api@11.3.6(encoding@0.1.13)':
     dependencies:
       '@react-native-community/cli-debugger-ui': 11.3.6
-      '@react-native-community/cli-tools': 11.3.6
+      '@react-native-community/cli-tools': 11.3.6(encoding@0.1.13)
       compression: 1.7.4
       connect: 3.7.0
       errorhandler: 1.5.1
@@ -21596,10 +21903,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@react-native-community/cli-server-api@13.6.6':
+  '@react-native-community/cli-server-api@13.6.6(encoding@0.1.13)':
     dependencies:
       '@react-native-community/cli-debugger-ui': 13.6.6
-      '@react-native-community/cli-tools': 13.6.6
+      '@react-native-community/cli-tools': 13.6.6(encoding@0.1.13)
       compression: 1.7.4
       connect: 3.7.0
       errorhandler: 1.5.1
@@ -21613,13 +21920,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@react-native-community/cli-tools@11.3.6':
+  '@react-native-community/cli-tools@11.3.6(encoding@0.1.13)':
     dependencies:
       appdirsjs: 1.2.7
       chalk: 4.1.2
       find-up: 5.0.0
       mime: 2.6.0
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
       open: 6.4.0
       ora: 5.4.1
       semver: 7.6.3
@@ -21627,14 +21934,14 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@react-native-community/cli-tools@13.6.6':
+  '@react-native-community/cli-tools@13.6.6(encoding@0.1.13)':
     dependencies:
       appdirsjs: 1.2.7
       chalk: 4.1.2
       execa: 5.1.1
       find-up: 5.0.0
       mime: 2.6.0
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
       open: 6.4.0
       ora: 5.4.1
       semver: 7.6.3
@@ -21651,16 +21958,16 @@ snapshots:
     dependencies:
       joi: 17.13.3
 
-  '@react-native-community/cli@11.3.6(@babel/core@7.24.5)':
+  '@react-native-community/cli@11.3.6(@babel/core@7.24.5)(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-clean': 11.3.6
-      '@react-native-community/cli-config': 11.3.6
+      '@react-native-community/cli-clean': 11.3.6(encoding@0.1.13)
+      '@react-native-community/cli-config': 11.3.6(encoding@0.1.13)
       '@react-native-community/cli-debugger-ui': 11.3.6
-      '@react-native-community/cli-doctor': 11.3.6
-      '@react-native-community/cli-hermes': 11.3.6
-      '@react-native-community/cli-plugin-metro': 11.3.6(@babel/core@7.24.5)
-      '@react-native-community/cli-server-api': 11.3.6
-      '@react-native-community/cli-tools': 11.3.6
+      '@react-native-community/cli-doctor': 11.3.6(encoding@0.1.13)
+      '@react-native-community/cli-hermes': 11.3.6(encoding@0.1.13)
+      '@react-native-community/cli-plugin-metro': 11.3.6(@babel/core@7.24.5)(encoding@0.1.13)
+      '@react-native-community/cli-server-api': 11.3.6(encoding@0.1.13)
+      '@react-native-community/cli-tools': 11.3.6(encoding@0.1.13)
       '@react-native-community/cli-types': 11.3.6
       chalk: 4.1.2
       commander: 9.5.0
@@ -21677,15 +21984,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@react-native-community/cli@13.6.6':
+  '@react-native-community/cli@13.6.6(encoding@0.1.13)':
     dependencies:
-      '@react-native-community/cli-clean': 13.6.6
-      '@react-native-community/cli-config': 13.6.6
+      '@react-native-community/cli-clean': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-config': 13.6.6(encoding@0.1.13)
       '@react-native-community/cli-debugger-ui': 13.6.6
-      '@react-native-community/cli-doctor': 13.6.6
-      '@react-native-community/cli-hermes': 13.6.6
-      '@react-native-community/cli-server-api': 13.6.6
-      '@react-native-community/cli-tools': 13.6.6
+      '@react-native-community/cli-doctor': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-hermes': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-server-api': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-tools': 13.6.6(encoding@0.1.13)
       '@react-native-community/cli-types': 13.6.6
       chalk: 4.1.2
       commander: 9.5.0
@@ -21702,79 +22009,49 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@react-native-community/masked-view@0.1.11(react-native@0.74.1)(react@18.2.0)':
+  '@react-native-community/masked-view@0.1.11(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+
+  '@react-native-community/masked-view@0.1.11(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
 
   '@react-native/assets-registry@0.72.0': {}
 
   '@react-native/assets-registry@0.74.83': {}
 
-  '@react-native/babel-plugin-codegen@0.74.83(@babel/preset-env@7.24.8)':
+  '@react-native/babel-plugin-codegen@0.74.83(@babel/preset-env@7.24.8(@babel/core@7.24.5))':
     dependencies:
-      '@react-native/codegen': 0.74.83(@babel/preset-env@7.24.8)
+      '@react-native/codegen': 0.74.83(@babel/preset-env@7.24.8(@babel/core@7.24.5))
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
 
-  '@react-native/babel-plugin-codegen@0.74.85(@babel/preset-env@7.24.8)':
+  '@react-native/babel-plugin-codegen@0.74.83(@babel/preset-env@7.24.8(@babel/core@7.24.7))':
     dependencies:
-      '@react-native/codegen': 0.74.85(@babel/preset-env@7.24.8)
+      '@react-native/codegen': 0.74.83(@babel/preset-env@7.24.8(@babel/core@7.24.7))
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
 
-  '@react-native/babel-preset@0.74.83(@babel/core@7.24.5)(@babel/preset-env@7.24.8)':
+  '@react-native/babel-plugin-codegen@0.74.85(@babel/preset-env@7.24.8(@babel/core@7.24.5))':
     dependencies:
-      '@babel/core': 7.24.5
-      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.24.5)
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.24.5)
-      '@babel/plugin-proposal-export-default-from': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-proposal-logical-assignment-operators': 7.20.7(@babel/core@7.24.5)
-      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.24.5)
-      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.24.5)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.24.5)
-      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.24.5)
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.24.5)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.5)
-      '@babel/plugin-syntax-export-default-from': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-syntax-flow': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.5)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.5)
-      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-block-scoping': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-classes': 7.24.8(@babel/core@7.24.5)
-      '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-destructuring': 7.24.8(@babel/core@7.24.5)
-      '@babel/plugin-transform-flow-strip-types': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-function-name': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-literals': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.24.5)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-private-methods': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-private-property-in-object': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-react-display-name': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-react-jsx': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-runtime': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-sticky-regex': 7.24.7(@babel/core@7.24.5)
-      '@babel/plugin-transform-typescript': 7.24.8(@babel/core@7.24.5)
-      '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.24.5)
-      '@babel/template': 7.24.7
-      '@react-native/babel-plugin-codegen': 0.74.83(@babel/preset-env@7.24.8)
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.24.5)
-      react-refresh: 0.14.2
+      '@react-native/codegen': 0.74.85(@babel/preset-env@7.24.8(@babel/core@7.24.5))
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
 
-  '@react-native/babel-preset@0.74.85(@babel/core@7.24.5)(@babel/preset-env@7.24.8)':
+  '@react-native/babel-plugin-codegen@0.74.85(@babel/preset-env@7.24.8(@babel/core@7.24.7))':
+    dependencies:
+      '@react-native/codegen': 0.74.85(@babel/preset-env@7.24.8(@babel/core@7.24.7))
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+
+  '@react-native/babel-preset@0.74.83(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))':
     dependencies:
       '@babel/core': 7.24.5
       '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.24.5)
@@ -21816,64 +22093,259 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.24.8(@babel/core@7.24.5)
       '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.24.5)
       '@babel/template': 7.24.7
-      '@react-native/babel-plugin-codegen': 0.74.85(@babel/preset-env@7.24.8)
+      '@react-native/babel-plugin-codegen': 0.74.83(@babel/preset-env@7.24.8(@babel/core@7.24.5))
       babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.24.5)
       react-refresh: 0.14.2
     transitivePeerDependencies:
       - '@babel/preset-env'
       - supports-color
 
-  '@react-native/codegen@0.72.8(@babel/preset-env@7.24.8)':
+  '@react-native/babel-preset@0.74.83(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.24.7)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.24.7)
+      '@babel/plugin-proposal-export-default-from': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-proposal-logical-assignment-operators': 7.20.7(@babel/core@7.24.7)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.24.7)
+      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.24.7)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.24.7)
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.24.7)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.24.7)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-export-default-from': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-syntax-flow': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-block-scoping': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-classes': 7.24.8(@babel/core@7.24.7)
+      '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-destructuring': 7.24.8(@babel/core@7.24.7)
+      '@babel/plugin-transform-flow-strip-types': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-function-name': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-literals': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.24.7)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-private-methods': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-private-property-in-object': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-react-display-name': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-react-jsx': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-runtime': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-sticky-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-typescript': 7.24.8(@babel/core@7.24.7)
+      '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/template': 7.24.7
+      '@react-native/babel-plugin-codegen': 0.74.83(@babel/preset-env@7.24.8(@babel/core@7.24.7))
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.24.7)
+      react-refresh: 0.14.2
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+
+  '@react-native/babel-preset@0.74.85(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))':
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.24.5)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-export-default-from': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-proposal-logical-assignment-operators': 7.20.7(@babel/core@7.24.5)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.24.5)
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.24.5)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-export-default-from': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-syntax-flow': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.5)
+      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-block-scoping': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-classes': 7.24.8(@babel/core@7.24.5)
+      '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-destructuring': 7.24.8(@babel/core@7.24.5)
+      '@babel/plugin-transform-flow-strip-types': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-function-name': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-literals': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.24.5)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-private-methods': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-private-property-in-object': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-react-display-name': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-react-jsx': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-runtime': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-sticky-regex': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-typescript': 7.24.8(@babel/core@7.24.5)
+      '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.24.5)
+      '@babel/template': 7.24.7
+      '@react-native/babel-plugin-codegen': 0.74.85(@babel/preset-env@7.24.8(@babel/core@7.24.5))
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.24.5)
+      react-refresh: 0.14.2
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+
+  '@react-native/babel-preset@0.74.85(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.24.7)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.24.7)
+      '@babel/plugin-proposal-export-default-from': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-proposal-logical-assignment-operators': 7.20.7(@babel/core@7.24.7)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.24.7)
+      '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.24.7)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.24.7)
+      '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.24.7)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.24.7)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-export-default-from': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-syntax-flow': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.7)
+      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-block-scoping': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-classes': 7.24.8(@babel/core@7.24.7)
+      '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-destructuring': 7.24.8(@babel/core@7.24.7)
+      '@babel/plugin-transform-flow-strip-types': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-function-name': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-literals': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.24.7)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-private-methods': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-private-property-in-object': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-react-display-name': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-react-jsx': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-runtime': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-sticky-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-typescript': 7.24.8(@babel/core@7.24.7)
+      '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.24.7)
+      '@babel/template': 7.24.7
+      '@react-native/babel-plugin-codegen': 0.74.85(@babel/preset-env@7.24.8(@babel/core@7.24.7))
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.24.7)
+      react-refresh: 0.14.2
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+
+  '@react-native/codegen@0.72.8(@babel/preset-env@7.24.8(@babel/core@7.24.5))':
     dependencies:
       '@babel/parser': 7.24.8
       '@babel/preset-env': 7.24.8(@babel/core@7.24.5)
       flow-parser: 0.206.0
       glob: 7.2.3
       invariant: 2.2.4
-      jscodeshift: 0.14.0(@babel/preset-env@7.24.8)
+      jscodeshift: 0.14.0(@babel/preset-env@7.24.8(@babel/core@7.24.5))
       mkdirp: 0.5.6
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/codegen@0.74.83(@babel/preset-env@7.24.8)':
+  '@react-native/codegen@0.74.83(@babel/preset-env@7.24.8(@babel/core@7.24.5))':
     dependencies:
       '@babel/parser': 7.24.8
       '@babel/preset-env': 7.24.8(@babel/core@7.24.5)
       glob: 7.2.3
       hermes-parser: 0.19.1
       invariant: 2.2.4
-      jscodeshift: 0.14.0(@babel/preset-env@7.24.8)
+      jscodeshift: 0.14.0(@babel/preset-env@7.24.8(@babel/core@7.24.5))
       mkdirp: 0.5.6
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/codegen@0.74.85(@babel/preset-env@7.24.8)':
+  '@react-native/codegen@0.74.83(@babel/preset-env@7.24.8(@babel/core@7.24.7))':
+    dependencies:
+      '@babel/parser': 7.24.8
+      '@babel/preset-env': 7.24.8(@babel/core@7.24.7)
+      glob: 7.2.3
+      hermes-parser: 0.19.1
+      invariant: 2.2.4
+      jscodeshift: 0.14.0(@babel/preset-env@7.24.8(@babel/core@7.24.7))
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@react-native/codegen@0.74.85(@babel/preset-env@7.24.8(@babel/core@7.24.5))':
     dependencies:
       '@babel/parser': 7.24.8
       '@babel/preset-env': 7.24.8(@babel/core@7.24.5)
       glob: 7.2.3
       hermes-parser: 0.19.1
       invariant: 2.2.4
-      jscodeshift: 0.14.0(@babel/preset-env@7.24.8)
+      jscodeshift: 0.14.0(@babel/preset-env@7.24.8(@babel/core@7.24.5))
       mkdirp: 0.5.6
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/community-cli-plugin@0.74.83(@babel/core@7.24.5)(@babel/preset-env@7.24.8)':
+  '@react-native/codegen@0.74.85(@babel/preset-env@7.24.8(@babel/core@7.24.7))':
     dependencies:
-      '@react-native-community/cli-server-api': 13.6.6
-      '@react-native-community/cli-tools': 13.6.6
-      '@react-native/dev-middleware': 0.74.83
-      '@react-native/metro-babel-transformer': 0.74.83(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+      '@babel/parser': 7.24.8
+      '@babel/preset-env': 7.24.8(@babel/core@7.24.7)
+      glob: 7.2.3
+      hermes-parser: 0.19.1
+      invariant: 2.2.4
+      jscodeshift: 0.14.0(@babel/preset-env@7.24.8(@babel/core@7.24.7))
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@react-native/community-cli-plugin@0.74.83(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)':
+    dependencies:
+      '@react-native-community/cli-server-api': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-tools': 13.6.6(encoding@0.1.13)
+      '@react-native/dev-middleware': 0.74.83(encoding@0.1.13)
+      '@react-native/metro-babel-transformer': 0.74.83(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))
       chalk: 4.1.2
       execa: 5.1.1
-      metro: 0.80.9
-      metro-config: 0.80.9
+      metro: 0.80.9(encoding@0.1.13)
+      metro-config: 0.80.9(encoding@0.1.13)
       metro-core: 0.80.9
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
+      querystring: 0.2.1
+      readline: 1.3.0
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@react-native/community-cli-plugin@0.74.83(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)':
+    dependencies:
+      '@react-native-community/cli-server-api': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-tools': 13.6.6(encoding@0.1.13)
+      '@react-native/dev-middleware': 0.74.83(encoding@0.1.13)
+      '@react-native/metro-babel-transformer': 0.74.83(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))
+      chalk: 4.1.2
+      execa: 5.1.1
+      metro: 0.80.9(encoding@0.1.13)
+      metro-config: 0.80.9(encoding@0.1.13)
+      metro-core: 0.80.9
+      node-fetch: 2.7.0(encoding@0.1.13)
       querystring: 0.2.1
       readline: 1.3.0
     transitivePeerDependencies:
@@ -21888,7 +22360,7 @@ snapshots:
 
   '@react-native/debugger-frontend@0.74.85': {}
 
-  '@react-native/dev-middleware@0.74.83':
+  '@react-native/dev-middleware@0.74.83(encoding@0.1.13)':
     dependencies:
       '@isaacs/ttlcache': 1.4.1
       '@react-native/debugger-frontend': 0.74.83
@@ -21896,7 +22368,7 @@ snapshots:
       chrome-launcher: 0.15.2
       connect: 3.7.0
       debug: 2.6.9
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
       nullthrows: 1.1.1
       open: 7.4.2
       selfsigned: 2.4.1
@@ -21909,7 +22381,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@react-native/dev-middleware@0.74.85':
+  '@react-native/dev-middleware@0.74.85(encoding@0.1.13)':
     dependencies:
       '@isaacs/ttlcache': 1.4.1
       '@react-native/debugger-frontend': 0.74.85
@@ -21917,7 +22389,7 @@ snapshots:
       chrome-launcher: 0.15.2
       connect: 3.7.0
       debug: 2.6.9
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
       nullthrows: 1.1.1
       open: 7.4.2
       selfsigned: 2.4.1
@@ -21938,10 +22410,20 @@ snapshots:
 
   '@react-native/js-polyfills@0.74.83': {}
 
-  '@react-native/metro-babel-transformer@0.74.83(@babel/core@7.24.5)(@babel/preset-env@7.24.8)':
+  '@react-native/metro-babel-transformer@0.74.83(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))':
     dependencies:
       '@babel/core': 7.24.5
-      '@react-native/babel-preset': 0.74.83(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+      '@react-native/babel-preset': 0.74.83(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))
+      hermes-parser: 0.19.1
+      nullthrows: 1.1.1
+    transitivePeerDependencies:
+      - '@babel/preset-env'
+      - supports-color
+
+  '@react-native/metro-babel-transformer@0.74.83(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))':
+    dependencies:
+      '@babel/core': 7.24.7
+      '@react-native/babel-preset': 0.74.83(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))
       hermes-parser: 0.19.1
       nullthrows: 1.1.1
     transitivePeerDependencies:
@@ -21958,37 +22440,70 @@ snapshots:
 
   '@react-native/normalize-colors@0.74.85': {}
 
-  '@react-native/virtualized-lists@0.72.8(react-native@0.72.4)':
+  '@react-native/virtualized-lists@0.72.8(react-native@0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)(react@18.2.0))':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
-      react-native: 0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(react@18.2.0)
+      react-native: 0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)(react@18.2.0)
 
-  '@react-native/virtualized-lists@0.74.83(@types/react@18.2.79)(react-native@0.74.1)(react@18.2.0)':
+  '@react-native/virtualized-lists@0.74.83(@types/react@18.2.79)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+    optionalDependencies:
       '@types/react': 18.2.79
+
+  '@react-native/virtualized-lists@0.74.83(@types/react@18.2.79)(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.79
 
-  '@react-native/virtualized-lists@0.74.83(@types/react@18.3.3)(react-native@0.74.1)(react@18.2.0)':
+  '@react-native/virtualized-lists@0.74.83(@types/react@18.3.3)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
+    optionalDependencies:
       '@types/react': 18.3.3
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
 
-  '@react-navigation/bottom-tabs@6.5.20(@react-navigation/native@6.1.18)(react-native-safe-area-context@4.10.1)(react-native-screens@3.31.1)(react-native@0.74.1)(react@18.2.0)':
+  '@react-navigation/bottom-tabs@6.5.20(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18)(react-native-safe-area-context@4.10.1)(react-native@0.74.1)(react@18.2.0)
-      '@react-navigation/native': 6.1.18(react-native@0.74.1)(react@18.2.0)
+      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native': 6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       color: 4.2.3
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
-      react-native-safe-area-context: 4.10.1(react-native@0.74.1)(react@18.2.0)
-      react-native-screens: 3.31.1(react-native@0.74.1)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      warn-once: 0.1.1
+
+  '@react-navigation/bottom-tabs@6.5.20(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native': 6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      color: 4.2.3
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      warn-once: 0.1.1
+
+  '@react-navigation/bottom-tabs@6.5.20(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native': 6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      color: 4.2.3
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       warn-once: 0.1.1
 
   '@react-navigation/core@3.7.9(react@18.2.0)':
@@ -22009,52 +22524,139 @@ snapshots:
       react-is: 16.13.1
       use-latest-callback: 0.2.1(react@18.2.0)
 
-  '@react-navigation/drawer@6.7.2(@react-navigation/native@6.1.18)(react-native-gesture-handler@2.16.2)(react-native-reanimated@3.10.1)(react-native-safe-area-context@4.10.1)(react-native-screens@3.31.1)(react-native@0.74.1)(react@18.2.0)':
-    dependencies:
-      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18)(react-native-safe-area-context@4.10.1)(react-native@0.74.1)(react@18.2.0)
-      '@react-navigation/native': 6.1.18(react-native@0.74.1)(react@18.2.0)
+  ? '@react-navigation/drawer@6.7.2(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)'
+  : dependencies:
+      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native': 6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       color: 4.2.3
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
-      react-native-gesture-handler: 2.16.2(react-native@0.74.1)(react@18.2.0)
-      react-native-reanimated: 3.10.1(@babel/core@7.24.5)(react-native@0.74.1)(react@18.2.0)
-      react-native-safe-area-context: 4.10.1(react-native@0.74.1)(react@18.2.0)
-      react-native-screens: 3.31.1(react-native@0.74.1)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+      react-native-gesture-handler: 2.16.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-reanimated: 3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       warn-once: 0.1.1
 
-  '@react-navigation/elements@1.3.31(@react-navigation/native@6.1.18)(react-native-safe-area-context@4.10.1)(react-native@0.74.1)(react@18.2.0)':
-    dependencies:
-      '@react-navigation/native': 6.1.18(react-native@0.74.1)(react@18.2.0)
+  ? '@react-navigation/drawer@6.7.2(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)'
+  : dependencies:
+      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native': 6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      color: 4.2.3
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
-      react-native-safe-area-context: 4.10.1(react-native@0.74.1)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
+      react-native-gesture-handler: 2.16.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-reanimated: 3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      warn-once: 0.1.1
+    optional: true
 
-  '@react-navigation/native-stack@6.9.26(@react-navigation/native@6.1.18)(react-native-safe-area-context@4.10.1)(react-native-screens@3.31.1)(react-native@0.74.1)(react@18.2.0)':
-    dependencies:
-      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18)(react-native-safe-area-context@4.10.1)(react-native@0.74.1)(react@18.2.0)
-      '@react-navigation/native': 6.1.18(react-native@0.74.1)(react@18.2.0)
+  ? '@react-navigation/drawer@6.7.2(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.7)(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)'
+  : dependencies:
+      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native': 6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      color: 4.2.3
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
-      react-native-safe-area-context: 4.10.1(react-native@0.74.1)(react@18.2.0)
-      react-native-screens: 3.31.1(react-native@0.74.1)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+      react-native-gesture-handler: 2.16.2(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-reanimated: 3.10.1(@babel/core@7.24.7)(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       warn-once: 0.1.1
 
-  '@react-navigation/native@3.8.4(react-native@0.74.1)(react@18.2.0)':
+  '@react-navigation/elements@1.3.31(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/native': 6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+
+  '@react-navigation/elements@1.3.31(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/native': 6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+
+  '@react-navigation/elements@1.3.31(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/native': 6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+
+  '@react-navigation/native-stack@6.9.26(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native': 6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      warn-once: 0.1.1
+
+  '@react-navigation/native-stack@6.9.26(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native': 6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      warn-once: 0.1.1
+
+  '@react-navigation/native-stack@6.9.26(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/elements': 1.3.31(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native': 6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      warn-once: 0.1.1
+
+  '@react-navigation/native@3.8.4(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       hoist-non-react-statics: 3.3.2
-      react-native-safe-area-view: 0.14.9(react-native@0.74.1)(react@18.2.0)
+      react-native-safe-area-view: 0.14.9(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - react
       - react-native
 
-  '@react-navigation/native@6.1.18(react-native@0.74.1)(react@18.2.0)':
+  '@react-navigation/native@3.8.4(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      hoist-non-react-statics: 3.3.2
+      react-native-safe-area-view: 0.14.9(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+    transitivePeerDependencies:
+      - react
+      - react-native
+
+  '@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@react-navigation/core': 6.4.17(react@18.2.0)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
       nanoid: 3.3.7
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+
+  '@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/core': 6.4.17(react@18.2.0)
+      escape-string-regexp: 4.0.0
+      fast-deep-equal: 3.1.3
+      nanoid: 3.3.7
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
+
+  '@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@react-navigation/core': 6.4.17(react@18.2.0)
+      escape-string-regexp: 4.0.0
+      fast-deep-equal: 3.1.3
+      nanoid: 3.3.7
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
 
   '@react-navigation/routers@6.1.9':
     dependencies:
@@ -22070,8 +22672,9 @@ snapshots:
       cookie-signature: 1.2.1
       source-map-support: 0.5.21
       stream-slice: 0.1.2
-      typescript: 5.3.3
       undici: 6.19.2
+    optionalDependencies:
+      typescript: 5.3.3
 
   '@remix-run/node@2.10.3(typescript@5.5.3)':
     dependencies:
@@ -22081,8 +22684,9 @@ snapshots:
       cookie-signature: 1.2.1
       source-map-support: 0.5.21
       stream-slice: 0.1.2
-      typescript: 5.5.3
       undici: 6.19.2
+    optionalDependencies:
+      typescript: 5.5.3
 
   '@remix-run/router@1.18.0': {}
 
@@ -22095,6 +22699,7 @@ snapshots:
       set-cookie-parser: 2.6.0
       source-map: 0.7.4
       turbo-stream: 2.2.0
+    optionalDependencies:
       typescript: 5.3.3
 
   '@remix-run/server-runtime@2.10.3(typescript@5.5.3)':
@@ -22106,6 +22711,7 @@ snapshots:
       set-cookie-parser: 2.6.0
       source-map: 0.7.4
       turbo-stream: 2.2.0
+    optionalDependencies:
       typescript: 5.5.3
 
   '@remix-run/web-blob@3.1.0':
@@ -22147,12 +22753,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@rollup/plugin-babel@5.3.1(@babel/core@7.24.5)(rollup@2.79.1)':
+  '@rollup/plugin-babel@5.3.1(@babel/core@7.24.5)(@types/babel__core@7.20.5)(rollup@2.79.1)':
     dependencies:
       '@babel/core': 7.24.5
       '@babel/helper-module-imports': 7.24.7
       '@rollup/pluginutils': 3.1.0(rollup@2.79.1)
       rollup: 2.79.1
+    optionalDependencies:
+      '@types/babel__core': 7.20.5
     transitivePeerDependencies:
       - supports-color
 
@@ -22164,6 +22772,7 @@ snapshots:
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.8
+    optionalDependencies:
       rollup: 2.79.1
 
   '@rollup/plugin-replace@2.4.2(rollup@2.79.1)':
@@ -22174,14 +22783,19 @@ snapshots:
 
   '@rollup/plugin-terser@0.4.4(rollup@2.79.1)':
     dependencies:
-      rollup: 2.79.1
       serialize-javascript: 6.0.2
       smob: 1.5.0
       terser: 5.31.3
+    optionalDependencies:
+      rollup: 2.79.1
 
   '@rollup/plugin-virtual@3.0.2(rollup@2.79.1)':
-    dependencies:
+    optionalDependencies:
       rollup: 2.79.1
+
+  '@rollup/plugin-virtual@3.0.2(rollup@4.18.1)':
+    optionalDependencies:
+      rollup: 4.18.1
 
   '@rollup/pluginutils@3.1.0(rollup@2.79.1)':
     dependencies:
@@ -22195,7 +22809,16 @@ snapshots:
       '@types/estree': 1.0.5
       estree-walker: 2.0.2
       picomatch: 2.3.1
+    optionalDependencies:
       rollup: 2.79.1
+
+  '@rollup/pluginutils@5.1.0(rollup@4.18.1)':
+    dependencies:
+      '@types/estree': 1.0.5
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+    optionalDependencies:
+      rollup: 4.18.1
 
   '@rollup/rollup-android-arm-eabi@4.18.0':
     optional: true
@@ -22295,10 +22918,10 @@ snapshots:
 
   '@rushstack/eslint-patch@1.10.3': {}
 
-  '@schematics/angular@18.1.1':
+  '@schematics/angular@18.1.1(chokidar@3.6.0)':
     dependencies:
-      '@angular-devkit/core': 18.1.1
-      '@angular-devkit/schematics': 18.1.1
+      '@angular-devkit/core': 18.1.1(chokidar@3.6.0)
+      '@angular-devkit/schematics': 18.1.1(chokidar@3.6.0)
       jsonc-parser: 3.3.1
     transitivePeerDependencies:
       - chokidar
@@ -22312,12 +22935,12 @@ snapshots:
       component-type: 1.2.2
       join-component: 1.1.0
 
-  '@shopify/flash-list@1.6.4(@babel/runtime@7.24.8)(react-native@0.74.1)(react@18.2.0)':
+  '@shopify/flash-list@1.6.4(@babel/runtime@7.24.8)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
-      recyclerlistview: 4.2.0(react-native@0.74.1)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
+      recyclerlistview: 4.2.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       tslib: 2.4.0
 
   '@sideway/address@4.1.5':
@@ -22521,7 +23144,7 @@ snapshots:
       '@babel/types': 7.24.9
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0)':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.4.5))':
     dependencies:
       '@babel/core': 7.24.5
       '@svgr/babel-preset': 8.1.0(@babel/core@7.24.5)
@@ -22531,7 +23154,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0)(typescript@5.4.5)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.4.5))(typescript@5.4.5)':
     dependencies:
       '@svgr/core': 8.1.0(typescript@5.4.5)
       cosmiconfig: 8.3.6(typescript@5.4.5)
@@ -22548,8 +23171,8 @@ snapshots:
       '@babel/preset-react': 7.24.7(@babel/core@7.24.5)
       '@babel/preset-typescript': 7.24.7(@babel/core@7.24.5)
       '@svgr/core': 8.1.0(typescript@5.4.5)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@5.4.5)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.4.5))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.4.5))(typescript@5.4.5)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -22584,7 +23207,7 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.6.13':
     optional: true
 
-  '@swc/core@1.6.13':
+  '@swc/core@1.6.13(@swc/helpers@0.5.5)':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.9
@@ -22599,6 +23222,7 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.6.13
       '@swc/core-win32-ia32-msvc': 1.6.13
       '@swc/core-win32-x64-msvc': 1.6.13
+      '@swc/helpers': 0.5.5
 
   '@swc/counter@0.1.3': {}
 
@@ -22637,25 +23261,25 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@tamagui/alert-dialog@1.79.6(@types/react@18.3.3)(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/alert-dialog@1.79.6(@types/react@18.3.3)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/animate-presence': 1.79.6(react@18.2.0)
       '@tamagui/aria-hidden': 1.79.6(react@18.2.0)
       '@tamagui/compose-refs': 1.79.6(react@18.2.0)
       '@tamagui/core': 1.79.6(react@18.2.0)
       '@tamagui/create-context': 1.79.6(react@18.2.0)
-      '@tamagui/dialog': 1.79.6(@types/react@18.3.3)(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/dialog': 1.79.6(@types/react@18.3.3)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/dismissable': 1.79.6(react@18.2.0)
       '@tamagui/focus-scope': 1.79.6(react@18.2.0)
       '@tamagui/polyfill-dev': 1.79.6
-      '@tamagui/popper': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/portal': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/popper': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/portal': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/remove-scroll': 1.79.6(@types/react@18.3.3)(react@18.2.0)
       '@tamagui/stacks': 1.79.6(react@18.2.0)
-      '@tamagui/text': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/text': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/use-controllable-state': 1.79.6(react@18.2.0)
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -22680,45 +23304,45 @@ snapshots:
       '@tamagui/web': 1.79.6(react@18.2.0)
       react: 18.2.0
 
-  '@tamagui/animations-moti@1.79.6(react-dom@18.2.0)(react-native-reanimated@3.10.1)(react@18.2.0)':
+  '@tamagui/animations-moti@1.79.6(react-dom@18.2.0(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/use-presence': 1.79.6(react@18.2.0)
       '@tamagui/web': 1.79.6(react@18.2.0)
-      moti: 0.25.4(react-dom@18.2.0)(react-native-reanimated@3.10.1)(react@18.2.0)
+      moti: 0.25.4(react-dom@18.2.0(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - react
       - react-dom
       - react-native-reanimated
 
-  '@tamagui/animations-react-native@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/animations-react-native@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/use-presence': 1.79.6(react@18.2.0)
       '@tamagui/web': 1.79.6(react@18.2.0)
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
 
   '@tamagui/aria-hidden@1.79.6(react@18.2.0)':
     dependencies:
       aria-hidden: 1.2.4
       react: 18.2.0
 
-  '@tamagui/avatar@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/avatar@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/core': 1.79.6(react@18.2.0)
-      '@tamagui/image': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/image': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/shapes': 1.79.6(react@18.2.0)
-      '@tamagui/text': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/text': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
 
-  '@tamagui/babel-plugin@1.79.6(react-dom@18.2.0)(react@18.2.0)':
+  '@tamagui/babel-plugin@1.79.6(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/generator': 7.24.10
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/template': 7.24.7
       '@babel/traverse': 7.24.8
       '@tamagui/simple-hash': 1.79.6
-      '@tamagui/static': 1.79.6(react-dom@18.2.0)(react@18.2.0)
+      '@tamagui/static': 1.79.6(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - encoding
       - react
@@ -22737,34 +23361,34 @@ snapshots:
       lodash.debounce: 4.0.8
       typescript: 5.5.3
 
-  '@tamagui/button@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/button@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/font-size': 1.79.6(react@18.2.0)
-      '@tamagui/get-button-sized': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/helpers-tamagui': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/text': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/get-button-sized': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers-tamagui': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/text': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/web': 1.79.6(react@18.2.0)
       react: 18.2.0
     transitivePeerDependencies:
       - react-native
 
-  '@tamagui/card@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/card@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/create-context': 1.79.6(react@18.2.0)
       '@tamagui/stacks': 1.79.6(react@18.2.0)
       '@tamagui/web': 1.79.6(react@18.2.0)
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
 
-  '@tamagui/checkbox@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/checkbox@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/core': 1.79.6(react@18.2.0)
       '@tamagui/create-context': 1.79.6(react@18.2.0)
       '@tamagui/focusable': 1.79.6(react@18.2.0)
       '@tamagui/font-size': 1.79.6(react@18.2.0)
-      '@tamagui/get-token': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/helpers-tamagui': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/label': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/get-token': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers-tamagui': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/label': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/stacks': 1.79.6(react@18.2.0)
       '@tamagui/use-controllable-state': 1.79.6(react@18.2.0)
       '@tamagui/use-previous': 1.79.6
@@ -22808,15 +23432,15 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@tamagui/config@1.79.6(react-dom@18.2.0)(react-native-reanimated@3.10.1)(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/config@1.79.6(react-dom@18.2.0(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/animations-css': 1.79.6
-      '@tamagui/animations-moti': 1.79.6(react-dom@18.2.0)(react-native-reanimated@3.10.1)(react@18.2.0)
-      '@tamagui/animations-react-native': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/animations-moti': 1.79.6(react-dom@18.2.0(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0)
+      '@tamagui/animations-react-native': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/colors': 1.79.6
       '@tamagui/font-inter': 1.79.6(react@18.2.0)
       '@tamagui/font-silkscreen': 1.79.6(react@18.2.0)
-      '@tamagui/react-native-media-driver': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/react-native-media-driver': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/shorthands': 1.79.6
       '@tamagui/themes': 1.79.6(react@18.2.0)
       '@tamagui/web': 1.79.6(react@18.2.0)
@@ -22850,7 +23474,7 @@ snapshots:
 
   '@tamagui/cubic-bezier-animator@1.79.6': {}
 
-  '@tamagui/dialog@1.79.6(@types/react@18.3.3)(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/dialog@1.79.6(@types/react@18.3.3)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/adapt': 1.79.6(react@18.2.0)
       '@tamagui/animate-presence': 1.79.6(react@18.2.0)
@@ -22861,15 +23485,15 @@ snapshots:
       '@tamagui/dismissable': 1.79.6(react@18.2.0)
       '@tamagui/focus-scope': 1.79.6(react@18.2.0)
       '@tamagui/polyfill-dev': 1.79.6
-      '@tamagui/popper': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/portal': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/popper': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/portal': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/remove-scroll': 1.79.6(@types/react@18.3.3)(react@18.2.0)
-      '@tamagui/sheet': 1.79.6(@types/react@18.3.3)(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/sheet': 1.79.6(@types/react@18.3.3)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/stacks': 1.79.6(react@18.2.0)
-      '@tamagui/text': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/text': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/use-controllable-state': 1.79.6(react@18.2.0)
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -22883,10 +23507,10 @@ snapshots:
 
   '@tamagui/fake-react-native@1.79.6': {}
 
-  '@tamagui/floating@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/floating@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.1(react-dom@18.2.0)(react@18.2.0)
-      '@floating-ui/react-native': 0.10.6(react-native@0.74.1)(react@18.2.0)
+      '@floating-ui/react-dom': 2.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@floating-ui/react-native': 0.10.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
@@ -22921,15 +23545,15 @@ snapshots:
       '@tamagui/core': 1.79.6(react@18.2.0)
       react: 18.2.0
 
-  '@tamagui/form@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/form@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/compose-refs': 1.79.6(react@18.2.0)
       '@tamagui/core': 1.79.6(react@18.2.0)
       '@tamagui/create-context': 1.79.6(react@18.2.0)
       '@tamagui/focusable': 1.79.6(react@18.2.0)
-      '@tamagui/get-button-sized': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/get-button-sized': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/get-font-sized': 1.79.6(react@18.2.0)
-      '@tamagui/text': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/text': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react: 18.2.0
     transitivePeerDependencies:
       - react-native
@@ -22945,9 +23569,9 @@ snapshots:
       - react
       - supports-color
 
-  '@tamagui/get-button-sized@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/get-button-sized@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@tamagui/get-token': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/get-token': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/web': 1.79.6(react@18.2.0)
       react: 18.2.0
     transitivePeerDependencies:
@@ -22958,40 +23582,40 @@ snapshots:
       '@tamagui/core': 1.79.6(react@18.2.0)
       react: 18.2.0
 
-  '@tamagui/get-token@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/get-token@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/web': 1.79.6(react@18.2.0)
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
 
-  '@tamagui/group@1.79.6(@types/react@18.3.3)(react@18.2.0)':
+  '@tamagui/group@1.79.6(@types/react@18.3.3)(immer@9.0.21)(react@18.2.0)':
     dependencies:
       '@tamagui/core': 1.79.6(react@18.2.0)
       '@tamagui/create-context': 1.79.6(react@18.2.0)
       '@tamagui/stacks': 1.79.6(react@18.2.0)
       '@tamagui/use-controllable-state': 1.79.6(react@18.2.0)
       react: 18.2.0
-      reforest: 0.13.0(@types/react@18.3.3)(react@18.2.0)
+      reforest: 0.13.0(@types/react@18.3.3)(immer@9.0.21)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - immer
 
-  '@tamagui/helpers-icon@1.79.6(react-native-svg@15.2.0)(react@18.2.0)':
+  '@tamagui/helpers-icon@1.79.6(react-native-svg@15.2.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/core': 1.79.6(react@18.2.0)
       react: 18.2.0
-      react-native-svg: 15.2.0(react-native@0.74.1)(react@18.2.0)
+      react-native-svg: 15.2.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
 
   '@tamagui/helpers-node@1.79.6':
     dependencies:
       '@tamagui/types': 1.79.6
 
-  '@tamagui/helpers-tamagui@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/helpers-tamagui@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/helpers': 1.79.6(react@18.2.0)
       '@tamagui/web': 1.79.6(react@18.2.0)
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
 
   '@tamagui/helpers@1.79.6(react@18.2.0)':
     dependencies:
@@ -23000,23 +23624,23 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@tamagui/image@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/image@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/core': 1.79.6(react@18.2.0)
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
 
-  '@tamagui/label@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/label@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/compose-refs': 1.79.6(react@18.2.0)
       '@tamagui/create-context': 1.79.6(react@18.2.0)
       '@tamagui/focusable': 1.79.6(react@18.2.0)
-      '@tamagui/get-button-sized': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/get-button-sized': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/get-font-sized': 1.79.6(react@18.2.0)
-      '@tamagui/text': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/text': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/web': 1.79.6(react@18.2.0)
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
 
   '@tamagui/linear-gradient@1.79.6(react@18.2.0)':
     dependencies:
@@ -23024,24 +23648,24 @@ snapshots:
       '@tamagui/stacks': 1.79.6(react@18.2.0)
       react: 18.2.0
 
-  '@tamagui/list-item@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/list-item@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/font-size': 1.79.6(react@18.2.0)
       '@tamagui/get-font-sized': 1.79.6(react@18.2.0)
-      '@tamagui/get-token': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/helpers-tamagui': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/text': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/get-token': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/helpers-tamagui': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/text': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/web': 1.79.6(react@18.2.0)
       react: 18.2.0
     transitivePeerDependencies:
       - react-native
 
-  '@tamagui/lucide-icons@1.79.6(react-native-svg@15.2.0)(react@18.2.0)':
+  '@tamagui/lucide-icons@1.79.6(react-native-svg@15.2.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/core': 1.79.6(react@18.2.0)
-      '@tamagui/helpers-icon': 1.79.6(react-native-svg@15.2.0)(react@18.2.0)
+      '@tamagui/helpers-icon': 1.79.6(react-native-svg@15.2.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0)
       react: 18.2.0
-      react-native-svg: 15.2.0(react-native@0.74.1)(react@18.2.0)
+      react-native-svg: 15.2.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
 
   '@tamagui/normalize-css-color@1.79.6':
     dependencies:
@@ -23049,71 +23673,71 @@ snapshots:
 
   '@tamagui/polyfill-dev@1.79.6': {}
 
-  '@tamagui/popover@1.79.6(@types/react@18.3.3)(react-dom@18.2.0)(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/popover@1.79.6(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@floating-ui/react': 0.24.8(react-dom@18.2.0)(react@18.2.0)
+      '@floating-ui/react': 0.24.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tamagui/adapt': 1.79.6(react@18.2.0)
       '@tamagui/animate': 1.79.6(react@18.2.0)
       '@tamagui/aria-hidden': 1.79.6(react@18.2.0)
       '@tamagui/compose-refs': 1.79.6(react@18.2.0)
       '@tamagui/core': 1.79.6(react@18.2.0)
       '@tamagui/dismissable': 1.79.6(react@18.2.0)
-      '@tamagui/floating': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/floating': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/focus-scope': 1.79.6(react@18.2.0)
       '@tamagui/polyfill-dev': 1.79.6
-      '@tamagui/popper': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/portal': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/popper': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/portal': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/remove-scroll': 1.79.6(@types/react@18.3.3)(react@18.2.0)
       '@tamagui/scroll-view': 1.79.6(react@18.2.0)
-      '@tamagui/sheet': 1.79.6(@types/react@18.3.3)(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/sheet': 1.79.6(@types/react@18.3.3)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/stacks': 1.79.6(react@18.2.0)
       '@tamagui/use-controllable-state': 1.79.6(react@18.2.0)
       react: 18.2.0
       react-freeze: 1.0.4(react@18.2.0)
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
 
-  '@tamagui/popper@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/popper@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/compose-refs': 1.79.6(react@18.2.0)
       '@tamagui/core': 1.79.6(react@18.2.0)
-      '@tamagui/floating': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/get-token': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/floating': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-token': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/stacks': 1.79.6(react@18.2.0)
       '@tamagui/use-controllable-state': 1.79.6(react@18.2.0)
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
 
-  '@tamagui/portal@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/portal@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/core': 1.79.6(react@18.2.0)
       '@tamagui/stacks': 1.79.6(react@18.2.0)
       '@tamagui/use-event': 1.79.6(react@18.2.0)
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
 
-  '@tamagui/progress@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/progress@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/compose-refs': 1.79.6(react@18.2.0)
       '@tamagui/core': 1.79.6(react@18.2.0)
       '@tamagui/create-context': 1.79.6(react@18.2.0)
-      '@tamagui/get-token': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/get-token': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/stacks': 1.79.6(react@18.2.0)
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
 
   '@tamagui/proxy-worm@1.79.6': {}
 
-  '@tamagui/radio-group@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/radio-group@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/compose-refs': 1.79.6(react@18.2.0)
       '@tamagui/core': 1.79.6(react@18.2.0)
       '@tamagui/create-context': 1.79.6(react@18.2.0)
       '@tamagui/focusable': 1.79.6(react@18.2.0)
-      '@tamagui/get-token': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/label': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/get-token': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/label': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/stacks': 1.79.6(react@18.2.0)
       '@tamagui/use-controllable-state': 1.79.6(react@18.2.0)
       '@tamagui/use-previous': 1.79.6
@@ -23121,10 +23745,10 @@ snapshots:
     transitivePeerDependencies:
       - react-native
 
-  '@tamagui/react-native-media-driver@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/react-native-media-driver@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/web': 1.79.6(react@18.2.0)
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
     transitivePeerDependencies:
       - react
 
@@ -23162,11 +23786,11 @@ snapshots:
       '@tamagui/web': 1.79.6(react@18.2.0)
       react: 18.2.0
 
-  '@tamagui/select@1.79.6(@types/react@18.3.3)(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/select@1.79.6(@types/react@18.3.3)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@floating-ui/react': 0.24.8(react-dom@18.2.0)(react@18.2.0)
-      '@floating-ui/react-dom': 2.1.1(react-dom@18.2.0)(react@18.2.0)
-      '@floating-ui/react-native': 0.10.6(react-native@0.74.1)(react@18.2.0)
+      '@floating-ui/react': 0.24.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@floating-ui/react-dom': 2.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@floating-ui/react-native': 0.10.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/adapt': 1.79.6(react@18.2.0)
       '@tamagui/animate-presence': 1.79.6(react@18.2.0)
       '@tamagui/compose-refs': 1.79.6(react@18.2.0)
@@ -23174,20 +23798,20 @@ snapshots:
       '@tamagui/create-context': 1.79.6(react@18.2.0)
       '@tamagui/dismissable': 1.79.6(react@18.2.0)
       '@tamagui/focus-scope': 1.79.6(react@18.2.0)
-      '@tamagui/get-token': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/list-item': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/portal': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/get-token': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/list-item': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/portal': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/remove-scroll': 1.79.6(@types/react@18.3.3)(react@18.2.0)
       '@tamagui/separator': 1.79.6(react@18.2.0)
-      '@tamagui/sheet': 1.79.6(@types/react@18.3.3)(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/sheet': 1.79.6(@types/react@18.3.3)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/stacks': 1.79.6(react@18.2.0)
-      '@tamagui/text': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/text': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/use-controllable-state': 1.79.6(react@18.2.0)
       '@tamagui/use-event': 1.79.6(react@18.2.0)
       '@tamagui/use-previous': 1.79.6
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -23202,22 +23826,22 @@ snapshots:
       '@tamagui/web': 1.79.6(react@18.2.0)
       react: 18.2.0
 
-  '@tamagui/sheet@1.79.6(@types/react@18.3.3)(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/sheet@1.79.6(@types/react@18.3.3)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/animate-presence': 1.79.6(react@18.2.0)
-      '@tamagui/animations-react-native': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/animations-react-native': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/compose-refs': 1.79.6(react@18.2.0)
       '@tamagui/core': 1.79.6(react@18.2.0)
       '@tamagui/create-context': 1.79.6(react@18.2.0)
-      '@tamagui/portal': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/portal': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/remove-scroll': 1.79.6(@types/react@18.3.3)(react@18.2.0)
       '@tamagui/scroll-view': 1.79.6(react@18.2.0)
       '@tamagui/stacks': 1.79.6(react@18.2.0)
       '@tamagui/use-constant': 1.79.6(react@18.2.0)
       '@tamagui/use-controllable-state': 1.79.6(react@18.2.0)
-      '@tamagui/use-keyboard-visible': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/use-keyboard-visible': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -23225,25 +23849,25 @@ snapshots:
 
   '@tamagui/simple-hash@1.79.6': {}
 
-  '@tamagui/slider@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/slider@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/compose-refs': 1.79.6(react@18.2.0)
       '@tamagui/core': 1.79.6(react@18.2.0)
       '@tamagui/create-context': 1.79.6(react@18.2.0)
-      '@tamagui/get-token': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/get-token': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/helpers': 1.79.6(react@18.2.0)
       '@tamagui/stacks': 1.79.6(react@18.2.0)
       '@tamagui/use-controllable-state': 1.79.6(react@18.2.0)
       '@tamagui/use-direction': 1.79.6(react@18.2.0)
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
 
   '@tamagui/stacks@1.79.6(react@18.2.0)':
     dependencies:
       '@tamagui/core': 1.79.6(react@18.2.0)
       react: 18.2.0
 
-  '@tamagui/static@1.79.6(react-dom@18.2.0)(react@18.2.0)':
+  '@tamagui/static@1.79.6(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/core': 7.24.5
       '@babel/generator': 7.24.10
@@ -23273,34 +23897,34 @@ snapshots:
       fs-extra: 11.2.0
       invariant: 2.2.4
       lodash: 4.17.21
-      react-native-web: 0.19.12(react-dom@18.2.0)(react@18.2.0)
+      react-native-web: 0.19.12(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-native-web-internals: 1.79.6(react@18.2.0)
-      react-native-web-lite: 1.79.6(react-dom@18.2.0)(react@18.2.0)
+      react-native-web-lite: 1.79.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - encoding
       - react
       - react-dom
       - supports-color
 
-  '@tamagui/switch@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/switch@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/compose-refs': 1.79.6(react@18.2.0)
       '@tamagui/core': 1.79.6(react@18.2.0)
       '@tamagui/create-context': 1.79.6(react@18.2.0)
       '@tamagui/focusable': 1.79.6(react@18.2.0)
-      '@tamagui/get-token': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/label': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/get-token': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/label': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/stacks': 1.79.6(react@18.2.0)
       '@tamagui/use-controllable-state': 1.79.6(react@18.2.0)
       '@tamagui/use-previous': 1.79.6
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
 
-  '@tamagui/tabs@1.79.6(@types/react@18.3.3)(react-dom@18.2.0)(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/tabs@1.79.6(@types/react@18.3.3)(immer@9.0.21)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/create-context': 1.79.6(react@18.2.0)
-      '@tamagui/get-button-sized': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/group': 1.79.6(@types/react@18.3.3)(react@18.2.0)
+      '@tamagui/get-button-sized': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/group': 1.79.6(@types/react@18.3.3)(immer@9.0.21)(react@18.2.0)
       '@tamagui/roving-focus': 1.79.6(react@18.2.0)
       '@tamagui/stacks': 1.79.6(react@18.2.0)
       '@tamagui/use-controllable-state': 1.79.6(react@18.2.0)
@@ -23313,10 +23937,10 @@ snapshots:
       - immer
       - react-native
 
-  '@tamagui/text@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/text@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/get-font-sized': 1.79.6(react@18.2.0)
-      '@tamagui/helpers-tamagui': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/helpers-tamagui': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/web': 1.79.6(react@18.2.0)
       react: 18.2.0
     transitivePeerDependencies:
@@ -23348,14 +23972,14 @@ snapshots:
 
   '@tamagui/timer@1.79.6': {}
 
-  '@tamagui/toggle-group@1.79.6(@types/react@18.3.3)(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/toggle-group@1.79.6(@types/react@18.3.3)(immer@9.0.21)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/create-context': 1.79.6(react@18.2.0)
       '@tamagui/focusable': 1.79.6(react@18.2.0)
       '@tamagui/font-size': 1.79.6(react@18.2.0)
-      '@tamagui/get-token': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/group': 1.79.6(@types/react@18.3.3)(react@18.2.0)
-      '@tamagui/helpers-tamagui': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/get-token': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/group': 1.79.6(@types/react@18.3.3)(immer@9.0.21)(react@18.2.0)
+      '@tamagui/helpers-tamagui': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/roving-focus': 1.79.6(react@18.2.0)
       '@tamagui/stacks': 1.79.6(react@18.2.0)
       '@tamagui/use-controllable-state': 1.79.6(react@18.2.0)
@@ -23367,22 +23991,22 @@ snapshots:
       - immer
       - react-native
 
-  '@tamagui/tooltip@1.79.6(@types/react@18.3.3)(react-dom@18.2.0)(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/tooltip@1.79.6(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@floating-ui/react': 0.24.8(react-dom@18.2.0)(react@18.2.0)
+      '@floating-ui/react': 0.24.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tamagui/compose-refs': 1.79.6(react@18.2.0)
       '@tamagui/core': 1.79.6(react@18.2.0)
       '@tamagui/create-context': 1.79.6(react@18.2.0)
-      '@tamagui/floating': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/get-token': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/floating': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-token': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/polyfill-dev': 1.79.6
-      '@tamagui/popover': 1.79.6(@types/react@18.3.3)(react-dom@18.2.0)(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/popper': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/popover': 1.79.6(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/popper': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/stacks': 1.79.6(react@18.2.0)
-      '@tamagui/text': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/text': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/use-controllable-state': 1.79.6(react@18.2.0)
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - react-dom
@@ -23425,10 +24049,10 @@ snapshots:
     dependencies:
       react: 18.2.0
 
-  '@tamagui/use-keyboard-visible@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/use-keyboard-visible@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
 
   '@tamagui/use-presence@1.79.6(react@18.2.0)':
     dependencies:
@@ -23437,11 +24061,11 @@ snapshots:
 
   '@tamagui/use-previous@1.79.6': {}
 
-  '@tamagui/use-window-dimensions@1.79.6(react-native@0.74.1)(react@18.2.0)':
+  '@tamagui/use-window-dimensions@1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tamagui/constants': 1.79.6(react@18.2.0)
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
 
   '@tamagui/visually-hidden@1.79.6(react@18.2.0)':
     dependencies:
@@ -23471,129 +24095,130 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/react@15.0.7(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)':
+  '@testing-library/react@15.0.7(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.24.8
       '@testing-library/dom': 10.3.2
-      '@types/react': 18.3.3
       '@types/react-dom': 18.3.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.3.3
 
   '@tiptap/core@2.5.4(@tiptap/pm@2.5.4)':
     dependencies:
       '@tiptap/pm': 2.5.4
 
-  '@tiptap/extension-blockquote@2.5.4(@tiptap/core@2.5.4)':
+  '@tiptap/extension-blockquote@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))':
     dependencies:
       '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
 
-  '@tiptap/extension-bold@2.5.4(@tiptap/core@2.5.4)':
+  '@tiptap/extension-bold@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))':
     dependencies:
       '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
 
-  '@tiptap/extension-bubble-menu@2.5.4(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)':
-    dependencies:
-      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
-      '@tiptap/pm': 2.5.4
-      tippy.js: 6.3.7
-
-  '@tiptap/extension-bullet-list@2.5.4(@tiptap/core@2.5.4)':
-    dependencies:
-      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
-
-  '@tiptap/extension-code-block@2.5.4(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)':
-    dependencies:
-      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
-      '@tiptap/pm': 2.5.4
-
-  '@tiptap/extension-code@2.5.4(@tiptap/core@2.5.4)':
-    dependencies:
-      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
-
-  '@tiptap/extension-collaboration-cursor@2.2.2(@tiptap/core@2.5.4)(y-prosemirror@1.0.20)':
-    dependencies:
-      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
-      y-prosemirror: 1.0.20(prosemirror-model@1.22.1)(prosemirror-state@1.4.3)(prosemirror-view@1.33.8)(y-protocols@1.0.6)(yjs@13.6.18)
-
-  '@tiptap/extension-collaboration@2.2.2(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)(y-prosemirror@1.0.20)':
-    dependencies:
-      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
-      '@tiptap/pm': 2.5.4
-      y-prosemirror: 1.0.20(prosemirror-model@1.22.1)(prosemirror-state@1.4.3)(prosemirror-view@1.33.8)(y-protocols@1.0.6)(yjs@13.6.18)
-
-  '@tiptap/extension-document@2.5.4(@tiptap/core@2.5.4)':
-    dependencies:
-      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
-
-  '@tiptap/extension-dropcursor@2.5.4(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)':
-    dependencies:
-      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
-      '@tiptap/pm': 2.5.4
-
-  '@tiptap/extension-floating-menu@2.5.4(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)':
+  '@tiptap/extension-bubble-menu@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)':
     dependencies:
       '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
       '@tiptap/pm': 2.5.4
       tippy.js: 6.3.7
 
-  '@tiptap/extension-gapcursor@2.5.4(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)':
+  '@tiptap/extension-bullet-list@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))':
+    dependencies:
+      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
+
+  '@tiptap/extension-code-block@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)':
     dependencies:
       '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
       '@tiptap/pm': 2.5.4
 
-  '@tiptap/extension-hard-break@2.5.4(@tiptap/core@2.5.4)':
+  '@tiptap/extension-code@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))':
     dependencies:
       '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
 
-  '@tiptap/extension-heading@2.5.4(@tiptap/core@2.5.4)':
+  '@tiptap/extension-collaboration-cursor@2.2.2(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(y-prosemirror@1.0.20(prosemirror-model@1.22.1)(prosemirror-state@1.4.3)(prosemirror-view@1.33.8)(y-protocols@1.0.6(yjs@13.6.18))(yjs@13.6.18))':
+    dependencies:
+      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
+      y-prosemirror: 1.0.20(prosemirror-model@1.22.1)(prosemirror-state@1.4.3)(prosemirror-view@1.33.8)(y-protocols@1.0.6(yjs@13.6.18))(yjs@13.6.18)
+
+  '@tiptap/extension-collaboration@2.2.2(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)(y-prosemirror@1.0.20(prosemirror-model@1.22.1)(prosemirror-state@1.4.3)(prosemirror-view@1.33.8)(y-protocols@1.0.6(yjs@13.6.18))(yjs@13.6.18))':
+    dependencies:
+      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
+      '@tiptap/pm': 2.5.4
+      y-prosemirror: 1.0.20(prosemirror-model@1.22.1)(prosemirror-state@1.4.3)(prosemirror-view@1.33.8)(y-protocols@1.0.6(yjs@13.6.18))(yjs@13.6.18)
+
+  '@tiptap/extension-document@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))':
     dependencies:
       '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
 
-  '@tiptap/extension-highlight@2.2.2(@tiptap/core@2.5.4)':
-    dependencies:
-      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
-
-  '@tiptap/extension-history@2.5.4(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)':
+  '@tiptap/extension-dropcursor@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)':
     dependencies:
       '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
       '@tiptap/pm': 2.5.4
 
-  '@tiptap/extension-horizontal-rule@2.5.4(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)':
+  '@tiptap/extension-floating-menu@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)':
+    dependencies:
+      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
+      '@tiptap/pm': 2.5.4
+      tippy.js: 6.3.7
+
+  '@tiptap/extension-gapcursor@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)':
     dependencies:
       '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
       '@tiptap/pm': 2.5.4
 
-  '@tiptap/extension-italic@2.5.4(@tiptap/core@2.5.4)':
+  '@tiptap/extension-hard-break@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))':
     dependencies:
       '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
 
-  '@tiptap/extension-list-item@2.5.4(@tiptap/core@2.5.4)':
+  '@tiptap/extension-heading@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))':
     dependencies:
       '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
 
-  '@tiptap/extension-ordered-list@2.5.4(@tiptap/core@2.5.4)':
+  '@tiptap/extension-highlight@2.2.2(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))':
     dependencies:
       '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
 
-  '@tiptap/extension-paragraph@2.5.4(@tiptap/core@2.5.4)':
-    dependencies:
-      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
-
-  '@tiptap/extension-strike@2.5.4(@tiptap/core@2.5.4)':
-    dependencies:
-      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
-
-  '@tiptap/extension-task-item@2.2.2(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)':
+  '@tiptap/extension-history@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)':
     dependencies:
       '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
       '@tiptap/pm': 2.5.4
 
-  '@tiptap/extension-task-list@2.2.2(@tiptap/core@2.5.4)':
+  '@tiptap/extension-horizontal-rule@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)':
+    dependencies:
+      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
+      '@tiptap/pm': 2.5.4
+
+  '@tiptap/extension-italic@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))':
     dependencies:
       '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
 
-  '@tiptap/extension-text@2.5.4(@tiptap/core@2.5.4)':
+  '@tiptap/extension-list-item@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))':
+    dependencies:
+      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
+
+  '@tiptap/extension-ordered-list@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))':
+    dependencies:
+      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
+
+  '@tiptap/extension-paragraph@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))':
+    dependencies:
+      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
+
+  '@tiptap/extension-strike@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))':
+    dependencies:
+      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
+
+  '@tiptap/extension-task-item@2.2.2(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)':
+    dependencies:
+      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
+      '@tiptap/pm': 2.5.4
+
+  '@tiptap/extension-task-list@2.2.2(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))':
+    dependencies:
+      '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
+
+  '@tiptap/extension-text@2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))':
     dependencies:
       '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
 
@@ -23618,11 +24243,11 @@ snapshots:
       prosemirror-transform: 1.9.0
       prosemirror-view: 1.33.8
 
-  '@tiptap/react@2.2.2(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)(react-dom@18.2.0)(react@18.2.0)':
+  '@tiptap/react@2.2.2(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
-      '@tiptap/extension-bubble-menu': 2.5.4(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)
-      '@tiptap/extension-floating-menu': 2.5.4(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)
+      '@tiptap/extension-bubble-menu': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)
+      '@tiptap/extension-floating-menu': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)
       '@tiptap/pm': 2.5.4
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -23630,24 +24255,24 @@ snapshots:
   '@tiptap/starter-kit@2.2.2(@tiptap/pm@2.5.4)':
     dependencies:
       '@tiptap/core': 2.5.4(@tiptap/pm@2.5.4)
-      '@tiptap/extension-blockquote': 2.5.4(@tiptap/core@2.5.4)
-      '@tiptap/extension-bold': 2.5.4(@tiptap/core@2.5.4)
-      '@tiptap/extension-bullet-list': 2.5.4(@tiptap/core@2.5.4)
-      '@tiptap/extension-code': 2.5.4(@tiptap/core@2.5.4)
-      '@tiptap/extension-code-block': 2.5.4(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)
-      '@tiptap/extension-document': 2.5.4(@tiptap/core@2.5.4)
-      '@tiptap/extension-dropcursor': 2.5.4(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)
-      '@tiptap/extension-gapcursor': 2.5.4(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)
-      '@tiptap/extension-hard-break': 2.5.4(@tiptap/core@2.5.4)
-      '@tiptap/extension-heading': 2.5.4(@tiptap/core@2.5.4)
-      '@tiptap/extension-history': 2.5.4(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)
-      '@tiptap/extension-horizontal-rule': 2.5.4(@tiptap/core@2.5.4)(@tiptap/pm@2.5.4)
-      '@tiptap/extension-italic': 2.5.4(@tiptap/core@2.5.4)
-      '@tiptap/extension-list-item': 2.5.4(@tiptap/core@2.5.4)
-      '@tiptap/extension-ordered-list': 2.5.4(@tiptap/core@2.5.4)
-      '@tiptap/extension-paragraph': 2.5.4(@tiptap/core@2.5.4)
-      '@tiptap/extension-strike': 2.5.4(@tiptap/core@2.5.4)
-      '@tiptap/extension-text': 2.5.4(@tiptap/core@2.5.4)
+      '@tiptap/extension-blockquote': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))
+      '@tiptap/extension-bold': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))
+      '@tiptap/extension-bullet-list': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))
+      '@tiptap/extension-code': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))
+      '@tiptap/extension-code-block': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)
+      '@tiptap/extension-document': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))
+      '@tiptap/extension-dropcursor': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)
+      '@tiptap/extension-gapcursor': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)
+      '@tiptap/extension-hard-break': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))
+      '@tiptap/extension-heading': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))
+      '@tiptap/extension-history': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)
+      '@tiptap/extension-horizontal-rule': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))(@tiptap/pm@2.5.4)
+      '@tiptap/extension-italic': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))
+      '@tiptap/extension-list-item': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))
+      '@tiptap/extension-ordered-list': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))
+      '@tiptap/extension-paragraph': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))
+      '@tiptap/extension-strike': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))
+      '@tiptap/extension-text': 2.5.4(@tiptap/core@2.5.4(@tiptap/pm@2.5.4))
     transitivePeerDependencies:
       - '@tiptap/pm'
 
@@ -23901,11 +24526,11 @@ snapshots:
     dependencies:
       '@types/react': 18.3.3
 
-  '@types/react-native-table-component@1.2.8(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(react@18.2.0)':
+  '@types/react-native-table-component@1.2.8(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)(react@18.2.0)':
     dependencies:
       '@types/react': 18.2.79
       csstype: 3.1.3
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
@@ -24006,7 +24631,7 @@ snapshots:
     dependencies:
       vue: 2.7.16
 
-  '@types/webpack@5.28.5(webpack-cli@5.1.4)':
+  '@types/webpack@5.28.5(webpack-cli@5.1.4(webpack@5.93.0))':
     dependencies:
       '@types/node': 20.14.11
       tapable: 2.2.1
@@ -24048,7 +24673,7 @@ snapshots:
       '@types/node': 20.14.11
     optional: true
 
-  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.55.0)(typescript@5.3.3)':
+  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.3.3))(eslint@8.55.0)(typescript@5.3.3)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
       '@typescript-eslint/parser': 6.21.0(eslint@8.55.0)(typescript@5.3.3)
@@ -24063,6 +24688,7 @@ snapshots:
       natural-compare: 1.4.0
       semver: 7.6.3
       ts-api-utils: 1.3.0(typescript@5.3.3)
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -24075,6 +24701,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.3.5(supports-color@8.1.1)
       eslint: 8.55.0
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -24087,6 +24714,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.3.5(supports-color@8.1.1)
       eslint: 8.57.0
+    optionalDependencies:
       typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
@@ -24103,6 +24731,7 @@ snapshots:
       debug: 4.3.5(supports-color@8.1.1)
       eslint: 8.55.0
       ts-api-utils: 1.3.0(typescript@5.3.3)
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -24119,6 +24748,7 @@ snapshots:
       minimatch: 9.0.3
       semver: 7.6.3
       ts-api-utils: 1.3.0(typescript@5.3.3)
+    optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
@@ -24133,6 +24763,7 @@ snapshots:
       minimatch: 9.0.3
       semver: 7.6.3
       ts-api-utils: 1.3.0(typescript@5.5.3)
+    optionalDependencies:
       typescript: 5.5.3
     transitivePeerDependencies:
       - supports-color
@@ -24184,32 +24815,33 @@ snapshots:
     transitivePeerDependencies:
       - graphql
 
-  '@vitejs/plugin-basic-ssl@1.1.0(vite@5.3.2)':
+  '@vitejs/plugin-basic-ssl@1.1.0(vite@5.3.2(@types/node@20.14.11)(less@4.2.0)(sass@1.77.6)(terser@5.29.2))':
     dependencies:
       vite: 5.3.2(@types/node@20.14.11)(less@4.2.0)(sass@1.77.6)(terser@5.29.2)
 
-  '@vitejs/plugin-react@4.3.1(vite@5.3.4)':
+  '@vitejs/plugin-react@4.3.1(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))':
     dependencies:
       '@babel/core': 7.24.5
       '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.24.5)
       '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.24.5)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.3.4(@types/node@20.14.11)
+      vite: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.0.5(vite@5.3.4)(vue@3.4.21)':
+  '@vitejs/plugin-vue@5.0.5(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))(vue@3.4.21(typescript@5.5.3))':
     dependencies:
-      vite: 5.3.4(sass@1.77.8)
+      vite: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
       vue: 3.4.21(typescript@5.5.3)
 
-  '@vitest/browser@1.6.0(vitest@1.6.0)(webdriverio@8.39.1)':
+  '@vitest/browser@1.6.0(vitest@1.6.0)(webdriverio@8.39.1(typescript@5.5.3))':
     dependencies:
       '@vitest/utils': 1.6.0
       magic-string: 0.30.10
       sirv: 2.0.4
-      vitest: 1.6.0(@types/node@20.14.11)(@vitest/browser@1.6.0)
+      vitest: 1.6.0(@types/node@20.14.11)(@vitest/browser@1.6.0)(jsdom@24.1.0)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
+    optionalDependencies:
       webdriverio: 8.39.1(typescript@5.5.3)
 
   '@vitest/expect@1.6.0':
@@ -24332,8 +24964,9 @@ snapshots:
       minimatch: 9.0.5
       muggle-string: 0.4.1
       path-browserify: 1.0.1
-      typescript: 5.5.3
       vue-template-compiler: 2.7.16
+    optionalDependencies:
+      typescript: 5.5.3
 
   '@vue/reactivity@3.4.21':
     dependencies:
@@ -24350,7 +24983,7 @@ snapshots:
       '@vue/shared': 3.4.21
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.4.21(vue@3.4.21)':
+  '@vue/server-renderer@3.4.21(vue@3.4.21(typescript@5.5.3))':
     dependencies:
       '@vue/compiler-ssr': 3.4.21
       '@vue/shared': 3.4.21
@@ -24360,21 +24993,21 @@ snapshots:
 
   '@vue/shared@3.4.32': {}
 
-  '@vuelidate/core@2.0.3(vue@3.4.21)':
+  '@vuelidate/core@2.0.3(vue@3.4.21(typescript@5.5.3))':
     dependencies:
       vue: 3.4.21(typescript@5.5.3)
-      vue-demi: 0.13.11(vue@3.4.21)
+      vue-demi: 0.13.11(vue@3.4.21(typescript@5.5.3))
 
-  '@vuelidate/validators@2.0.4(vue@3.4.21)':
+  '@vuelidate/validators@2.0.4(vue@3.4.21(typescript@5.5.3))':
     dependencies:
       vue: 3.4.21(typescript@5.5.3)
-      vue-demi: 0.13.11(vue@3.4.21)
+      vue-demi: 0.13.11(vue@3.4.21(typescript@5.5.3))
 
-  '@vuetify/loader-shared@2.0.3(vue@3.4.21)(vuetify@3.6.8)':
+  '@vuetify/loader-shared@2.0.3(vue@3.4.21(typescript@5.5.3))(vuetify@3.6.8(typescript@5.5.3)(vite-plugin-vuetify@2.0.3)(vue@3.4.21(typescript@5.5.3)))':
     dependencies:
       upath: 2.0.1
       vue: 3.4.21(typescript@5.5.3)
-      vuetify: 3.6.8(typescript@5.5.3)(vite-plugin-vuetify@2.0.3)(vue@3.4.21)
+      vuetify: 3.6.8(typescript@5.5.3)(vite-plugin-vuetify@2.0.3)(vue@3.4.21(typescript@5.5.3))
 
   '@wdio/config@8.39.0':
     dependencies:
@@ -24505,17 +25138,17 @@ snapshots:
     dependencies:
       commander: 10.0.1
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.93.0)':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.93.0(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.93.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.93.0)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.93.0)':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.93.0(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.93.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.93.0)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.93.0)':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.93.0(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.93.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.93.0)
@@ -24593,15 +25226,15 @@ snapshots:
       indent-string: 4.0.0
 
   ajv-formats@2.1.1(ajv@8.11.0):
-    dependencies:
+    optionalDependencies:
       ajv: 8.11.0
 
   ajv-formats@2.1.1(ajv@8.17.1):
-    dependencies:
+    optionalDependencies:
       ajv: 8.17.1
 
   ajv-formats@3.0.1(ajv@8.16.0):
-    dependencies:
+    optionalDependencies:
       ajv: 8.16.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
@@ -24972,19 +25605,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-loader@9.1.3(@babel/core@7.24.5)(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5))):
+    dependencies:
+      '@babel/core': 7.24.5
+      find-cache-dir: 4.0.0
+      schema-utils: 4.2.0
+      webpack: 5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5))
+
   babel-loader@9.1.3(@babel/core@7.24.5)(webpack@5.93.0):
     dependencies:
       '@babel/core': 7.24.5
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.93.0(@swc/core@1.6.13)
+      webpack: 5.93.0
 
-  babel-loader@9.1.3(@babel/core@7.24.7)(webpack@5.92.1):
+  babel-loader@9.1.3(@babel/core@7.24.7)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)):
     dependencies:
       '@babel/core': 7.24.7
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.92.1(esbuild@0.21.5)
+      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)
+
+  babel-loader@9.1.3(@babel/core@7.24.7)(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5))):
+    dependencies:
+      '@babel/core': 7.24.7
+      find-cache-dir: 4.0.0
+      schema-utils: 4.2.0
+      webpack: 5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5))
+
+  babel-loader@9.1.3(@babel/core@7.24.7)(webpack@5.93.0):
+    dependencies:
+      '@babel/core': 7.24.7
+      find-cache-dir: 4.0.0
+      schema-utils: 4.2.0
+      webpack: 5.93.0
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -25064,7 +25718,13 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
 
-  babel-preset-expo@11.0.12(@babel/core@7.24.5)(@babel/preset-env@7.24.8):
+  babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.24.7):
+    dependencies:
+      '@babel/plugin-syntax-flow': 7.24.7(@babel/core@7.24.7)
+    transitivePeerDependencies:
+      - '@babel/core'
+
+  babel-preset-expo@11.0.12(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5)):
     dependencies:
       '@babel/plugin-proposal-decorators': 7.24.7(@babel/core@7.24.5)
       '@babel/plugin-transform-export-namespace-from': 7.24.7(@babel/core@7.24.5)
@@ -25072,7 +25732,24 @@ snapshots:
       '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.5)
       '@babel/preset-react': 7.24.7(@babel/core@7.24.5)
       '@babel/preset-typescript': 7.24.7(@babel/core@7.24.5)
-      '@react-native/babel-preset': 0.74.85(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+      '@react-native/babel-preset': 0.74.85(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))
+      babel-plugin-react-compiler: 0.0.0-experimental-696af53-20240625
+      babel-plugin-react-native-web: 0.19.12
+      react-refresh: 0.14.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - supports-color
+
+  babel-preset-expo@11.0.12(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7)):
+    dependencies:
+      '@babel/plugin-proposal-decorators': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-export-namespace-from': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-object-rest-spread': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.7)
+      '@babel/preset-react': 7.24.7(@babel/core@7.24.7)
+      '@babel/preset-typescript': 7.24.7(@babel/core@7.24.7)
+      '@react-native/babel-preset': 0.74.85(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))
       babel-plugin-react-compiler: 0.0.0-experimental-696af53-20240625
       babel-plugin-react-native-web: 0.19.12
       react-refresh: 0.14.2
@@ -25831,9 +26508,9 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0
 
-  copy-webpack-plugin@12.0.2(webpack@5.92.1):
+  copy-webpack-plugin@12.0.2(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -25841,7 +26518,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.92.1(esbuild@0.21.5)
+      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)
 
   core-js-compat@3.37.1:
     dependencies:
@@ -25884,6 +26561,7 @@ snapshots:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
+    optionalDependencies:
       typescript: 5.4.5
 
   cosmiconfig@9.0.0(typescript@5.5.3):
@@ -25892,6 +26570,7 @@ snapshots:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
+    optionalDependencies:
       typescript: 5.5.3
 
   crc-32@1.2.2: {}
@@ -25917,15 +26596,15 @@ snapshots:
 
   cross-dirname@0.1.0: {}
 
-  cross-fetch@3.1.8:
+  cross-fetch@3.1.8(encoding@0.1.13):
     dependencies:
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
-  cross-fetch@4.0.0:
+  cross-fetch@4.0.0(encoding@0.1.13):
     dependencies:
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
@@ -25979,9 +26658,10 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.4.39)
       postcss-value-parser: 4.2.0
       semver: 7.6.3
-      webpack: 5.93.0(webpack-cli@5.1.4)
+    optionalDependencies:
+      webpack: 5.93.0
 
-  css-loader@7.1.2(webpack@5.92.1):
+  css-loader@7.1.2(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
@@ -25991,18 +26671,20 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
       semver: 7.6.2
-      webpack: 5.92.1(esbuild@0.21.5)
+    optionalDependencies:
+      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)
 
   css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.93.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      clean-css: 5.3.3
       cssnano: 6.1.2(postcss@8.4.39)
       jest-worker: 29.7.0
       postcss: 8.4.39
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0
+    optionalDependencies:
+      clean-css: 5.3.3
 
   css-select@4.3.0:
     dependencies:
@@ -26333,6 +27015,7 @@ snapshots:
   debug@4.3.5(supports-color@8.1.1):
     dependencies:
       ms: 2.1.2
+    optionalDependencies:
       supports-color: 8.1.1
 
   decamelize-keys@1.1.1:
@@ -26539,9 +27222,9 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  docusaurus-plugin-typedoc@1.0.3(typedoc-plugin-markdown@4.0.3):
+  docusaurus-plugin-typedoc@1.0.3(typedoc-plugin-markdown@4.0.3(typedoc@0.25.13(typescript@5.4.5))):
     dependencies:
-      typedoc-plugin-markdown: 4.0.3(typedoc@0.25.13)
+      typedoc-plugin-markdown: 4.0.3(typedoc@0.25.13(typescript@5.4.5))
 
   dom-accessibility-api@0.5.16: {}
 
@@ -26614,7 +27297,7 @@ snapshots:
 
   duplexer@0.1.2: {}
 
-  eas-cli@7.8.5(@types/node@20.14.11)(expo-modules-autolinking@1.11.1)(typescript@5.3.3):
+  eas-cli@7.8.5(@swc/core@1.6.13)(@types/node@20.14.11)(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(typescript@5.3.3):
     dependencies:
       '@expo/apple-utils': 1.7.0
       '@expo/code-signing-certificates': 0.0.5
@@ -26630,16 +27313,16 @@ snapshots:
       '@expo/package-manager': 1.1.2
       '@expo/pkcs12': 0.0.8
       '@expo/plist': 0.0.20
-      '@expo/plugin-help': 5.1.23(@types/node@20.14.11)(typescript@5.3.3)
-      '@expo/plugin-warn-if-update-available': 2.5.1(@types/node@20.14.11)(typescript@5.3.3)
-      '@expo/prebuild-config': 6.7.3(expo-modules-autolinking@1.11.1)
+      '@expo/plugin-help': 5.1.23(@swc/core@1.6.13)(@types/node@20.14.11)(typescript@5.3.3)
+      '@expo/plugin-warn-if-update-available': 2.5.1(@swc/core@1.6.13)(@types/node@20.14.11)(typescript@5.3.3)
+      '@expo/prebuild-config': 6.7.3(encoding@0.1.13)(expo-modules-autolinking@1.11.1)
       '@expo/results': 1.0.0
-      '@expo/rudder-sdk-node': 1.1.1
+      '@expo/rudder-sdk-node': 1.1.1(encoding@0.1.13)
       '@expo/spawn-async': 1.7.0
       '@expo/steps': 1.0.95
       '@expo/timeago.js': 1.0.0
       '@oclif/core': 1.26.2
-      '@oclif/plugin-autocomplete': 2.3.10(@types/node@20.14.11)(typescript@5.3.3)
+      '@oclif/plugin-autocomplete': 2.3.10(@swc/core@1.6.13)(@types/node@20.14.11)(typescript@5.3.3)
       '@segment/ajv-human-errors': 2.13.0(ajv@8.11.0)
       '@urql/core': 4.0.11(graphql@16.8.1)
       '@urql/exchange-retry': 1.2.0(graphql@16.8.1)
@@ -26672,7 +27355,7 @@ snapshots:
       mime: 3.0.0
       minimatch: 5.1.2
       nanoid: 3.3.4
-      node-fetch: 2.6.7
+      node-fetch: 2.6.7(encoding@0.1.13)
       node-forge: 1.3.1
       nullthrows: 1.1.1
       ora: 5.1.0
@@ -27074,11 +27757,12 @@ snapshots:
       '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.57.0)
       eslint-plugin-react: 7.34.4(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
+    optionalDependencies:
       typescript: 5.5.3
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
@@ -27088,17 +27772,18 @@ snapshots:
     dependencies:
       eslint: 8.55.0
 
-  eslint-config-universe@12.0.0(eslint@8.55.0)(prettier@3.3.3)(typescript@5.3.3):
+  eslint-config-universe@12.0.0(@types/eslint@8.56.10)(eslint@8.55.0)(prettier@3.3.3)(typescript@5.3.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.55.0)(typescript@5.3.3)
+      '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.3.3))(eslint@8.55.0)(typescript@5.3.3)
       '@typescript-eslint/parser': 6.21.0(eslint@8.55.0)(typescript@5.3.3)
       eslint: 8.55.0
       eslint-config-prettier: 8.10.0(eslint@8.55.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0)(eslint@8.55.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.3.3))(eslint@8.55.0)
       eslint-plugin-node: 11.1.0(eslint@8.55.0)
-      eslint-plugin-prettier: 5.2.1(eslint-config-prettier@8.10.0)(eslint@8.55.0)(prettier@3.3.3)
+      eslint-plugin-prettier: 5.2.1(@types/eslint@8.56.10)(eslint-config-prettier@8.10.0(eslint@8.55.0))(eslint@8.55.0)(prettier@3.3.3)
       eslint-plugin-react: 7.34.4(eslint@8.55.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.55.0)
+    optionalDependencies:
       prettier: 3.3.3
     transitivePeerDependencies:
       - '@types/eslint'
@@ -27115,13 +27800,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 4.3.5(supports-color@8.1.1)
       enhanced-resolve: 5.17.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.15.0
@@ -27132,22 +27817,24 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint@8.55.0):
     dependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
       debug: 3.2.7
-      eslint: 8.57.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@8.55.0)(typescript@5.3.3)
+      eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint@8.55.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.55.0)(typescript@5.3.3)
       debug: 3.2.7
-      eslint: 8.55.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
+      eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -27157,35 +27844,8 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.3.3))(eslint@8.55.0):
     dependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
-      array-includes: 3.1.8
-      array.prototype.findlastindex: 1.2.5
-      array.prototype.flat: 1.3.2
-      array.prototype.flatmap: 1.3.2
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 8.57.0
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
-      hasown: 2.0.2
-      is-core-module: 2.15.0
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.0
-      semver: 6.3.1
-      tsconfig-paths: 3.15.0
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0)(eslint@8.55.0):
-    dependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.55.0)(typescript@5.3.3)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.2
@@ -27194,7 +27854,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.55.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint@8.55.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.55.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint@8.55.0)
       hasown: 2.0.2
       is-core-module: 2.15.0
       is-glob: 4.0.3
@@ -27204,6 +27864,35 @@ snapshots:
       object.values: 1.2.0
       semver: 6.3.1
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@8.55.0)(typescript@5.3.3)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+    dependencies:
+      array-includes: 3.1.8
+      array.prototype.findlastindex: 1.2.5
+      array.prototype.flat: 1.3.2
+      array.prototype.flatmap: 1.3.2
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.57.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      hasown: 2.0.2
+      is-core-module: 2.15.0
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.0
+      semver: 6.3.1
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.5.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -27239,13 +27928,15 @@ snapshots:
       resolve: 1.22.8
       semver: 6.3.1
 
-  eslint-plugin-prettier@5.2.1(eslint-config-prettier@8.10.0)(eslint@8.55.0)(prettier@3.3.3):
+  eslint-plugin-prettier@5.2.1(@types/eslint@8.56.10)(eslint-config-prettier@8.10.0(eslint@8.55.0))(eslint@8.55.0)(prettier@3.3.3):
     dependencies:
       eslint: 8.55.0
-      eslint-config-prettier: 8.10.0(eslint@8.55.0)
       prettier: 3.3.3
       prettier-linter-helpers: 1.0.0
       synckit: 0.9.1
+    optionalDependencies:
+      '@types/eslint': 8.56.10
+      eslint-config-prettier: 8.10.0(eslint@8.55.0)
 
   eslint-plugin-react-hooks@4.6.2(eslint@8.55.0):
     dependencies:
@@ -27522,98 +28213,142 @@ snapshots:
     dependencies:
       homedir-polyfill: 1.0.3
 
-  expo-asset@10.0.10(expo@51.0.21):
+  expo-asset@10.0.10(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)):
     dependencies:
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
-      expo-constants: 16.0.2(expo@51.0.21)
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
+      expo-constants: 16.0.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       invariant: 2.2.4
       md5-file: 3.2.3
     transitivePeerDependencies:
       - supports-color
 
-  expo-build-properties@0.12.3(expo@51.0.21):
+  expo-asset@10.0.10(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)):
+    dependencies:
+      expo: 51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)
+      expo-constants: 16.0.2(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13))
+      invariant: 2.2.4
+      md5-file: 3.2.3
+    transitivePeerDependencies:
+      - supports-color
+
+  expo-build-properties@0.12.3(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)):
     dependencies:
       ajv: 8.17.1
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
       semver: 7.6.3
 
-  expo-camera@15.0.14(expo@51.0.21):
+  expo-build-properties@0.12.3(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)):
     dependencies:
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+      ajv: 8.17.1
+      expo: 51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)
+      semver: 7.6.3
+
+  expo-camera@15.0.14(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)):
+    dependencies:
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
       invariant: 2.2.4
 
-  expo-constants@16.0.2(expo@51.0.21):
+  expo-constants@16.0.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)):
     dependencies:
       '@expo/config': 9.0.3
       '@expo/env': 0.3.0
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
     transitivePeerDependencies:
       - supports-color
 
-  expo-crypto@13.0.2(expo@51.0.21):
+  expo-constants@16.0.2(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)):
+    dependencies:
+      '@expo/config': 9.0.3
+      '@expo/env': 0.3.0
+      expo: 51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)
+    transitivePeerDependencies:
+      - supports-color
+
+  expo-crypto@13.0.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)):
     dependencies:
       base64-js: 1.5.1
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
 
-  expo-dev-client@4.0.20(expo@51.0.21):
+  expo-dev-client@4.0.20(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)):
     dependencies:
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
-      expo-dev-launcher: 4.0.22(expo@51.0.21)
-      expo-dev-menu: 5.0.16(expo@51.0.21)
-      expo-dev-menu-interface: 1.8.3(expo@51.0.21)
-      expo-manifests: 0.14.3(expo@51.0.21)
-      expo-updates-interface: 0.16.2(expo@51.0.21)
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
+      expo-dev-launcher: 4.0.22(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
+      expo-dev-menu: 5.0.16(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
+      expo-dev-menu-interface: 1.8.3(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
+      expo-manifests: 0.14.3(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
+      expo-updates-interface: 0.16.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
     transitivePeerDependencies:
       - supports-color
 
-  expo-dev-launcher@4.0.22(expo@51.0.21):
+  expo-dev-launcher@4.0.22(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)):
     dependencies:
       ajv: 8.11.0
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
-      expo-dev-menu: 5.0.16(expo@51.0.21)
-      expo-manifests: 0.14.3(expo@51.0.21)
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
+      expo-dev-menu: 5.0.16(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
+      expo-manifests: 0.14.3(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       resolve-from: 5.0.0
       semver: 7.6.3
     transitivePeerDependencies:
       - supports-color
 
-  expo-dev-menu-interface@1.8.3(expo@51.0.21):
+  expo-dev-menu-interface@1.8.3(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)):
     dependencies:
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
 
-  expo-dev-menu@5.0.16(expo@51.0.21):
+  expo-dev-menu@5.0.16(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)):
     dependencies:
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
-      expo-dev-menu-interface: 1.8.3(expo@51.0.21)
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
+      expo-dev-menu-interface: 1.8.3(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       semver: 7.6.3
 
-  expo-file-system@17.0.1(expo@51.0.21):
+  expo-file-system@17.0.1(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)):
     dependencies:
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
 
-  expo-font@12.0.9(expo@51.0.21):
+  expo-file-system@17.0.1(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)):
     dependencies:
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+      expo: 51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)
+
+  expo-font@12.0.9(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)):
+    dependencies:
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
+      fontfaceobserver: 2.3.0
+
+  expo-font@12.0.9(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)):
+    dependencies:
+      expo: 51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)
       fontfaceobserver: 2.3.0
 
   expo-json-utils@0.13.1: {}
 
-  expo-keep-awake@13.0.2(expo@51.0.21):
+  expo-keep-awake@13.0.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)):
     dependencies:
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
 
-  expo-linking@6.3.1(expo@51.0.21):
+  expo-keep-awake@13.0.2(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)):
     dependencies:
-      expo-constants: 16.0.2(expo@51.0.21)
+      expo: 51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)
+
+  expo-linking@6.3.1(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)):
+    dependencies:
+      expo-constants: 16.0.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       invariant: 2.2.4
     transitivePeerDependencies:
       - expo
       - supports-color
 
-  expo-manifests@0.14.3(expo@51.0.21):
+  expo-linking@6.3.1(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)):
+    dependencies:
+      expo-constants: 16.0.2(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13))
+      invariant: 2.2.4
+    transitivePeerDependencies:
+      - expo
+      - supports-color
+
+  expo-manifests@0.14.3(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)):
     dependencies:
       '@expo/config': 9.0.3
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
       expo-json-utils: 0.13.1
     transitivePeerDependencies:
       - supports-color
@@ -27630,25 +28365,26 @@ snapshots:
     dependencies:
       invariant: 2.2.4
 
-  expo-router@3.5.15(@react-navigation/drawer@6.7.2)(expo-constants@16.0.2)(expo-linking@6.3.1)(expo-modules-autolinking@1.11.1)(expo-status-bar@1.12.1)(expo@51.0.21)(react-native-reanimated@3.10.1)(react-native-safe-area-context@4.10.1)(react-native-screens@3.31.1)(react-native@0.74.1)(react@18.2.0)(typescript@5.5.3):
-    dependencies:
-      '@expo/metro-runtime': 3.2.1(react-native@0.74.1)
+  ? expo-router@3.5.15(@react-navigation/drawer@6.7.2(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(encoding@0.1.13)(expo-constants@16.0.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)))(expo-linking@6.3.1(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)))(expo-modules-autolinking@1.11.1)(expo-status-bar@1.12.1)(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)(typescript@5.5.3)
+  : dependencies:
+      '@expo/metro-runtime': 3.2.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))
       '@expo/server': 0.4.4(typescript@5.5.3)
       '@radix-ui/react-slot': 1.0.1(react@18.2.0)
-      '@react-navigation/bottom-tabs': 6.5.20(@react-navigation/native@6.1.18)(react-native-safe-area-context@4.10.1)(react-native-screens@3.31.1)(react-native@0.74.1)(react@18.2.0)
-      '@react-navigation/drawer': 6.7.2(@react-navigation/native@6.1.18)(react-native-gesture-handler@2.16.2)(react-native-reanimated@3.10.1)(react-native-safe-area-context@4.10.1)(react-native-screens@3.31.1)(react-native@0.74.1)(react@18.2.0)
-      '@react-navigation/native': 6.1.18(react-native@0.74.1)(react@18.2.0)
-      '@react-navigation/native-stack': 6.9.26(@react-navigation/native@6.1.18)(react-native-safe-area-context@4.10.1)(react-native-screens@3.31.1)(react-native@0.74.1)(react@18.2.0)
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
-      expo-constants: 16.0.2(expo@51.0.21)
-      expo-linking: 6.3.1(expo@51.0.21)
-      expo-splash-screen: 0.27.4(expo-modules-autolinking@1.11.1)(expo@51.0.21)
+      '@react-navigation/bottom-tabs': 6.5.20(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native': 6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native-stack': 6.9.26(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
+      expo-constants: 16.0.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
+      expo-linking: 6.3.1(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
+      expo-splash-screen: 0.27.4(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       expo-status-bar: 1.12.1
       react-native-helmet-async: 2.0.4(react@18.2.0)
-      react-native-reanimated: 3.10.1(@babel/core@7.24.5)(react-native@0.74.1)(react@18.2.0)
-      react-native-safe-area-context: 4.10.1(react-native@0.74.1)(react@18.2.0)
-      react-native-screens: 3.31.1(react-native@0.74.1)(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       schema-utils: 4.2.0
+    optionalDependencies:
+      '@react-navigation/drawer': 6.7.2(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-reanimated: 3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - encoding
       - expo-modules-autolinking
@@ -27657,24 +28393,26 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-router@3.5.15(expo-constants@16.0.2)(expo-linking@6.3.1)(expo-modules-autolinking@1.11.1)(expo-status-bar@1.12.1)(expo@51.0.21)(react-native-reanimated@3.10.1)(react-native-safe-area-context@4.10.1)(react-native-screens@3.31.1)(react-native@0.74.1)(react@18.2.0)(typescript@5.3.3):
-    dependencies:
-      '@expo/metro-runtime': 3.2.1(react-native@0.74.1)
+  ? expo-router@3.5.15(@react-navigation/drawer@6.7.2(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(encoding@0.1.13)(expo-constants@16.0.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)))(expo-linking@6.3.1(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)))(expo-modules-autolinking@1.11.1)(expo-status-bar@1.12.1)(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+  : dependencies:
+      '@expo/metro-runtime': 3.2.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))
       '@expo/server': 0.4.4(typescript@5.3.3)
       '@radix-ui/react-slot': 1.0.1(react@18.2.0)
-      '@react-navigation/bottom-tabs': 6.5.20(@react-navigation/native@6.1.18)(react-native-safe-area-context@4.10.1)(react-native-screens@3.31.1)(react-native@0.74.1)(react@18.2.0)
-      '@react-navigation/native': 6.1.18(react-native@0.74.1)(react@18.2.0)
-      '@react-navigation/native-stack': 6.9.26(@react-navigation/native@6.1.18)(react-native-safe-area-context@4.10.1)(react-native-screens@3.31.1)(react-native@0.74.1)(react@18.2.0)
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
-      expo-constants: 16.0.2(expo@51.0.21)
-      expo-linking: 6.3.1(expo@51.0.21)
-      expo-splash-screen: 0.27.4(expo-modules-autolinking@1.11.1)(expo@51.0.21)
+      '@react-navigation/bottom-tabs': 6.5.20(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native': 6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native-stack': 6.9.26(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
+      expo-constants: 16.0.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
+      expo-linking: 6.3.1(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
+      expo-splash-screen: 0.27.4(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       expo-status-bar: 1.12.1
       react-native-helmet-async: 2.0.4(react@18.2.0)
-      react-native-reanimated: 3.10.1(@babel/core@7.24.5)(react-native@0.74.1)(react@18.2.0)
-      react-native-safe-area-context: 4.10.1(react-native@0.74.1)(react@18.2.0)
-      react-native-screens: 3.31.1(react-native@0.74.1)(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       schema-utils: 4.2.0
+    optionalDependencies:
+      '@react-navigation/drawer': 6.7.2(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-reanimated: 3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - encoding
       - expo-modules-autolinking
@@ -27683,23 +28421,69 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-secure-store@13.0.2(expo@51.0.21):
-    dependencies:
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+  ? expo-router@3.5.15(@react-navigation/drawer@6.7.2(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.7)(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(encoding@0.1.13)(expo-constants@16.0.2(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)))(expo-linking@6.3.1(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)))(expo-modules-autolinking@1.11.1)(expo-status-bar@1.12.1)(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13))(react-native-reanimated@3.10.1(@babel/core@7.24.7)(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)(typescript@5.5.3)
+  : dependencies:
+      '@expo/metro-runtime': 3.2.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))
+      '@expo/server': 0.4.4(typescript@5.5.3)
+      '@radix-ui/react-slot': 1.0.1(react@18.2.0)
+      '@react-navigation/bottom-tabs': 6.5.20(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native': 6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@react-navigation/native-stack': 6.9.26(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      expo: 51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)
+      expo-constants: 16.0.2(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13))
+      expo-linking: 6.3.1(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13))
+      expo-splash-screen: 0.27.4(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13))
+      expo-status-bar: 1.12.1
+      react-native-helmet-async: 2.0.4(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      schema-utils: 4.2.0
+    optionalDependencies:
+      '@react-navigation/drawer': 6.7.2(@react-navigation/native@6.1.18(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.7)(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-reanimated: 3.10.1(@babel/core@7.24.7)(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+    transitivePeerDependencies:
+      - encoding
+      - expo-modules-autolinking
+      - react
+      - react-native
+      - supports-color
+      - typescript
 
-  expo-splash-screen@0.27.4(expo-modules-autolinking@1.11.1)(expo@51.0.21):
+  expo-secure-store@13.0.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)):
     dependencies:
-      '@expo/prebuild-config': 7.0.3(expo-modules-autolinking@1.11.1)
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
+
+  expo-splash-screen@0.27.4(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)):
+    dependencies:
+      '@expo/prebuild-config': 7.0.3(encoding@0.1.13)(expo-modules-autolinking@1.11.1)
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - expo-modules-autolinking
       - supports-color
 
-  expo-splash-screen@0.27.5(expo-modules-autolinking@1.11.1)(expo@51.0.21):
+  expo-splash-screen@0.27.4(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)):
     dependencies:
-      '@expo/prebuild-config': 7.0.6(expo-modules-autolinking@1.11.1)
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+      '@expo/prebuild-config': 7.0.3(encoding@0.1.13)(expo-modules-autolinking@1.11.1)
+      expo: 51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - expo-modules-autolinking
+      - supports-color
+
+  expo-splash-screen@0.27.5(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)):
+    dependencies:
+      '@expo/prebuild-config': 7.0.6(encoding@0.1.13)(expo-modules-autolinking@1.11.1)
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - expo-modules-autolinking
+      - supports-color
+
+  expo-splash-screen@0.27.5(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)):
+    dependencies:
+      '@expo/prebuild-config': 7.0.6(encoding@0.1.13)(expo-modules-autolinking@1.11.1)
+      expo: 51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - expo-modules-autolinking
@@ -27707,26 +28491,51 @@ snapshots:
 
   expo-status-bar@1.12.1: {}
 
-  expo-updates-interface@0.16.2(expo@51.0.21):
+  expo-updates-interface@0.16.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)):
     dependencies:
-      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+      expo: 51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
 
-  expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8):
+  expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13):
     dependencies:
       '@babel/runtime': 7.24.8
-      '@expo/cli': 0.18.25(expo-modules-autolinking@1.11.1)
+      '@expo/cli': 0.18.25(encoding@0.1.13)(expo-modules-autolinking@1.11.1)
       '@expo/config': 9.0.3
       '@expo/config-plugins': 8.0.8
       '@expo/metro-config': 0.18.8
       '@expo/vector-icons': 14.0.2
-      babel-preset-expo: 11.0.12(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
-      expo-asset: 10.0.10(expo@51.0.21)
-      expo-file-system: 17.0.1(expo@51.0.21)
-      expo-font: 12.0.9(expo@51.0.21)
-      expo-keep-awake: 13.0.2(expo@51.0.21)
+      babel-preset-expo: 11.0.12(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))
+      expo-asset: 10.0.10(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
+      expo-file-system: 17.0.1(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
+      expo-font: 12.0.9(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
+      expo-keep-awake: 13.0.2(expo@51.0.21(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13))
       expo-modules-autolinking: 1.11.1
       expo-modules-core: 1.12.19
-      fbemitter: 3.0.0
+      fbemitter: 3.0.0(encoding@0.1.13)
+      whatwg-url-without-unicode: 8.0.0-3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13):
+    dependencies:
+      '@babel/runtime': 7.24.8
+      '@expo/cli': 0.18.25(encoding@0.1.13)(expo-modules-autolinking@1.11.1)
+      '@expo/config': 9.0.3
+      '@expo/config-plugins': 8.0.8
+      '@expo/metro-config': 0.18.8
+      '@expo/vector-icons': 14.0.2
+      babel-preset-expo: 11.0.12(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))
+      expo-asset: 10.0.10(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13))
+      expo-file-system: 17.0.1(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13))
+      expo-font: 12.0.9(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13))
+      expo-keep-awake: 13.0.2(expo@51.0.21(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13))
+      expo-modules-autolinking: 1.11.1
+      expo-modules-core: 1.12.19
+      fbemitter: 3.0.0(encoding@0.1.13)
       whatwg-url-without-unicode: 8.0.0-3
     transitivePeerDependencies:
       - '@babel/core'
@@ -27858,17 +28667,17 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
-  fbemitter@3.0.0:
+  fbemitter@3.0.0(encoding@0.1.13):
     dependencies:
-      fbjs: 3.0.5
+      fbjs: 3.0.5(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
   fbjs-css-vars@1.0.2: {}
 
-  fbjs@3.0.5:
+  fbjs@3.0.5(encoding@0.1.13):
     dependencies:
-      cross-fetch: 3.1.8
+      cross-fetch: 3.1.8(encoding@0.1.13)
       fbjs-css-vars: 1.0.2
       loose-envify: 1.4.0
       object-assign: 4.1.1
@@ -27905,7 +28714,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0
 
   filelist@1.0.4:
     dependencies:
@@ -28030,7 +28839,7 @@ snapshots:
   flush-promises@1.0.2: {}
 
   follow-redirects@1.15.6(debug@4.3.5):
-    dependencies:
+    optionalDependencies:
       debug: 4.3.5(supports-color@8.1.1)
 
   fontfaceobserver@2.3.0: {}
@@ -28044,7 +28853,7 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(typescript@5.4.5)(webpack@5.93.0):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@8.57.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)(webpack@5.93.0):
     dependencies:
       '@babel/code-frame': 7.24.7
       '@types/json-schema': 7.0.15
@@ -28060,7 +28869,10 @@ snapshots:
       semver: 7.6.3
       tapable: 1.1.3
       typescript: 5.4.5
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0
+    optionalDependencies:
+      eslint: 8.57.0
+      vue-template-compiler: 2.7.16
 
   form-data-encoder@2.1.4: {}
 
@@ -28098,7 +28910,7 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
-  framer-motion@6.5.1(react-dom@18.2.0)(react@18.2.0):
+  framer-motion@6.5.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@motionone/dom': 10.12.0
       framesync: 6.0.1
@@ -28742,6 +29554,27 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  html-webpack-plugin@5.6.0(webpack@5.92.1(@swc/core@1.6.13)):
+    dependencies:
+      '@types/html-minifier-terser': 6.1.0
+      html-minifier-terser: 6.1.0
+      lodash: 4.17.21
+      pretty-error: 4.0.0
+      tapable: 2.2.1
+    optionalDependencies:
+      webpack: 5.92.1(@swc/core@1.6.13)
+    optional: true
+
+  html-webpack-plugin@5.6.0(webpack@5.93.0(webpack-cli@5.1.4)):
+    dependencies:
+      '@types/html-minifier-terser': 6.1.0
+      html-minifier-terser: 6.1.0
+      lodash: 4.17.21
+      pretty-error: 4.0.0
+      tapable: 2.2.1
+    optionalDependencies:
+      webpack: 5.93.0(webpack-cli@5.1.4)
+
   html-webpack-plugin@5.6.0(webpack@5.93.0):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
@@ -28749,7 +29582,8 @@ snapshots:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.93.0(webpack-cli@5.1.4)
+    optionalDependencies:
+      webpack: 5.93.0
 
   htmlparser2@6.1.0:
     dependencies:
@@ -28814,12 +29648,13 @@ snapshots:
 
   http-proxy-middleware@2.0.6(@types/express@4.17.21):
     dependencies:
-      '@types/express': 4.17.21
       '@types/http-proxy': 1.17.14
       http-proxy: 1.18.1(debug@4.3.5)
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.7
+    optionalDependencies:
+      '@types/express': 4.17.21
     transitivePeerDependencies:
       - debug
 
@@ -29437,7 +30272,7 @@ snapshots:
 
   jsc-safe-url@0.2.4: {}
 
-  jscodeshift@0.14.0(@babel/preset-env@7.24.8):
+  jscodeshift@0.14.0(@babel/preset-env@7.24.8(@babel/core@7.24.5)):
     dependencies:
       '@babel/core': 7.24.5
       '@babel/parser': 7.24.8
@@ -29446,6 +30281,31 @@ snapshots:
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.24.5)
       '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.24.5)
       '@babel/preset-env': 7.24.8(@babel/core@7.24.5)
+      '@babel/preset-flow': 7.24.7(@babel/core@7.24.5)
+      '@babel/preset-typescript': 7.24.7(@babel/core@7.24.5)
+      '@babel/register': 7.24.6(@babel/core@7.24.5)
+      babel-core: 7.0.0-bridge.0(@babel/core@7.24.5)
+      chalk: 4.1.2
+      flow-parser: 0.241.0
+      graceful-fs: 4.2.11
+      micromatch: 4.0.7
+      neo-async: 2.6.2
+      node-dir: 0.1.17
+      recast: 0.21.5
+      temp: 0.8.4
+      write-file-atomic: 2.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  jscodeshift@0.14.0(@babel/preset-env@7.24.8(@babel/core@7.24.7)):
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/parser': 7.24.8
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.24.5)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.24.5)
+      '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.24.5)
+      '@babel/preset-env': 7.24.8(@babel/core@7.24.7)
       '@babel/preset-flow': 7.24.7(@babel/core@7.24.5)
       '@babel/preset-typescript': 7.24.7(@babel/core@7.24.5)
       '@babel/register': 7.24.6(@babel/core@7.24.5)
@@ -29623,10 +30483,11 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
-  less-loader@12.2.0(less@4.2.0)(webpack@5.92.1):
+  less-loader@12.2.0(less@4.2.0)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)):
     dependencies:
       less: 4.2.0
-      webpack: 5.92.1(esbuild@0.21.5)
+    optionalDependencies:
+      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)
 
   less@4.2.0:
     dependencies:
@@ -29657,10 +30518,11 @@ snapshots:
     dependencies:
       isomorphic.js: 0.2.5
 
-  license-webpack-plugin@4.0.2(webpack@5.92.1):
+  license-webpack-plugin@4.0.2(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)):
     dependencies:
-      webpack: 5.92.1(esbuild@0.21.5)
       webpack-sources: 3.2.3
+    optionalDependencies:
+      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)
 
   lie@3.3.0:
     dependencies:
@@ -30319,12 +31181,12 @@ snapshots:
       metro-core: 0.80.9
       rimraf: 3.0.2
 
-  metro-config@0.76.7:
+  metro-config@0.76.7(encoding@0.1.13):
     dependencies:
       connect: 3.7.0
       cosmiconfig: 5.2.1
       jest-validate: 29.7.0
-      metro: 0.76.7
+      metro: 0.76.7(encoding@0.1.13)
       metro-cache: 0.76.7
       metro-core: 0.76.7
       metro-runtime: 0.76.7
@@ -30334,12 +31196,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro-config@0.80.9:
+  metro-config@0.80.9(encoding@0.1.13):
     dependencies:
       connect: 3.7.0
       cosmiconfig: 5.2.1
       jest-validate: 29.7.0
-      metro: 0.80.9
+      metro: 0.80.9(encoding@0.1.13)
       metro-cache: 0.80.9
       metro-core: 0.80.9
       metro-runtime: 0.80.9
@@ -30395,11 +31257,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-inspector-proxy@0.76.7:
+  metro-inspector-proxy@0.76.7(encoding@0.1.13):
     dependencies:
       connect: 3.7.0
       debug: 2.6.9
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
       ws: 7.5.10
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -30584,14 +31446,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-transform-worker@0.76.7:
+  metro-transform-worker@0.76.7(encoding@0.1.13):
     dependencies:
       '@babel/core': 7.24.5
       '@babel/generator': 7.24.10
       '@babel/parser': 7.24.8
       '@babel/types': 7.24.9
       babel-preset-fbjs: 3.4.0(@babel/core@7.24.5)
-      metro: 0.76.7
+      metro: 0.76.7(encoding@0.1.13)
       metro-babel-transformer: 0.76.7
       metro-cache: 0.76.7
       metro-cache-key: 0.76.7
@@ -30604,13 +31466,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro-transform-worker@0.80.9:
+  metro-transform-worker@0.80.9(encoding@0.1.13):
     dependencies:
       '@babel/core': 7.24.5
       '@babel/generator': 7.24.10
       '@babel/parser': 7.24.8
       '@babel/types': 7.24.9
-      metro: 0.80.9
+      metro: 0.80.9(encoding@0.1.13)
       metro-babel-transformer: 0.80.9
       metro-cache: 0.80.9
       metro-cache-key: 0.80.9
@@ -30624,7 +31486,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro@0.76.7:
+  metro@0.76.7(encoding@0.1.13):
     dependencies:
       '@babel/code-frame': 7.24.7
       '@babel/core': 7.24.5
@@ -30651,10 +31513,10 @@ snapshots:
       metro-babel-transformer: 0.76.7
       metro-cache: 0.76.7
       metro-cache-key: 0.76.7
-      metro-config: 0.76.7
+      metro-config: 0.76.7(encoding@0.1.13)
       metro-core: 0.76.7
       metro-file-map: 0.76.7
-      metro-inspector-proxy: 0.76.7
+      metro-inspector-proxy: 0.76.7(encoding@0.1.13)
       metro-minify-terser: 0.76.7
       metro-minify-uglify: 0.76.7
       metro-react-native-babel-preset: 0.76.7(@babel/core@7.24.5)
@@ -30663,9 +31525,9 @@ snapshots:
       metro-source-map: 0.76.7
       metro-symbolicate: 0.76.7
       metro-transform-plugins: 0.76.7
-      metro-transform-worker: 0.76.7
+      metro-transform-worker: 0.76.7(encoding@0.1.13)
       mime-types: 2.1.35
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
       nullthrows: 1.1.1
       rimraf: 3.0.2
       serialize-error: 2.1.0
@@ -30680,7 +31542,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  metro@0.80.9:
+  metro@0.80.9(encoding@0.1.13):
     dependencies:
       '@babel/code-frame': 7.24.7
       '@babel/core': 7.24.5
@@ -30706,7 +31568,7 @@ snapshots:
       metro-babel-transformer: 0.80.9
       metro-cache: 0.80.9
       metro-cache-key: 0.80.9
-      metro-config: 0.80.9
+      metro-config: 0.80.9(encoding@0.1.13)
       metro-core: 0.80.9
       metro-file-map: 0.80.9
       metro-resolver: 0.80.9
@@ -30714,9 +31576,9 @@ snapshots:
       metro-source-map: 0.80.9
       metro-symbolicate: 0.80.9
       metro-transform-plugins: 0.80.9
-      metro-transform-worker: 0.80.9
+      metro-transform-worker: 0.80.9(encoding@0.1.13)
       mime-types: 2.1.35
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
       nullthrows: 1.1.1
       rimraf: 3.0.2
       serialize-error: 2.1.0
@@ -31065,17 +31927,17 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.0(webpack@5.92.1):
+  mini-css-extract-plugin@2.9.0(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
-      webpack: 5.92.1(esbuild@0.21.5)
+      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)
 
   mini-css-extract-plugin@2.9.0(webpack@5.93.0):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0
 
   minimalistic-assert@1.0.1: {}
 
@@ -31191,10 +32053,10 @@ snapshots:
   moment@2.30.1:
     optional: true
 
-  moti@0.25.4(react-dom@18.2.0)(react-native-reanimated@3.10.1)(react@18.2.0):
+  moti@0.25.4(react-dom@18.2.0(react@18.2.0))(react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0):
     dependencies:
-      framer-motion: 6.5.1(react-dom@18.2.0)(react@18.2.0)
-      react-native-reanimated: 3.10.1(@babel/core@7.24.5)(react-native@0.74.1)(react@18.2.0)
+      framer-motion: 6.5.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-native-reanimated: 3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -31293,7 +32155,7 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next@14.2.3(@babel/core@7.24.5)(react-dom@18.2.0)(react@18.2.0)(sass@1.77.8):
+  next@14.2.3(@babel/core@7.24.7)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(sass@1.77.8):
     dependencies:
       '@next/env': 14.2.3
       '@swc/helpers': 0.5.5
@@ -31303,8 +32165,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      sass: 1.77.8
-      styled-jsx: 5.1.1(@babel/core@7.24.5)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.24.7)(react@18.2.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.3
       '@next/swc-darwin-x64': 14.2.3
@@ -31315,6 +32176,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.3
       '@next/swc-win32-ia32-msvc': 14.2.3
       '@next/swc-win32-x64-msvc': 14.2.3
+      sass: 1.77.8
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -31362,13 +32224,17 @@ snapshots:
       emojilib: 2.4.0
       skin-tone: 2.0.0
 
-  node-fetch@2.6.7:
+  node-fetch@2.6.7(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
 
-  node-fetch@2.7.0:
+  node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
 
   node-fetch@3.3.2:
     dependencies:
@@ -32085,11 +32951,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.39
 
-  postcss-load-config@4.0.2(postcss@8.4.39):
+  postcss-load-config@4.0.2(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3)):
     dependencies:
       lilconfig: 3.1.2
-      postcss: 8.4.39
       yaml: 2.4.5
+    optionalDependencies:
+      postcss: 8.4.39
+      ts-node: 10.9.2(@swc/core@1.6.13)(@types/node@20.14.11)(typescript@5.5.3)
 
   postcss-loader@7.3.4(postcss@8.4.39)(typescript@5.4.5)(webpack@5.93.0):
     dependencies:
@@ -32097,17 +32965,18 @@ snapshots:
       jiti: 1.21.6
       postcss: 8.4.39
       semver: 7.6.3
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0
     transitivePeerDependencies:
       - typescript
 
-  postcss-loader@8.1.1(postcss@8.4.38)(typescript@5.5.3)(webpack@5.92.1):
+  postcss-loader@8.1.1(postcss@8.4.38)(typescript@5.5.3)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.5.3)
       jiti: 1.21.6
       postcss: 8.4.38
       semver: 7.6.2
-      webpack: 5.92.1(esbuild@0.21.5)
+    optionalDependencies:
+      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)
     transitivePeerDependencies:
       - typescript
 
@@ -32589,11 +33458,12 @@ snapshots:
     dependencies:
       '@puppeteer/browsers': 1.4.6(typescript@5.5.3)
       chromium-bidi: 0.4.16(devtools-protocol@0.0.1147663)
-      cross-fetch: 4.0.0
+      cross-fetch: 4.0.0(encoding@0.1.13)
       debug: 4.3.4
       devtools-protocol: 0.0.1147663
-      typescript: 5.5.3
       ws: 8.13.0
+    optionalDependencies:
+      typescript: 5.5.3
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -32666,7 +33536,7 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-dev-utils@12.0.1(typescript@5.4.5)(webpack@5.93.0):
+  react-dev-utils@12.0.1(eslint@8.57.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)(webpack@5.93.0):
     dependencies:
       '@babel/code-frame': 7.24.7
       address: 1.2.2
@@ -32677,7 +33547,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(typescript@5.4.5)(webpack@5.93.0)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.57.0)(typescript@5.4.5)(vue-template-compiler@2.7.16)(webpack@5.93.0)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -32692,8 +33562,9 @@ snapshots:
       shell-quote: 1.8.1
       strip-ansi: 6.0.1
       text-table: 0.2.0
+      webpack: 5.93.0
+    optionalDependencies:
       typescript: 5.4.5
-      webpack: 5.93.0(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -32736,7 +33607,7 @@ snapshots:
     dependencies:
       react: 18.2.0
 
-  react-helmet-async@1.3.0(react-dom@18.2.0)(react@18.2.0):
+  react-helmet-async@1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.24.8
       invariant: 2.2.4
@@ -32763,13 +33634,13 @@ snapshots:
     dependencies:
       react: 18.2.0
 
-  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0)(webpack@5.93.0):
+  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@18.2.0))(webpack@5.93.0):
     dependencies:
       '@babel/runtime': 7.24.8
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.2.0)'
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0
 
-  react-native-elements@3.4.3(react-native-safe-area-context@4.10.1)(react-native-vector-icons@10.1.0)(react-native@0.74.1)(react@18.2.0):
+  react-native-elements@3.4.3(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-vector-icons@10.1.0)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       '@types/react-native-vector-icons': 6.4.18
       color: 3.2.1
@@ -32777,24 +33648,40 @@ snapshots:
       hoist-non-react-statics: 3.3.2
       lodash.isequal: 4.5.0
       opencollective-postinstall: 2.0.3
-      react-native-ratings: 8.0.4(react-native@0.74.1)(react@18.2.0)
-      react-native-safe-area-context: 4.10.1(react-native@0.74.1)(react@18.2.0)
-      react-native-size-matters: 0.3.1(react-native@0.74.1)
+      react-native-ratings: 8.0.4(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-size-matters: 0.3.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))
       react-native-vector-icons: 10.1.0
     transitivePeerDependencies:
       - react
       - react-native
 
-  react-native-encrypted-storage@4.0.3(react-native@0.74.1)(react@18.2.0):
+  react-native-elements@3.4.3(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-vector-icons@10.1.0)(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@types/react-native-vector-icons': 6.4.18
+      color: 3.2.1
+      deepmerge: 4.3.1
+      hoist-non-react-statics: 3.3.2
+      lodash.isequal: 4.5.0
+      opencollective-postinstall: 2.0.3
+      react-native-ratings: 8.0.4(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-size-matters: 0.3.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))
+      react-native-vector-icons: 10.1.0
+    transitivePeerDependencies:
+      - react
+      - react-native
+
+  react-native-encrypted-storage@4.0.3(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
 
   react-native-fetch-api@3.0.0:
     dependencies:
       p-defer: 3.0.0
 
-  react-native-gesture-handler@2.16.2(react-native@0.74.1)(react@18.2.0):
+  react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       hoist-non-react-statics: 3.3.2
@@ -32802,12 +33689,47 @@ snapshots:
       lodash: 4.17.21
       prop-types: 15.8.1
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
 
-  react-native-get-random-values@1.11.0(react-native@0.74.1):
+  react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@egjs/hammerjs': 2.0.17
+      hoist-non-react-statics: 3.3.2
+      invariant: 2.2.4
+      lodash: 4.17.21
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
+
+  react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@egjs/hammerjs': 2.0.17
+      hoist-non-react-statics: 3.3.2
+      invariant: 2.2.4
+      lodash: 4.17.21
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+
+  react-native-get-random-values@1.11.0(react-native@0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)(react@18.2.0)):
     dependencies:
       fast-base64-decode: 1.0.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)(react@18.2.0)
+
+  react-native-get-random-values@1.11.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)):
+    dependencies:
+      fast-base64-decode: 1.0.0
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+
+  react-native-get-random-values@1.11.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)):
+    dependencies:
+      fast-base64-decode: 1.0.0
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
+
+  react-native-get-random-values@1.11.0(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)):
+    dependencies:
+      fast-base64-decode: 1.0.0
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
 
   react-native-helmet-async@2.0.4(react@18.2.0):
     dependencies:
@@ -32816,53 +33738,87 @@ snapshots:
       react-fast-compare: 3.2.2
       shallowequal: 1.1.0
 
-  react-native-iphone-x-helper@1.3.1(react-native@0.74.1):
+  react-native-iphone-x-helper@1.3.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)):
     dependencies:
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
 
-  react-native-pager-view@6.3.0(react-native@0.74.1)(react@18.2.0):
+  react-native-iphone-x-helper@1.3.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)):
+    dependencies:
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+
+  react-native-pager-view@6.3.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
 
-  react-native-polyfill-globals@3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0)(react-native-url-polyfill@2.0.0)(text-encoding@0.7.0)(web-streams-polyfill@3.2.1):
+  react-native-polyfill-globals@3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0(react-native@0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)(react@18.2.0)))(react-native-url-polyfill@2.0.0(react-native@0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)(react@18.2.0)))(text-encoding@0.7.0)(web-streams-polyfill@3.3.3):
     dependencies:
       base-64: 1.0.0
       react-native-fetch-api: 3.0.0
-      react-native-get-random-values: 1.11.0(react-native@0.74.1)
-      react-native-url-polyfill: 2.0.0(react-native@0.74.1)
+      react-native-get-random-values: 1.11.0(react-native@0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)(react@18.2.0))
+      react-native-url-polyfill: 2.0.0(react-native@0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)(react@18.2.0))
+      text-encoding: 0.7.0
+      web-streams-polyfill: 3.3.3
+
+  react-native-polyfill-globals@3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)))(react-native-url-polyfill@2.0.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)))(text-encoding@0.7.0)(web-streams-polyfill@3.3.3):
+    dependencies:
+      base-64: 1.0.0
+      react-native-fetch-api: 3.0.0
+      react-native-get-random-values: 1.11.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))
+      react-native-url-polyfill: 2.0.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))
+      text-encoding: 0.7.0
+      web-streams-polyfill: 3.3.3
+
+  react-native-polyfill-globals@3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)))(react-native-url-polyfill@2.0.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)))(text-encoding@0.7.0)(web-streams-polyfill@3.2.1):
+    dependencies:
+      base-64: 1.0.0
+      react-native-fetch-api: 3.0.0
+      react-native-get-random-values: 1.11.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))
+      react-native-url-polyfill: 2.0.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))
       text-encoding: 0.7.0
       web-streams-polyfill: 3.2.1
 
-  react-native-polyfill-globals@3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0)(react-native-url-polyfill@2.0.0)(text-encoding@0.7.0)(web-streams-polyfill@3.3.3):
+  react-native-polyfill-globals@3.1.0(base-64@1.0.0)(react-native-fetch-api@3.0.0)(react-native-get-random-values@1.11.0(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)))(react-native-url-polyfill@2.0.0(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)))(text-encoding@0.7.0)(web-streams-polyfill@3.3.3):
     dependencies:
       base-64: 1.0.0
       react-native-fetch-api: 3.0.0
-      react-native-get-random-values: 1.11.0(react-native@0.74.1)
-      react-native-url-polyfill: 2.0.0(react-native@0.74.1)
+      react-native-get-random-values: 1.11.0(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))
+      react-native-url-polyfill: 2.0.0(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))
       text-encoding: 0.7.0
       web-streams-polyfill: 3.3.3
 
   react-native-prompt-android@1.1.0: {}
 
-  react-native-quick-base64@2.1.2(react-native@0.74.1)(react@18.2.0):
+  react-native-quick-base64@2.1.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       base64-js: 1.5.1
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
 
-  react-native-ratings@8.0.4(react-native@0.74.1)(react@18.2.0):
+  react-native-quick-base64@2.1.2(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      base64-js: 1.5.1
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+
+  react-native-ratings@8.0.4(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       lodash: 4.17.21
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
 
-  react-native-reanimated-table@0.0.2(react-native@0.74.1)(react@18.2.0):
+  react-native-ratings@8.0.4(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      lodash: 4.17.21
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+
+  react-native-reanimated-table@0.0.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
 
-  react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1)(react@18.2.0):
+  react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/core': 7.24.5
       '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.5)
@@ -32874,51 +33830,139 @@ snapshots:
       convert-source-map: 2.0.0
       invariant: 2.2.4
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  react-native-safe-area-context@4.10.1(react-native@0.74.1)(react@18.2.0):
+  react-native-reanimated@3.10.1(@babel/core@7.24.5)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@babel/core': 7.24.5
+      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-optional-chaining': 7.24.8(@babel/core@7.24.5)
+      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.24.5)
+      '@babel/plugin-transform-template-literals': 7.24.7(@babel/core@7.24.5)
+      '@babel/preset-typescript': 7.24.7(@babel/core@7.24.5)
+      convert-source-map: 2.0.0
+      invariant: 2.2.4
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  react-native-reanimated@3.10.1(@babel/core@7.24.7)(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-optional-chaining': 7.24.8(@babel/core@7.24.7)
+      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.24.7)
+      '@babel/plugin-transform-template-literals': 7.24.7(@babel/core@7.24.7)
+      '@babel/preset-typescript': 7.24.7(@babel/core@7.24.7)
+      convert-source-map: 2.0.0
+      invariant: 2.2.4
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
 
-  react-native-safe-area-view@0.14.9(react-native@0.74.1)(react@18.2.0):
+  react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
+
+  react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+
+  react-native-safe-area-view@0.14.9(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       hoist-non-react-statics: 2.5.5
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
 
-  react-native-safe-area-view@1.1.1(react-native-safe-area-context@4.10.1)(react-native@0.74.1)(react@18.2.0):
+  react-native-safe-area-view@0.14.9(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       hoist-non-react-statics: 2.5.5
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
-      react-native-safe-area-context: 4.10.1(react-native@0.74.1)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
 
-  react-native-screens@3.31.1(react-native@0.74.1)(react@18.2.0):
+  react-native-safe-area-view@1.1.1(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      hoist-non-react-statics: 2.5.5
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+
+  react-native-safe-area-view@1.1.1(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      hoist-non-react-statics: 2.5.5
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+
+  react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       react: 18.2.0
       react-freeze: 1.0.4(react@18.2.0)
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
       warn-once: 0.1.1
 
-  react-native-size-matters@0.3.1(react-native@0.74.1):
+  react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
+      react: 18.2.0
+      react-freeze: 1.0.4(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
+      warn-once: 0.1.1
 
-  react-native-svg@15.2.0(react-native@0.74.1)(react@18.2.0):
+  react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-freeze: 1.0.4(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+      warn-once: 0.1.1
+
+  react-native-size-matters@0.3.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)):
+    dependencies:
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+
+  react-native-size-matters@0.3.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)):
+    dependencies:
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+
+  react-native-svg@15.2.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       css-select: 5.1.0
       css-tree: 1.1.3
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
 
   react-native-table-component@1.2.2: {}
 
-  react-native-url-polyfill@2.0.0(react-native@0.74.1):
+  react-native-url-polyfill@2.0.0(react-native@0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)(react@18.2.0)):
     dependencies:
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)(react@18.2.0)
+      whatwg-url-without-unicode: 8.0.0-3
+
+  react-native-url-polyfill@2.0.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)):
+    dependencies:
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+      whatwg-url-without-unicode: 8.0.0-3
+
+  react-native-url-polyfill@2.0.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)):
+    dependencies:
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
+      whatwg-url-without-unicode: 8.0.0-3
+
+  react-native-url-polyfill@2.0.0(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)):
+    dependencies:
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
       whatwg-url-without-unicode: 8.0.0-3
 
   react-native-vector-icons@10.1.0:
@@ -32935,7 +33979,7 @@ snapshots:
       react: 18.2.0
       styleq: 0.1.3
 
-  react-native-web-lite@1.79.6(react-dom@18.2.0)(react@18.2.0):
+  react-native-web-lite@1.79.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@tamagui/normalize-css-color': 1.79.6
       invariant: 2.2.4
@@ -32944,11 +33988,11 @@ snapshots:
       react-native-web-internals: 1.79.6(react@18.2.0)
       styleq: 0.1.3
 
-  react-native-web@0.19.12(react-dom@18.2.0)(react@18.2.0):
+  react-native-web@0.19.12(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.24.8
       '@react-native/normalize-colors': 0.74.85
-      fbjs: 3.0.5
+      fbjs: 3.0.5(encoding@0.1.13)
       inline-style-prefixer: 6.0.4
       memoize-one: 6.0.0
       nullthrows: 1.1.1
@@ -32959,18 +34003,18 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  react-native@0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(react@18.2.0):
+  react-native@0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)(react@18.2.0):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
-      '@react-native-community/cli': 11.3.6(@babel/core@7.24.5)
-      '@react-native-community/cli-platform-android': 11.3.6
-      '@react-native-community/cli-platform-ios': 11.3.6
+      '@react-native-community/cli': 11.3.6(@babel/core@7.24.5)(encoding@0.1.13)
+      '@react-native-community/cli-platform-android': 11.3.6(encoding@0.1.13)
+      '@react-native-community/cli-platform-ios': 11.3.6(encoding@0.1.13)
       '@react-native/assets-registry': 0.72.0
-      '@react-native/codegen': 0.72.8(@babel/preset-env@7.24.8)
+      '@react-native/codegen': 0.72.8(@babel/preset-env@7.24.8(@babel/core@7.24.5))
       '@react-native/gradle-plugin': 0.72.11
       '@react-native/js-polyfills': 0.72.1
       '@react-native/normalize-colors': 0.72.0
-      '@react-native/virtualized-lists': 0.72.8(react-native@0.72.4)
+      '@react-native/virtualized-lists': 0.72.8(react-native@0.72.4(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)(react@18.2.0))
       abort-controller: 3.0.0
       anser: 1.4.10
       base64-js: 1.5.1
@@ -33006,47 +34050,48 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0):
+  react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
-      '@react-native-community/cli': 13.6.6
-      '@react-native-community/cli-platform-android': 13.6.6
-      '@react-native-community/cli-platform-ios': 13.6.6
+      '@react-native-community/cli': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-platform-android': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-platform-ios': 13.6.6(encoding@0.1.13)
       '@react-native/assets-registry': 0.74.83
-      '@react-native/codegen': 0.74.83(@babel/preset-env@7.24.8)
-      '@react-native/community-cli-plugin': 0.74.83(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+      '@react-native/codegen': 0.74.83(@babel/preset-env@7.24.8(@babel/core@7.24.5))
+      '@react-native/community-cli-plugin': 0.74.83(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
       '@react-native/gradle-plugin': 0.74.83
       '@react-native/js-polyfills': 0.74.83
       '@react-native/normalize-colors': 0.74.83
-      '@react-native/virtualized-lists': 0.74.83(@types/react@18.2.79)(react-native@0.74.1)(react@18.2.0)
+      '@react-native/virtualized-lists': 0.74.83(@types/react@18.2.79)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      ansi-regex: 5.0.1
+      base64-js: 1.5.1
+      chalk: 4.1.2
+      event-target-shim: 5.0.1
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      jest-environment-node: 29.7.0
+      jsc-android: 250231.0.0
+      memoize-one: 5.2.1
+      metro-runtime: 0.80.9
+      metro-source-map: 0.80.9
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+      pretty-format: 26.6.2
+      promise: 8.3.0
+      react: 18.2.0
+      react-devtools-core: 5.3.1
+      react-refresh: 0.14.2
+      react-shallow-renderer: 16.15.0(react@18.2.0)
+      regenerator-runtime: 0.13.11
+      scheduler: 0.24.0-canary-efb381bbf-20230505
+      stacktrace-parser: 0.1.10
+      whatwg-fetch: 3.6.20
+      ws: 6.2.3
+      yargs: 17.7.2
+    optionalDependencies:
       '@types/react': 18.2.79
-      abort-controller: 3.0.0
-      anser: 1.4.10
-      ansi-regex: 5.0.1
-      base64-js: 1.5.1
-      chalk: 4.1.2
-      event-target-shim: 5.0.1
-      flow-enums-runtime: 0.0.6
-      invariant: 2.2.4
-      jest-environment-node: 29.7.0
-      jsc-android: 250231.0.0
-      memoize-one: 5.2.1
-      metro-runtime: 0.80.9
-      metro-source-map: 0.80.9
-      mkdirp: 0.5.6
-      nullthrows: 1.1.1
-      pretty-format: 26.6.2
-      promise: 8.3.0
-      react: 18.2.0
-      react-devtools-core: 5.3.1
-      react-refresh: 0.14.2
-      react-shallow-renderer: 16.15.0(react@18.2.0)
-      regenerator-runtime: 0.13.11
-      scheduler: 0.24.0-canary-efb381bbf-20230505
-      stacktrace-parser: 0.1.10
-      whatwg-fetch: 3.6.20
-      ws: 6.2.3
-      yargs: 17.7.2
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
@@ -33055,20 +34100,19 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0):
+  react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
-      '@react-native-community/cli': 13.6.6
-      '@react-native-community/cli-platform-android': 13.6.6
-      '@react-native-community/cli-platform-ios': 13.6.6
+      '@react-native-community/cli': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-platform-android': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-platform-ios': 13.6.6(encoding@0.1.13)
       '@react-native/assets-registry': 0.74.83
-      '@react-native/codegen': 0.74.83(@babel/preset-env@7.24.8)
-      '@react-native/community-cli-plugin': 0.74.83(@babel/core@7.24.5)(@babel/preset-env@7.24.8)
+      '@react-native/codegen': 0.74.83(@babel/preset-env@7.24.8(@babel/core@7.24.5))
+      '@react-native/community-cli-plugin': 0.74.83(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(encoding@0.1.13)
       '@react-native/gradle-plugin': 0.74.83
       '@react-native/js-polyfills': 0.74.83
       '@react-native/normalize-colors': 0.74.83
-      '@react-native/virtualized-lists': 0.74.83(@types/react@18.3.3)(react-native@0.74.1)(react@18.2.0)
-      '@types/react': 18.3.3
+      '@react-native/virtualized-lists': 0.74.83(@types/react@18.3.3)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1
@@ -33096,6 +34140,8 @@ snapshots:
       whatwg-fetch: 3.6.20
       ws: 6.2.3
       yargs: 17.7.2
+    optionalDependencies:
+      '@types/react': 18.3.3
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
@@ -33104,24 +34150,93 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  react-navigation-stack@2.10.4(@react-native-community/masked-view@0.1.11)(react-native-gesture-handler@2.16.2)(react-native-safe-area-context@4.10.1)(react-native-screens@3.31.1)(react-native@0.74.1)(react-navigation@4.4.4)(react@18.2.0):
+  react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0):
     dependencies:
-      '@react-native-community/masked-view': 0.1.11(react-native@0.74.1)(react@18.2.0)
+      '@jest/create-cache-key-function': 29.7.0
+      '@react-native-community/cli': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-platform-android': 13.6.6(encoding@0.1.13)
+      '@react-native-community/cli-platform-ios': 13.6.6(encoding@0.1.13)
+      '@react-native/assets-registry': 0.74.83
+      '@react-native/codegen': 0.74.83(@babel/preset-env@7.24.8(@babel/core@7.24.7))
+      '@react-native/community-cli-plugin': 0.74.83(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(encoding@0.1.13)
+      '@react-native/gradle-plugin': 0.74.83
+      '@react-native/js-polyfills': 0.74.83
+      '@react-native/normalize-colors': 0.74.83
+      '@react-native/virtualized-lists': 0.74.83(@types/react@18.2.79)(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      ansi-regex: 5.0.1
+      base64-js: 1.5.1
+      chalk: 4.1.2
+      event-target-shim: 5.0.1
+      flow-enums-runtime: 0.0.6
+      invariant: 2.2.4
+      jest-environment-node: 29.7.0
+      jsc-android: 250231.0.0
+      memoize-one: 5.2.1
+      metro-runtime: 0.80.9
+      metro-source-map: 0.80.9
+      mkdirp: 0.5.6
+      nullthrows: 1.1.1
+      pretty-format: 26.6.2
+      promise: 8.3.0
+      react: 18.2.0
+      react-devtools-core: 5.3.1
+      react-refresh: 0.14.2
+      react-shallow-renderer: 16.15.0(react@18.2.0)
+      regenerator-runtime: 0.13.11
+      scheduler: 0.24.0-canary-efb381bbf-20230505
+      stacktrace-parser: 0.1.10
+      whatwg-fetch: 3.6.20
+      ws: 6.2.3
+      yargs: 17.7.2
+    optionalDependencies:
+      '@types/react': 18.2.79
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/preset-env'
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  ? react-navigation-stack@2.10.4(@react-native-community/masked-view@0.1.11(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react-navigation@4.4.4(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0)
+  : dependencies:
+      '@react-native-community/masked-view': 0.1.11(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       color: 3.2.1
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
-      react-native-gesture-handler: 2.16.2(react-native@0.74.1)(react@18.2.0)
-      react-native-iphone-x-helper: 1.3.1(react-native@0.74.1)
-      react-native-safe-area-context: 4.10.1(react-native@0.74.1)(react@18.2.0)
-      react-native-screens: 3.31.1(react-native@0.74.1)(react@18.2.0)
-      react-navigation: 4.4.4(react-native@0.74.1)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+      react-native-gesture-handler: 2.16.2(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-iphone-x-helper: 1.3.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 3.31.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-navigation: 4.4.4(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
 
-  react-navigation@4.4.4(react-native@0.74.1)(react@18.2.0):
+  ? react-navigation-stack@2.10.4(@react-native-community/masked-view@0.1.11(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-gesture-handler@2.16.2(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react-navigation@4.4.4(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react@18.2.0)
+  : dependencies:
+      '@react-native-community/masked-view': 0.1.11(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      color: 3.2.1
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+      react-native-gesture-handler: 2.16.2(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-iphone-x-helper: 1.3.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))
+      react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-screens: 3.31.1(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-navigation: 4.4.4(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+
+  react-navigation@4.4.4(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       '@react-navigation/core': 3.7.9(react@18.2.0)
-      '@react-navigation/native': 3.8.4(react-native@0.74.1)(react@18.2.0)
+      '@react-navigation/native': 3.8.4(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.2.79)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
+
+  react-navigation@4.4.4(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      '@react-navigation/core': 3.7.9(react@18.2.0)
+      '@react-navigation/native': 3.8.4(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
 
   react-refresh@0.14.2: {}
 
@@ -33129,22 +34244,24 @@ snapshots:
 
   react-remove-scroll-bar@2.3.6(@types/react@18.3.3)(react@18.2.0):
     dependencies:
-      '@types/react': 18.3.3
       react: 18.2.0
       react-style-singleton: 2.2.1(@types/react@18.3.3)(react@18.2.0)
       tslib: 2.6.3
+    optionalDependencies:
+      '@types/react': 18.3.3
 
   react-remove-scroll@2.5.10(@types/react@18.3.3)(react@18.2.0):
     dependencies:
-      '@types/react': 18.3.3
       react: 18.2.0
       react-remove-scroll-bar: 2.3.6(@types/react@18.3.3)(react@18.2.0)
       react-style-singleton: 2.2.1(@types/react@18.3.3)(react@18.2.0)
       tslib: 2.6.3
       use-callback-ref: 1.3.2(@types/react@18.3.3)(react@18.2.0)
       use-sidecar: 1.1.2(@types/react@18.3.3)(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.3.3
 
-  react-router-config@5.1.1(react-router@5.3.4)(react@18.2.0):
+  react-router-config@5.1.1(react-router@5.3.4(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.24.8
       react: 18.2.0
@@ -33161,7 +34278,7 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  react-router-dom@6.25.1(react-dom@18.2.0)(react@18.2.0):
+  react-router-dom@6.25.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@remix-run/router': 1.18.0
       react: 18.2.0
@@ -33194,13 +34311,14 @@ snapshots:
 
   react-style-singleton@2.2.1(@types/react@18.3.3)(react@18.2.0):
     dependencies:
-      '@types/react': 18.3.3
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 18.2.0
       tslib: 2.6.3
+    optionalDependencies:
+      '@types/react': 18.3.3
 
-  react-transition-group@4.4.5(react-dom@18.2.0)(react@18.2.0):
+  react-transition-group@4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.24.8
       dom-helpers: 5.2.1
@@ -33311,12 +34429,12 @@ snapshots:
     dependencies:
       minimatch: 3.1.2
 
-  recyclerlistview@4.2.0(react-native@0.74.1)(react@18.2.0):
+  recyclerlistview@4.2.0(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       lodash.debounce: 4.0.8
       prop-types: 15.8.1
       react: 18.2.0
-      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8)(@types/react@18.3.3)(react@18.2.0)
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0)
       ts-object-utils: 0.0.5
 
   redent@3.0.0:
@@ -33340,11 +34458,11 @@ snapshots:
       globalthis: 1.0.4
       which-builtin-type: 1.1.3
 
-  reforest@0.13.0(@types/react@18.3.3)(react@18.2.0):
+  reforest@0.13.0(@types/react@18.3.3)(immer@9.0.21)(react@18.2.0):
     dependencies:
       performant-array-to-tree: 1.11.0
       react: 18.2.0
-      zustand: 4.5.4(@types/react@18.3.3)(react@18.2.0)
+      zustand: 4.5.4(@types/react@18.3.3)(immer@9.0.21)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -33746,14 +34864,16 @@ snapshots:
   sass-loader@13.3.3(sass@1.77.8)(webpack@5.93.0):
     dependencies:
       neo-async: 2.6.2
+      webpack: 5.93.0
+    optionalDependencies:
       sass: 1.77.8
-      webpack: 5.93.0(webpack-cli@5.1.4)
 
-  sass-loader@14.2.1(sass@1.77.6)(webpack@5.92.1):
+  sass-loader@14.2.1(sass@1.77.6)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)):
     dependencies:
       neo-async: 2.6.2
+    optionalDependencies:
       sass: 1.77.6
-      webpack: 5.92.1(esbuild@0.21.5)
+      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)
 
   sass@1.77.6:
     dependencies:
@@ -34127,11 +35247,11 @@ snapshots:
 
   source-map-js@1.2.0: {}
 
-  source-map-loader@5.0.0(webpack@5.92.1):
+  source-map-loader@5.0.0(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.0
-      webpack: 5.92.1(esbuild@0.21.5)
+      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)
 
   source-map-support@0.5.21:
     dependencies:
@@ -34385,9 +35505,13 @@ snapshots:
 
   structured-headers@0.4.1: {}
 
+  style-loader@3.3.4(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5))):
+    dependencies:
+      webpack: 5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5))
+
   style-loader@3.3.4(webpack@5.93.0):
     dependencies:
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0
 
   style-to-object@0.4.4:
     dependencies:
@@ -34402,11 +35526,12 @@ snapshots:
       hey-listen: 1.0.8
       tslib: 2.6.3
 
-  styled-jsx@5.1.1(@babel/core@7.24.5)(react@18.2.0):
+  styled-jsx@5.1.1(@babel/core@7.24.7)(react@18.2.0):
     dependencies:
-      '@babel/core': 7.24.5
       client-only: 0.0.1
       react: 18.2.0
+    optionalDependencies:
+      '@babel/core': 7.24.7
 
   stylehacks@6.1.1(postcss@8.4.39):
     dependencies:
@@ -34510,7 +35635,7 @@ snapshots:
 
   tabbable@6.2.0: {}
 
-  tailwindcss@3.4.6:
+  tailwindcss@3.4.6(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -34529,7 +35654,7 @@ snapshots:
       postcss: 8.4.39
       postcss-import: 15.1.0(postcss@8.4.39)
       postcss-js: 4.0.1(postcss@8.4.39)
-      postcss-load-config: 4.0.2(postcss@8.4.39)
+      postcss-load-config: 4.0.2(postcss@8.4.39)(ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3))
       postcss-nested: 6.0.1(postcss@8.4.39)
       postcss-selector-parser: 6.1.1
       resolve: 1.22.8
@@ -34537,61 +35662,61 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tamagui@1.79.6(@types/react@18.3.3)(react-dom@18.2.0)(react-native-web@0.19.12)(react-native@0.74.1)(react@18.2.0):
+  tamagui@1.79.6(@types/react@18.3.3)(immer@9.0.21)(react-dom@18.2.0(react@18.2.0))(react-native-web@0.19.12(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:
       '@tamagui/accordion': 1.79.6(react@18.2.0)
       '@tamagui/adapt': 1.79.6(react@18.2.0)
-      '@tamagui/alert-dialog': 1.79.6(@types/react@18.3.3)(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/alert-dialog': 1.79.6(@types/react@18.3.3)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/animate-presence': 1.79.6(react@18.2.0)
-      '@tamagui/avatar': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/button': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/card': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/checkbox': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/avatar': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/button': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/card': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/checkbox': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/compose-refs': 1.79.6(react@18.2.0)
       '@tamagui/core': 1.79.6(react@18.2.0)
       '@tamagui/create-context': 1.79.6(react@18.2.0)
-      '@tamagui/dialog': 1.79.6(@types/react@18.3.3)(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/dialog': 1.79.6(@types/react@18.3.3)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/fake-react-native': 1.79.6
       '@tamagui/focusable': 1.79.6(react@18.2.0)
       '@tamagui/font-size': 1.79.6(react@18.2.0)
-      '@tamagui/form': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/get-button-sized': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/form': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/get-button-sized': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/get-font-sized': 1.79.6(react@18.2.0)
-      '@tamagui/get-token': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/get-token': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/helpers': 1.79.6(react@18.2.0)
-      '@tamagui/helpers-tamagui': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/image': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/label': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/helpers-tamagui': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/image': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/label': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/linear-gradient': 1.79.6(react@18.2.0)
-      '@tamagui/list-item': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/list-item': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/polyfill-dev': 1.79.6
-      '@tamagui/popover': 1.79.6(@types/react@18.3.3)(react-dom@18.2.0)(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/popper': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/portal': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/progress': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/radio-group': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/react-native-media-driver': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/popover': 1.79.6(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/popper': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/portal': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/progress': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/radio-group': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/react-native-media-driver': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/scroll-view': 1.79.6(react@18.2.0)
-      '@tamagui/select': 1.79.6(@types/react@18.3.3)(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/select': 1.79.6(@types/react@18.3.3)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/separator': 1.79.6(react@18.2.0)
       '@tamagui/shapes': 1.79.6(react@18.2.0)
-      '@tamagui/sheet': 1.79.6(@types/react@18.3.3)(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/slider': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/sheet': 1.79.6(@types/react@18.3.3)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/slider': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/stacks': 1.79.6(react@18.2.0)
-      '@tamagui/switch': 1.79.6(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/tabs': 1.79.6(@types/react@18.3.3)(react-dom@18.2.0)(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/text': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/switch': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/tabs': 1.79.6(@types/react@18.3.3)(immer@9.0.21)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/text': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/theme': 1.79.6(react@18.2.0)
-      '@tamagui/toggle-group': 1.79.6(@types/react@18.3.3)(react-native@0.74.1)(react@18.2.0)
-      '@tamagui/tooltip': 1.79.6(@types/react@18.3.3)(react-dom@18.2.0)(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/toggle-group': 1.79.6(@types/react@18.3.3)(immer@9.0.21)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      '@tamagui/tooltip': 1.79.6(@types/react@18.3.3)(react-dom@18.2.0(react@18.2.0))(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/use-controllable-state': 1.79.6(react@18.2.0)
       '@tamagui/use-debounce': 1.79.6(react@18.2.0)
       '@tamagui/use-force-update': 1.79.6(react@18.2.0)
-      '@tamagui/use-window-dimensions': 1.79.6(react-native@0.74.1)(react@18.2.0)
+      '@tamagui/use-window-dimensions': 1.79.6(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.3.3)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       '@tamagui/visually-hidden': 1.79.6(react@18.2.0)
       react: 18.2.0
-      react-native-web: 0.19.12(react-dom@18.2.0)(react@18.2.0)
-      reforest: 0.13.0(@types/react@18.3.3)(react@18.2.0)
+      react-native-web: 0.19.12(encoding@0.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      reforest: 0.13.0(@types/react@18.3.3)(immer@9.0.21)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -34691,34 +35816,49 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.6.13)(webpack@5.93.0):
+  terser-webpack-plugin@5.3.10(@swc/core@1.6.13(@swc/helpers@0.5.5))(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      '@swc/core': 1.6.13
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.31.3
-      webpack: 5.93.0(@swc/core@1.6.13)
+      webpack: 5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5))
+    optionalDependencies:
+      '@swc/core': 1.6.13(@swc/helpers@0.5.5)
 
-  terser-webpack-plugin@5.3.10(esbuild@0.21.5)(webpack@5.92.1):
+  terser-webpack-plugin@5.3.10(@swc/core@1.6.13)(esbuild@0.21.5)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.31.3
+      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)
+    optionalDependencies:
+      '@swc/core': 1.6.13(@swc/helpers@0.5.5)
       esbuild: 0.21.5
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.2
-      terser: 5.31.3
-      webpack: 5.92.1(esbuild@0.21.5)
 
-  terser-webpack-plugin@5.3.10(webpack@5.92.1):
+  terser-webpack-plugin@5.3.10(@swc/core@1.6.13)(webpack@5.92.1(@swc/core@1.6.13)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.31.3
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13)
+    optionalDependencies:
+      '@swc/core': 1.6.13(@swc/helpers@0.5.5)
+    optional: true
+
+  terser-webpack-plugin@5.3.10(webpack@5.93.0(webpack-cli@5.1.4)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.31.3
+      webpack: 5.93.0(webpack-cli@5.1.4)
 
   terser-webpack-plugin@5.3.10(webpack@5.93.0):
     dependencies:
@@ -34727,7 +35867,7 @@ snapshots:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.31.3
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0
 
   terser@5.29.2:
     dependencies:
@@ -34872,7 +36012,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-loader@9.5.1(typescript@5.5.3)(webpack@5.93.0):
+  ts-loader@9.5.1(typescript@5.5.3)(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5))):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.17.0
@@ -34880,12 +36020,11 @@ snapshots:
       semver: 7.6.3
       source-map: 0.7.4
       typescript: 5.5.3
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5))
 
-  ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.11)(typescript@4.5.5):
+  ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@4.5.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
-      '@swc/core': 1.6.13
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
@@ -34900,8 +36039,30 @@ snapshots:
       typescript: 4.5.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.6.13(@swc/helpers@0.5.5)
 
-  ts-node@10.9.2(@types/node@20.14.11)(typescript@5.3.3):
+  ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.5))(@types/node@20.14.11)(typescript@5.5.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.14.11
+      acorn: 8.12.1
+      acorn-walk: 8.3.3
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.5.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.6.13(@swc/helpers@0.5.5)
+
+  ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.11)(typescript@5.3.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -34918,8 +36079,10 @@ snapshots:
       typescript: 5.3.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.6.13(@swc/helpers@0.5.5)
 
-  ts-node@10.9.2(@types/node@20.14.11)(typescript@5.5.3):
+  ts-node@10.9.2(@swc/core@1.6.13)(@types/node@20.14.11)(typescript@5.5.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -34936,6 +36099,8 @@ snapshots:
       typescript: 5.5.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.6.13(@swc/helpers@0.5.5)
 
   ts-object-utils@0.0.5: {}
 
@@ -35072,7 +36237,7 @@ snapshots:
       typed-array-buffer: 1.0.2
       typed-array-byte-offset: 1.0.2
 
-  typedoc-plugin-markdown@4.0.3(typedoc@0.25.13):
+  typedoc-plugin-markdown@4.0.3(typedoc@0.25.13(typescript@5.4.5)):
     dependencies:
       typedoc: 0.25.13(typescript@5.4.5)
 
@@ -35218,16 +36383,16 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-fonts@1.1.1(vite@5.3.4):
+  unplugin-fonts@1.1.1(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)):
     dependencies:
       fast-glob: 3.3.2
       unplugin: 1.11.0
-      vite: 5.3.4(sass@1.77.8)
+      vite: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
 
-  unplugin-vue-components@0.26.0(rollup@2.79.1)(vue@3.4.21):
+  unplugin-vue-components@0.26.0(@babel/parser@7.24.8)(rollup@4.18.1)(vue@3.4.21(typescript@5.5.3)):
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
+      '@rollup/pluginutils': 5.1.0(rollup@4.18.1)
       chokidar: 3.6.0
       debug: 4.3.5(supports-color@8.1.1)
       fast-glob: 3.3.2
@@ -35237,6 +36402,8 @@ snapshots:
       resolve: 1.22.8
       unplugin: 1.11.0
       vue: 3.4.21(typescript@5.5.3)
+    optionalDependencies:
+      '@babel/parser': 7.24.8
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -35290,13 +36457,14 @@ snapshots:
 
   url-join@4.0.1: {}
 
-  url-loader@4.1.1(file-loader@6.2.0)(webpack@5.93.0):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.93.0))(webpack@5.93.0):
     dependencies:
-      file-loader: 6.2.0(webpack@5.93.0)
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0
+    optionalDependencies:
+      file-loader: 6.2.0(webpack@5.93.0)
 
   url-parse@1.5.10:
     dependencies:
@@ -35305,9 +36473,10 @@ snapshots:
 
   use-callback-ref@1.3.2(@types/react@18.3.3)(react@18.2.0):
     dependencies:
-      '@types/react': 18.3.3
       react: 18.2.0
       tslib: 2.6.3
+    optionalDependencies:
+      '@types/react': 18.3.3
 
   use-latest-callback@0.2.1(react@18.2.0):
     dependencies:
@@ -35315,10 +36484,11 @@ snapshots:
 
   use-sidecar@1.1.2(@types/react@18.3.3)(react@18.2.0):
     dependencies:
-      '@types/react': 18.3.3
       detect-node-es: 1.1.0
       react: 18.2.0
       tslib: 2.6.3
+    optionalDependencies:
+      '@types/react': 18.3.3
 
   use-sync-external-store@1.2.0(react@18.2.0):
     dependencies:
@@ -35392,13 +36562,13 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vite-node@1.6.0:
+  vite-node@1.6.0(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3):
     dependencies:
       cac: 6.7.14
       debug: 4.3.5(supports-color@8.1.1)
       pathe: 1.1.2
       picocolors: 1.0.1
-      vite: 5.3.4(sass@1.77.8)
+      vite: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -35409,44 +36579,27 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@1.6.0(@types/node@20.14.11):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.3.5(supports-color@8.1.1)
-      pathe: 1.1.2
-      picocolors: 1.0.1
-      vite: 5.3.4(@types/node@20.14.11)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vite-plugin-pwa@0.19.8(vite@5.3.4)(workbox-build@7.1.1)(workbox-window@7.1.0):
+  vite-plugin-pwa@0.19.8(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))(workbox-build@7.1.1(@types/babel__core@7.20.5))(workbox-window@7.1.0):
     dependencies:
       debug: 4.3.5(supports-color@8.1.1)
       fast-glob: 3.3.2
       pretty-bytes: 6.1.1
-      vite: 5.3.4(@types/node@20.14.11)
-      workbox-build: 7.1.1
+      vite: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
+      workbox-build: 7.1.1(@types/babel__core@7.20.5)
       workbox-window: 7.1.0
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-require@1.2.14(@swc/core@1.6.13)(vite@5.3.4):
+  vite-plugin-require@1.2.14(@swc/core@1.6.13(@swc/helpers@0.5.5))(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)):
     dependencies:
       '@babel/generator': 7.24.10
       '@babel/parser': 7.24.8
       '@babel/traverse': 7.24.8
       '@babel/types': 7.24.9
       '@vue/compiler-sfc': 3.4.32
-      vite: 5.3.4(@types/node@20.14.11)
-      vue-loader: 17.4.2(@vue/compiler-sfc@3.4.32)(webpack@5.93.0)
-      webpack: 5.93.0(@swc/core@1.6.13)
+      vite: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
+      vue-loader: 17.4.2(@vue/compiler-sfc@3.4.32)(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5)))
+      webpack: 5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5))
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -35455,149 +36608,91 @@ snapshots:
       - vue
       - webpack-cli
 
-  vite-plugin-top-level-await@1.4.1(rollup@2.79.1)(vite@5.3.4):
+  vite-plugin-top-level-await@1.4.1(@swc/helpers@0.5.5)(rollup@2.79.1)(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@2.79.1)
-      '@swc/core': 1.6.13
+      '@swc/core': 1.6.13(@swc/helpers@0.5.5)
       uuid: 9.0.1
-      vite: 5.3.4(@types/node@20.14.11)
+      vite: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
     transitivePeerDependencies:
       - '@swc/helpers'
       - rollup
 
-  vite-plugin-vuetify@2.0.3(vite@5.3.4)(vue@3.4.21)(vuetify@3.6.8):
+  vite-plugin-top-level-await@1.4.1(@swc/helpers@0.5.5)(rollup@4.18.1)(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)):
     dependencies:
-      '@vuetify/loader-shared': 2.0.3(vue@3.4.21)(vuetify@3.6.8)
+      '@rollup/plugin-virtual': 3.0.2(rollup@4.18.1)
+      '@swc/core': 1.6.13(@swc/helpers@0.5.5)
+      uuid: 9.0.1
+      vite: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
+    transitivePeerDependencies:
+      - '@swc/helpers'
+      - rollup
+
+  vite-plugin-vuetify@2.0.3(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))(vue@3.4.21(typescript@5.5.3))(vuetify@3.6.8):
+    dependencies:
+      '@vuetify/loader-shared': 2.0.3(vue@3.4.21(typescript@5.5.3))(vuetify@3.6.8(typescript@5.5.3)(vite-plugin-vuetify@2.0.3)(vue@3.4.21(typescript@5.5.3)))
       debug: 4.3.5(supports-color@8.1.1)
       upath: 2.0.1
-      vite: 5.3.4(sass@1.77.8)
+      vite: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
       vue: 3.4.21(typescript@5.5.3)
-      vuetify: 3.6.8(typescript@5.5.3)(vite-plugin-vuetify@2.0.3)(vue@3.4.21)
+      vuetify: 3.6.8(typescript@5.5.3)(vite-plugin-vuetify@2.0.3)(vue@3.4.21(typescript@5.5.3))
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-wasm@3.3.0(vite@5.3.4):
+  vite-plugin-wasm@3.3.0(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)):
     dependencies:
-      vite: 5.3.4(@types/node@20.14.11)
+      vite: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
 
   vite@5.3.2(@types/node@20.14.11)(less@4.2.0)(sass@1.77.6)(terser@5.29.2):
     dependencies:
-      '@types/node': 20.14.11
       esbuild: 0.21.5
-      less: 4.2.0
       postcss: 8.4.38
       rollup: 4.18.1
+    optionalDependencies:
+      '@types/node': 20.14.11
+      fsevents: 2.3.3
+      less: 4.2.0
       sass: 1.77.6
       terser: 5.29.2
-    optionalDependencies:
-      fsevents: 2.3.3
 
-  vite@5.3.4(@types/node@20.14.11):
+  vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3):
     dependencies:
+      esbuild: 0.21.5
+      postcss: 8.4.39
+      rollup: 4.18.1
+    optionalDependencies:
       '@types/node': 20.14.11
-      esbuild: 0.21.5
-      postcss: 8.4.39
-      rollup: 4.18.1
-    optionalDependencies:
       fsevents: 2.3.3
-
-  vite@5.3.4(sass@1.77.8):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.4.39
-      rollup: 4.18.1
+      less: 4.2.0
       sass: 1.77.8
+      terser: 5.31.3
+
+  vitest@1.6.0(@types/node@20.14.11)(@vitest/browser@1.6.0)(jsdom@24.1.0)(less@4.2.0)(sass@1.77.8)(terser@5.31.3):
+    dependencies:
+      '@vitest/expect': 1.6.0
+      '@vitest/runner': 1.6.0
+      '@vitest/snapshot': 1.6.0
+      '@vitest/spy': 1.6.0
+      '@vitest/utils': 1.6.0
+      acorn-walk: 8.3.3
+      chai: 4.4.1
+      debug: 4.3.5(supports-color@8.1.1)
+      execa: 8.0.1
+      local-pkg: 0.5.0
+      magic-string: 0.30.10
+      pathe: 1.1.2
+      picocolors: 1.0.1
+      std-env: 3.7.0
+      strip-literal: 2.1.0
+      tinybench: 2.8.0
+      tinypool: 0.8.4
+      vite: 5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
+      vite-node: 1.6.0(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3)
+      why-is-node-running: 2.3.0
     optionalDependencies:
-      fsevents: 2.3.3
-
-  vitest@1.6.0(@types/node@20.14.11)(@vitest/browser@1.6.0):
-    dependencies:
       '@types/node': 20.14.11
-      '@vitest/browser': 1.6.0(vitest@1.6.0)(webdriverio@8.39.1)
-      '@vitest/expect': 1.6.0
-      '@vitest/runner': 1.6.0
-      '@vitest/snapshot': 1.6.0
-      '@vitest/spy': 1.6.0
-      '@vitest/utils': 1.6.0
-      acorn-walk: 8.3.3
-      chai: 4.4.1
-      debug: 4.3.5(supports-color@8.1.1)
-      execa: 8.0.1
-      local-pkg: 0.5.0
-      magic-string: 0.30.10
-      pathe: 1.1.2
-      picocolors: 1.0.1
-      std-env: 3.7.0
-      strip-literal: 2.1.0
-      tinybench: 2.8.0
-      tinypool: 0.8.4
-      vite: 5.3.4(@types/node@20.14.11)
-      vite-node: 1.6.0(@types/node@20.14.11)
-      why-is-node-running: 2.3.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vitest@1.6.0(@vitest/browser@1.6.0):
-    dependencies:
-      '@vitest/browser': 1.6.0(vitest@1.6.0)(webdriverio@8.39.1)
-      '@vitest/expect': 1.6.0
-      '@vitest/runner': 1.6.0
-      '@vitest/snapshot': 1.6.0
-      '@vitest/spy': 1.6.0
-      '@vitest/utils': 1.6.0
-      acorn-walk: 8.3.3
-      chai: 4.4.1
-      debug: 4.3.5(supports-color@8.1.1)
-      execa: 8.0.1
-      local-pkg: 0.5.0
-      magic-string: 0.30.10
-      pathe: 1.1.2
-      picocolors: 1.0.1
-      std-env: 3.7.0
-      strip-literal: 2.1.0
-      tinybench: 2.8.0
-      tinypool: 0.8.4
-      vite: 5.3.4(sass@1.77.8)
-      vite-node: 1.6.0
-      why-is-node-running: 2.3.0
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vitest@1.6.0(jsdom@24.1.0):
-    dependencies:
-      '@vitest/expect': 1.6.0
-      '@vitest/runner': 1.6.0
-      '@vitest/snapshot': 1.6.0
-      '@vitest/spy': 1.6.0
-      '@vitest/utils': 1.6.0
-      acorn-walk: 8.3.3
-      chai: 4.4.1
-      debug: 4.3.5(supports-color@8.1.1)
-      execa: 8.0.1
+      '@vitest/browser': 1.6.0(vitest@1.6.0)(webdriverio@8.39.1(typescript@5.5.3))
       jsdom: 24.1.0
-      local-pkg: 0.5.0
-      magic-string: 0.30.10
-      pathe: 1.1.2
-      picocolors: 1.0.1
-      std-env: 3.7.0
-      strip-literal: 2.1.0
-      tinybench: 2.8.0
-      tinypool: 0.8.4
-      vite: 5.3.4(sass@1.77.8)
-      vite-node: 1.6.0
-      why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -35617,19 +36712,20 @@ snapshots:
 
   vscode-uri@3.0.8: {}
 
-  vue-demi@0.13.11(vue@3.4.21):
+  vue-demi@0.13.11(vue@3.4.21(typescript@5.5.3)):
     dependencies:
       vue: 3.4.21(typescript@5.5.3)
 
-  vue-loader@17.4.2(@vue/compiler-sfc@3.4.32)(webpack@5.93.0):
+  vue-loader@17.4.2(@vue/compiler-sfc@3.4.32)(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5))):
     dependencies:
-      '@vue/compiler-sfc': 3.4.32
       chalk: 4.1.2
       hash-sum: 2.0.0
       watchpack: 2.4.1
-      webpack: 5.93.0(@swc/core@1.6.13)
+      webpack: 5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5))
+    optionalDependencies:
+      '@vue/compiler-sfc': 3.4.32
 
-  vue-router@4.4.0(vue@3.4.21):
+  vue-router@4.4.0(vue@3.4.21(typescript@5.5.3)):
     dependencies:
       '@vue/devtools-api': 6.6.3
       vue: 3.4.21(typescript@5.5.3)
@@ -35656,15 +36752,17 @@ snapshots:
       '@vue/compiler-dom': 3.4.21
       '@vue/compiler-sfc': 3.4.21
       '@vue/runtime-dom': 3.4.21
-      '@vue/server-renderer': 3.4.21(vue@3.4.21)
+      '@vue/server-renderer': 3.4.21(vue@3.4.21(typescript@5.5.3))
       '@vue/shared': 3.4.21
+    optionalDependencies:
       typescript: 5.5.3
 
-  vuetify@3.6.8(typescript@5.5.3)(vite-plugin-vuetify@2.0.3)(vue@3.4.21):
+  vuetify@3.6.8(typescript@5.5.3)(vite-plugin-vuetify@2.0.3)(vue@3.4.21(typescript@5.5.3)):
     dependencies:
-      typescript: 5.5.3
-      vite-plugin-vuetify: 2.0.3(vite@5.3.4)(vue@3.4.21)(vuetify@3.6.8)
       vue: 3.4.21(typescript@5.5.3)
+    optionalDependencies:
+      typescript: 5.5.3
+      vite-plugin-vuetify: 2.0.3(vite@5.3.4(@types/node@20.14.11)(less@4.2.0)(sass@1.77.8)(terser@5.31.3))(vue@3.4.21(typescript@5.5.3))(vuetify@3.6.8)
 
   w3c-keyname@2.2.8: {}
 
@@ -35794,9 +36892,9 @@ snapshots:
   webpack-cli@5.1.4(webpack@5.93.0):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.93.0)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.93.0)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.93.0)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.93.0(webpack-cli@5.1.4))
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.93.0(webpack-cli@5.1.4))
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack@5.93.0))(webpack@5.93.0(webpack-cli@5.1.4))
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.3
@@ -35815,9 +36913,9 @@ snapshots:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0
 
-  webpack-dev-middleware@7.2.1(webpack@5.92.1):
+  webpack-dev-middleware@7.2.1(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.9.3
@@ -35825,7 +36923,8 @@ snapshots:
       on-finished: 2.4.1
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.92.1(esbuild@0.21.5)
+    optionalDependencies:
+      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)
 
   webpack-dev-server@4.15.2(webpack@5.93.0):
     dependencies:
@@ -35857,16 +36956,17 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.93.0(webpack-cli@5.1.4)
       webpack-dev-middleware: 5.3.4(webpack@5.93.0)
       ws: 8.18.0
+    optionalDependencies:
+      webpack: 5.93.0
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  webpack-dev-server@5.0.4(webpack@5.92.1):
+  webpack-dev-server@5.0.4(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -35896,9 +36996,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.92.1
-      webpack-dev-middleware: 7.2.1(webpack@5.92.1)
+      webpack-dev-middleware: 7.2.1(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))
       ws: 8.18.0
+    optionalDependencies:
+      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -35913,14 +37014,16 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack-subresource-integrity@5.1.0(webpack@5.92.1):
+  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.0(webpack@5.92.1(@swc/core@1.6.13)))(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)):
     dependencies:
       typed-assert: 1.0.9
-      webpack: 5.92.1(esbuild@0.21.5)
+      webpack: 5.92.1(@swc/core@1.6.13)(esbuild@0.21.5)
+    optionalDependencies:
+      html-webpack-plugin: 5.6.0(webpack@5.92.1(@swc/core@1.6.13))
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.92.1:
+  webpack@5.92.1(@swc/core@1.6.13):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.5
@@ -35943,7 +37046,39 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.92.1)
+      terser-webpack-plugin: 5.3.10(@swc/core@1.6.13)(webpack@5.92.1(@swc/core@1.6.13))
+      watchpack: 2.4.1
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    optional: true
+
+  webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.5
+      '@webassemblyjs/ast': 1.12.1
+      '@webassemblyjs/wasm-edit': 1.12.1
+      '@webassemblyjs/wasm-parser': 1.12.1
+      acorn: 8.12.1
+      acorn-import-attributes: 1.9.5(acorn@8.12.1)
+      browserslist: 4.23.2
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.17.0
+      es-module-lexer: 1.5.4
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.10(@swc/core@1.6.13)(esbuild@0.21.5)(webpack@5.92.1(@swc/core@1.6.13)(esbuild@0.21.5))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -35951,7 +37086,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.92.1(esbuild@0.21.5):
+  webpack@5.93.0:
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.5
@@ -35974,7 +37109,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(esbuild@0.21.5)(webpack@5.92.1)
+      terser-webpack-plugin: 5.3.10(webpack@5.93.0)
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -35982,7 +37117,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.93.0(@swc/core@1.6.13):
+  webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5)):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.5
@@ -36005,7 +37140,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.6.13)(webpack@5.93.0)
+      terser-webpack-plugin: 5.3.10(@swc/core@1.6.13(@swc/helpers@0.5.5))(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.5)))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -36036,10 +37171,11 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.93.0)
+      terser-webpack-plugin: 5.3.10(webpack@5.93.0(webpack-cli@5.1.4))
       watchpack: 2.4.1
-      webpack-cli: 5.1.4(webpack@5.93.0)
       webpack-sources: 3.2.3
+    optionalDependencies:
+      webpack-cli: 5.1.4(webpack@5.93.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -36051,7 +37187,7 @@ snapshots:
       consola: 2.15.3
       pretty-time: 1.1.0
       std-env: 3.7.0
-      webpack: 5.93.0(webpack-cli@5.1.4)
+      webpack: 5.93.0
 
   websocket-driver@0.7.4:
     dependencies:
@@ -36188,13 +37324,13 @@ snapshots:
     dependencies:
       workbox-core: 7.1.0
 
-  workbox-build@7.1.1:
+  workbox-build@7.1.1(@types/babel__core@7.20.5):
     dependencies:
       '@apideck/better-ajv-errors': 0.3.6(ajv@8.17.1)
       '@babel/core': 7.24.5
       '@babel/preset-env': 7.24.8(@babel/core@7.24.5)
       '@babel/runtime': 7.24.8
-      '@rollup/plugin-babel': 5.3.1(@babel/core@7.24.5)(rollup@2.79.1)
+      '@rollup/plugin-babel': 5.3.1(@babel/core@7.24.5)(@types/babel__core@7.20.5)(rollup@2.79.1)
       '@rollup/plugin-node-resolve': 15.2.3(rollup@2.79.1)
       '@rollup/plugin-replace': 2.4.2(rollup@2.79.1)
       '@rollup/plugin-terser': 0.4.4(rollup@2.79.1)
@@ -36389,7 +37525,7 @@ snapshots:
 
   xterm@4.19.0: {}
 
-  y-prosemirror@1.0.20(prosemirror-model@1.22.1)(prosemirror-state@1.4.3)(prosemirror-view@1.33.8)(y-protocols@1.0.6)(yjs@13.6.18):
+  y-prosemirror@1.0.20(prosemirror-model@1.22.1)(prosemirror-state@1.4.3)(prosemirror-view@1.33.8)(y-protocols@1.0.6(yjs@13.6.18))(yjs@13.6.18):
     dependencies:
       lib0: 0.2.94
       prosemirror-model: 1.22.1
@@ -36508,10 +37644,12 @@ snapshots:
 
   zone.js@0.14.8: {}
 
-  zustand@4.5.4(@types/react@18.3.3)(react@18.2.0):
+  zustand@4.5.4(@types/react@18.3.3)(immer@9.0.21)(react@18.2.0):
     dependencies:
-      '@types/react': 18.3.3
-      react: 18.2.0
       use-sync-external-store: 1.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      immer: 9.0.21
+      react: 18.2.0
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -875,6 +875,9 @@ importers:
       react-native-elements:
         specifier: ^3.4.3
         version: 3.4.3(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0))(react-native-vector-icons@10.1.0)(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
+      react-native-encrypted-storage:
+        specifier: ^4.0.3
+        version: 4.0.3(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
       react-native-fetch-api:
         specifier: ^3.0.0
         version: 3.0.0
@@ -33671,6 +33674,11 @@ snapshots:
     transitivePeerDependencies:
       - react
       - react-native
+
+  react-native-encrypted-storage@4.0.3(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
+    dependencies:
+      react: 18.2.0
+      react-native: 0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.24.8(@babel/core@7.24.5))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0)
 
   react-native-encrypted-storage@4.0.3(react-native@0.74.1(@babel/core@7.24.7)(@babel/preset-env@7.24.8(@babel/core@7.24.7))(@types/react@18.2.79)(encoding@0.1.13)(react@18.2.0))(react@18.2.0):
     dependencies:


### PR DESCRIPTION
## Description
There appears to be an issue with pnpm update (https://github.com/pnpm/pnpm/pull/7633/files) which has resulted in `workspace` changing behaviour when publishing. As a result it duplicates the package version resulting in something like `1.3.0^1.3.0`. We are therefore changing the `peerDeps` range to use `^` and removing the version number i.e. no longer `^1.3.0` and just `^`.

When the packages are updated this should resolve this https://github.com/powersync-ja/powersync-js/issues/231