### PR TITLE
[Fix] WebSocket close bug

### DIFF
--- a/.changeset/pretty-zebras-brush.md
+++ b/.changeset/pretty-zebras-brush.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Fix issue where WebSockets might not close under some error conditions.

--- a/packages/common/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/common/src/client/sync/stream/AbstractRemote.ts
@@ -256,6 +256,13 @@ export abstract class AbstractRemote {
     // We initially request this amount and expect these to arrive eventually
     let pendingEventsCount = SYNC_QUEUE_REQUEST_N;
 
+    const closedListener = stream.registerListener({
+      closed: () => {
+        closeSocket();
+        closedListener();
+      }
+    });
+
     const socket = await new Promise<Requestable>((resolve, reject) => {
       let connectionEstablished = false;
 
@@ -275,9 +282,8 @@ export abstract class AbstractRemote {
             if (e.message !== 'Closed. ') {
               this.logger.error(e);
             }
-            // RSocket will close this automatically
-            // Attempting to close multiple times causes a console warning
-            socketIsClosed = true;
+            // RSocket will close the RSocket stream automatically
+            // Close the downstream stream as well - this will close the RSocket connection
             stream.close();
             // Handles cases where the connection failed e.g. auth error or connection error
             if (!connectionEstablished) {
@@ -318,8 +324,7 @@ export abstract class AbstractRemote {
         }
       },
       closed: () => {
-        closeSocket();
-        l?.();
+        l();
       }
     });
 

--- a/packages/common/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/common/src/client/sync/stream/AbstractRemote.ts
@@ -253,13 +253,15 @@ export abstract class AbstractRemote {
       socketIsClosed = true;
       rsocket.close();
     };
+    // Helps to prevent double close scenarios
+    rsocket.onClose(() => (socketIsClosed = true));
     // We initially request this amount and expect these to arrive eventually
     let pendingEventsCount = SYNC_QUEUE_REQUEST_N;
 
-    const closedListener = stream.registerListener({
+    const disposeClosedListener = stream.registerListener({
       closed: () => {
         closeSocket();
-        closedListener();
+        disposeClosedListener();
       }
     });
 
@@ -283,7 +285,7 @@ export abstract class AbstractRemote {
               this.logger.error(e);
             }
             // RSocket will close the RSocket stream automatically
-            // Close the downstream stream as well - this will close the RSocket connection
+            // Close the downstream stream as well - this will close the RSocket connection and WebSocket
             stream.close();
             // Handles cases where the connection failed e.g. auth error or connection error
             if (!connectionEstablished) {


### PR DESCRIPTION
# Overview

RSocket allows for multiple endpoints to be handled over a single connection. We currently only use a connection to perform a single `stream` request to the `sync/stream` route.  

RSocket will close the `stream` on error, but it won't close the main connection. This means under some circumstances, such as `stream` authentication errors, the WebSocket won't be closed by the client. 

This PR updates the logic to close the connection and WebSocket whenever an error occurs. Extra logic is added to cater for cases where the `stream` is not accepted by the server.

## Testing

This was tested locally by logging the number of active WebSocket connections during various error states.

Before (without changes from https://github.com/powersync-ja/powersync-service/pull/45): The number of active clients would increase on every auth error. 
![image](https://github.com/user-attachments/assets/e065b4e9-dbe1-402c-aa3a-8bb5eb1560de)

After: The number of connected clients remains at `1` which is the current request.
![image](https://github.com/user-attachments/assets/90af3aa5-07bb-48a1-9940-9610d935244b)


This has been tested with and without the changes from https://github.com/powersync-ja/powersync-service/pull/45. The Socket should be closed under both circumstances.

