### PR TITLE
Ignore demos for changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["demos/*"],
+  "ignore": ["!@powersync/*"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true,
     "updateInternalDependents": "out-of-range"

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": [],
+  "ignore": ["demos/*"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true,
     "updateInternalDependents": "out-of-range"


### PR DESCRIPTION
The demo packages make version bump pull requests become very verbose on simple changes to `@powersync/common` or similar core packages. See an example [here](https://github.com/powersync-ja/powersync-js/pull/236).

This excludes demos from changesets completely. This means we'll have to manually manage changelots for those when we do make significant changes.
