### PR TITLE
chore: revert @powersync/common peer dep workspace change

### DIFF
--- a/.changeset/shaggy-walls-hang.md
+++ b/.changeset/shaggy-walls-hang.md
@@ -1,0 +1,10 @@
+---
+'@powersync/kysely-driver': patch
+'@powersync/react-native': patch
+'@powersync/attachments': patch
+'@powersync/react': patch
+'@powersync/vue': patch
+'@powersync/web': patch
+---
+
+revert peer dep change

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,9 @@ jobs:
       - uses: pnpm/action-setup@v2
         name: Install pnpm
         with:
-          version: 9
+          # Pnpm 9.4 introduces this https://github.com/pnpm/pnpm/pull/7633
+          # which causes workspace:^1.2.0 to be converted to 1.2.0^1.2.0
+          version: 9.3
           run_install: false
       - name: Get pnpm store directory
         shell: bash

--- a/packages/attachments/package.json
+++ b/packages/attachments/package.json
@@ -27,6 +27,6 @@
     "watch": "tsc -b -w"
   },
   "peerDependencies": {
-    "@powersync/common": "workspace:^"
+    "@powersync/common": "workspace:^1.13.0"
   }
 }

--- a/packages/kysely-driver/package.json
+++ b/packages/kysely-driver/package.json
@@ -25,7 +25,7 @@
     "test": "pnpm build && vitest"
   },
   "peerDependencies": {
-    "@powersync/common": "workspace:^"
+    "@powersync/common": "workspace:^1.13.0"
   },
   "dependencies": {
     "kysely": "^0.27.2"

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -31,7 +31,7 @@
     "react": "*",
     "react-native": "*",
     "react-native-polyfill-globals": "^3.1.0",
-    "@powersync/common": "workspace:^"
+    "@powersync/common": "workspace:^1.13.0"
   },
   "dependencies": {
     "@powersync/react": "workspace:*",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://docs.powersync.com",
   "peerDependencies": {
     "react": "*",
-    "@powersync/common": "workspace:^"
+    "@powersync/common": "workspace:^1.13.0"
   },
   "devDependencies": {
     "@testing-library/react": "^15.0.2",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://docs.powersync.com",
   "peerDependencies": {
     "vue": "*",
-    "@powersync/common": "workspace:^"
+    "@powersync/common": "workspace:^1.13.0"
   },
   "devDependencies": {
     "flush-promises": "^1.0.2",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -34,7 +34,7 @@
   "license": "Apache-2.0",
   "peerDependencies": {
     "@journeyapps/wa-sqlite": "~0.2.0",
-    "@powersync/common": "workspace:^"
+    "@powersync/common": "workspace:^1.13.0"
   },
   "dependencies": {
     "@powersync/common": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1328,7 +1328,7 @@ importers:
   packages/attachments:
     dependencies:
       '@powersync/common':
-        specifier: workspace:^
+        specifier: workspace:^1.13.0
         version: link:../common
 
   packages/common:
@@ -1383,7 +1383,7 @@ importers:
   packages/kysely-driver:
     dependencies:
       '@powersync/common':
-        specifier: workspace:^
+        specifier: workspace:^1.13.0
         version: link:../common
       kysely:
         specifier: ^0.27.2
@@ -1429,7 +1429,7 @@ importers:
   packages/react:
     dependencies:
       '@powersync/common':
-        specifier: workspace:^
+        specifier: workspace:^1.13.0
         version: link:../common
     devDependencies:
       '@testing-library/react':
@@ -1488,7 +1488,7 @@ importers:
   packages/vue:
     dependencies:
       '@powersync/common':
-        specifier: workspace:^
+        specifier: workspace:^1.13.0
         version: link:../common
     devDependencies:
       flush-promises:


### PR DESCRIPTION
## Description
We need to revert this previous PR https://github.com/powersync-ja/powersync-js/pull/235 as it is causing changesets to make major version updates.

In order to avoid the previous issue where e.g, `workspace:^1.2.0` is changed to `1.2.0^1.2.0`, this PR also reduces the pnpm version for the release github action to use `pnpm 9.3` as `9.4` and newer introduces the issue.