### PR TITLE
[Feature] Add warning if crud transactions are not completed

### DIFF
--- a/.changeset/mean-carrots-relax.md
+++ b/.changeset/mean-carrots-relax.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': minor
+---
+
+Added a warning if connector `uploadData` functions don't process CRUD items completely.

--- a/.changeset/mean-carrots-relax.md
+++ b/.changeset/mean-carrots-relax.md
@@ -1,5 +1,7 @@
 ---
 '@powersync/common': minor
+'@powersync/web': minor
+'@powersync/react-native': minor
 ---
 
 Added a warning if connector `uploadData` functions don't process CRUD items completely.

--- a/demos/react-native-supabase-todolist/ios/Podfile.lock
+++ b/demos/react-native-supabase-todolist/ios/Podfile.lock
@@ -21,7 +21,7 @@ PODS:
     - ExpoModulesCore
   - ExpoKeepAwake (13.0.2):
     - ExpoModulesCore
-  - ExpoModulesCore (1.12.13):
+  - ExpoModulesCore (1.12.19):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1340,7 +1340,7 @@ DEPENDENCIES:
   - boost (from `../../../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - DoubleConversion (from `../../../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - EXConstants (from `../../../node_modules/expo-constants/ios`)
-  - Expo (from `../node_modules/expo`)
+  - Expo (from `../../../node_modules/expo`)
   - ExpoAsset (from `../../../node_modules/expo-asset/ios`)
   - ExpoCamera (from `../../../node_modules/expo-camera/ios`)
   - ExpoCrypto (from `../../../node_modules/expo-crypto/ios`)
@@ -1348,7 +1348,7 @@ DEPENDENCIES:
   - ExpoFont (from `../../../node_modules/expo-font/ios`)
   - ExpoHead (from `../../../node_modules/expo-router/ios`)
   - ExpoKeepAwake (from `../../../node_modules/expo-keep-awake/ios`)
-  - ExpoModulesCore (from `../node_modules/expo-modules-core`)
+  - ExpoModulesCore (from `../../../node_modules/expo-modules-core`)
   - ExpoSecureStore (from `../../../node_modules/expo-secure-store/ios`)
   - EXSplashScreen (from `../../../node_modules/expo-splash-screen/ios`)
   - FBLazyVector (from `../../../node_modules/react-native/Libraries/FBLazyVector`)
@@ -1428,7 +1428,7 @@ EXTERNAL SOURCES:
   EXConstants:
     :path: "../../../node_modules/expo-constants/ios"
   Expo:
-    :path: "../node_modules/expo"
+    :path: "../../../node_modules/expo"
   ExpoAsset:
     :path: "../../../node_modules/expo-asset/ios"
   ExpoCamera:
@@ -1444,7 +1444,7 @@ EXTERNAL SOURCES:
   ExpoKeepAwake:
     :path: "../../../node_modules/expo-keep-awake/ios"
   ExpoModulesCore:
-    :path: "../node_modules/expo-modules-core"
+    :path: "../../../node_modules/expo-modules-core"
   ExpoSecureStore:
     :path: "../../../node_modules/expo-secure-store/ios"
   EXSplashScreen:
@@ -1583,7 +1583,7 @@ SPEC CHECKSUMS:
   ExpoFont: e7f2275c10ca8573c991e007329ad6bf98086485
   ExpoHead: 8eb4deb289c2fdd8bb624f996cd31414cd07f38a
   ExpoKeepAwake: 3b8815d9dd1d419ee474df004021c69fdd316d08
-  ExpoModulesCore: a4b45b5f081f5fe9b8e87667906d180cd52f32d7
+  ExpoModulesCore: 734c1802786b23c9598f4d15273753a779969368
   ExpoSecureStore: 060cebcb956b80ddae09821610ac1aa9e1ac74cd
   EXSplashScreen: fbf0ec78e9cee911df188bf17b4fe51d15a84b87
   FBLazyVector: 898d14d17bf19e2435cafd9ea2a1033efe445709

--- a/packages/common/src/client/sync/bucket/BucketStorageAdapter.ts
+++ b/packages/common/src/client/sync/bucket/BucketStorageAdapter.ts
@@ -1,7 +1,7 @@
-import { OpId } from './CrudEntry';
-import { CrudBatch } from './CrudBatch';
-import { SyncDataBatch } from './SyncDataBatch';
 import { BaseListener, BaseObserver, Disposable } from '../../../utils/BaseObserver';
+import { CrudBatch } from './CrudBatch';
+import { CrudEntry, OpId } from './CrudEntry';
+import { SyncDataBatch } from './SyncDataBatch';
 
 export interface Checkpoint {
   last_op_id: OpId;
@@ -62,6 +62,7 @@ export interface BucketStorageAdapter extends BaseObserver<BucketStorageListener
 
   syncLocalDatabase(checkpoint: Checkpoint): Promise<{ checkpointValid: boolean; ready: boolean; failures?: any[] }>;
 
+  nextCrudItem(): Promise<CrudEntry | undefined>;
   hasCrud(): Promise<boolean>;
   getCrudBatch(limit?: number): Promise<CrudBatch | null>;
 

--- a/packages/common/src/client/sync/bucket/SqliteBucketStorage.ts
+++ b/packages/common/src/client/sync/bucket/SqliteBucketStorage.ts
@@ -1,5 +1,7 @@
 import { Mutex } from 'async-mutex';
+import Logger, { ILogger } from 'js-logger';
 import { DBAdapter, Transaction, extractTableUpdates } from '../../../db/DBAdapter';
+import { BaseObserver } from '../../../utils/BaseObserver';
 import {
   BucketState,
   BucketStorageAdapter,
@@ -8,12 +10,10 @@ import {
   PSInternalTable,
   SyncLocalDatabaseResult
 } from './BucketStorageAdapter';
-import { OpTypeEnum } from './OpType';
 import { CrudBatch } from './CrudBatch';
-import { CrudEntry } from './CrudEntry';
+import { CrudEntry, CrudEntryJSON } from './CrudEntry';
+import { OpTypeEnum } from './OpType';
 import { SyncDataBatch } from './SyncDataBatch';
-import Logger, { ILogger } from 'js-logger';
-import { BaseObserver } from '../../../utils/BaseObserver';
 
 const COMPACT_OPERATION_INTERVAL = 1_000;
 
@@ -51,10 +51,10 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
 
   async init() {
     this._hasCompletedSync = false;
-    const existingTableRows = await this.db.execute(
+    const existingTableRows = await this.db.getAll<{ name: string }>(
       `SELECT name FROM sqlite_master WHERE type='table' AND name GLOB 'ps_data_*'`
     );
-    for (const row of existingTableRows.rows?._array ?? []) {
+    for (const row of existingTableRows ?? []) {
       this.tableNames.add(row.name);
     }
   }
@@ -72,10 +72,10 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
   startSession(): void {}
 
   async getBucketStates(): Promise<BucketState[]> {
-    const result = await this.db.execute(
+    const result = await this.db.getAll<BucketState>(
       'SELECT name as bucket, cast(last_op as TEXT) as op_id FROM ps_buckets WHERE pending_delete = 0'
     );
-    return result.rows?._array ?? [];
+    return result;
   }
 
   async saveSyncData(batch: SyncDataBatch) {
@@ -258,19 +258,20 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
   }
 
   async updateLocalTarget(cb: () => Promise<string>): Promise<boolean> {
-    const rs1 = await this.db.execute("SELECT target_op FROM ps_buckets WHERE name = '$local' AND target_op = ?", [
+    const rs1 = await this.db.getAll("SELECT target_op FROM ps_buckets WHERE name = '$local' AND target_op = ?", [
       SqliteBucketStorage.MAX_OP_ID
     ]);
-    if (!rs1.rows?.length) {
+    if (!rs1.length) {
       // Nothing to update
       return false;
     }
-    const rs = await this.db.execute("SELECT seq FROM sqlite_sequence WHERE name = 'ps_crud'");
-    if (!rs.rows?.length) {
+    const rs = await this.db.getAll<{ seq: number }>("SELECT seq FROM sqlite_sequence WHERE name = 'ps_crud'");
+    if (!rs.length) {
       // Nothing to update
       return false;
     }
-    const seqBefore: number = rs.rows?.item(0)['seq'];
+
+    const seqBefore: number = rs[0]['seq'];
 
     const opId = await cb();
 
@@ -304,9 +305,17 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
     });
   }
 
+  async nextCrudItem(): Promise<CrudEntry | undefined> {
+    const next = await this.db.getOptional<CrudEntryJSON>('SELECT * FROM ps_crud ORDER BY id ASC LIMIT 1');
+    if (!next) {
+      return;
+    }
+    return CrudEntry.fromRow(next);
+  }
+
   async hasCrud(): Promise<boolean> {
-    const anyData = await this.db.execute('SELECT 1 FROM ps_crud LIMIT 1');
-    return !!anyData.rows?.length;
+    const anyData = await this.db.getOptional('SELECT 1 FROM ps_crud LIMIT 1');
+    return !!anyData;
   }
 
   /**
@@ -318,10 +327,10 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
       return null;
     }
 
-    const crudResult = await this.db.execute('SELECT * FROM ps_crud ORDER BY id ASC LIMIT ?', [limit]);
+    const crudResult = await this.db.getAll<CrudEntryJSON>('SELECT * FROM ps_crud ORDER BY id ASC LIMIT ?', [limit]);
 
     const all: CrudEntry[] = [];
-    for (const row of crudResult.rows?._array ?? []) {
+    for (const row of crudResult) {
       all.push(CrudEntry.fromRow(row));
     }
 

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -2,6 +2,13 @@ import throttle from 'lodash/throttle';
 
 import Logger, { ILogger } from 'js-logger';
 
+import { SyncStatus, SyncStatusOptions } from '../../../db/crud/SyncStatus';
+import { AbortOperation } from '../../../utils/AbortOperation';
+import { BaseListener, BaseObserver, Disposable } from '../../../utils/BaseObserver';
+import { BucketChecksum, BucketStorageAdapter, Checkpoint } from '../bucket/BucketStorageAdapter';
+import { CrudEntry } from '../bucket/CrudEntry';
+import { SyncDataBucket } from '../bucket/SyncDataBucket';
+import { AbstractRemote, SyncStreamOptions } from './AbstractRemote';
 import {
   BucketRequest,
   StreamingSyncRequestParameterType,
@@ -11,12 +18,6 @@ import {
   isStreamingSyncCheckpointDiff,
   isStreamingSyncData
 } from './streaming-sync-types';
-import { AbstractRemote, SyncStreamOptions } from './AbstractRemote';
-import { BucketChecksum, BucketStorageAdapter, Checkpoint } from '../bucket/BucketStorageAdapter';
-import { SyncStatus, SyncStatusOptions } from '../../../db/crud/SyncStatus';
-import { SyncDataBucket } from '../bucket/SyncDataBucket';
-import { BaseObserver, BaseListener, Disposable } from '../../../utils/BaseObserver';
-import { AbortOperation } from '../../../utils/AbortOperation';
 
 export enum LockType {
   CRUD = 'crud',
@@ -215,18 +216,40 @@ export abstract class AbstractStreamingSyncImplementation
     return this.obtainLock({
       type: LockType.CRUD,
       callback: async () => {
-        this.updateSyncStatus({
-          dataFlow: {
-            uploading: true
-          }
-        });
+        /**
+         * Keep track of the first item in the CRUD queue for the last `uploadCrud` iteration.
+         */
+        let checkedCrudItem: CrudEntry | undefined;
+
         while (true) {
+          this.updateSyncStatus({
+            dataFlow: {
+              uploading: true
+            }
+          });
           try {
-            const done = await this.uploadCrudBatch();
-            if (done) {
+            /**
+             * This is the first item in the FIFO CRUD queue.
+             */
+            const nextCrudItem = await this.options.adapter.nextCrudItem();
+            if (nextCrudItem) {
+              if (nextCrudItem.id == checkedCrudItem?.id) {
+                // This will force a higher log level than exceptions which are caught here.
+                this.logger.warn(`Potentially previously uploaded CRUD entries are still present in the upload queue.
+Make sure to handle uploads and complete CRUD transactions or batches by calling and awaiting their [.complete()] method.
+The next upload iteration will be delayed.`);
+                throw new Error('Delaying due to previously encountered CRUD item.');
+              }
+
+              checkedCrudItem = nextCrudItem;
+              await this.options.uploadCrud();
+            } else {
+              // Uploading is completed
+              await this.options.adapter.updateLocalTarget(() => this.getWriteCheckpoint());
               break;
             }
           } catch (ex) {
+            checkedCrudItem = undefined;
             this.updateSyncStatus({
               dataFlow: {
                 uploading: false
@@ -250,17 +273,6 @@ export abstract class AbstractStreamingSyncImplementation
         }
       }
     });
-  }
-
-  protected async uploadCrudBatch(): Promise<boolean> {
-    const hasCrud = await this.options.adapter.hasCrud();
-    if (hasCrud) {
-      await this.options.uploadCrud();
-      return false;
-    } else {
-      await this.options.adapter.updateLocalTarget(() => this.getWriteCheckpoint());
-      return true;
-    }
   }
 
   async connect(options?: PowerSyncConnectionOptions) {

--- a/packages/web/tests/multiple_instances.test.ts
+++ b/packages/web/tests/multiple_instances.test.ts
@@ -243,7 +243,6 @@ describe('Multiple Instances', () => {
     // The status in the second stream client should be updated
     await stream2UpdatedPromise;
 
-    console.log('stream  2 status updated');
     expect(stream2.isConnected).true;
 
     // Create something with CRUD in it.
@@ -256,8 +255,6 @@ describe('Multiple Instances', () => {
     stream1.triggerCrudUpload();
     // The second connector should be called to upload
     await upload2TriggeredPromise;
-
-    console.log('2 upload was triggered');
 
     // It should call the latest connected client
     expect(spy2).toHaveBeenCalledOnce();


### PR DESCRIPTION
# Overview

Currently when processing CRUD items the `PowerSyncDatabase` client will call the backend connector's `uploadData` function whenever `CrudEntry` items are present in the `ps_crud` internal table.

The `uploadData` callback has access to the `PowerSyncDatabase` client which it can use to get the pending `CrudEntry`s. The connector can consume the CRUD events in numerous different ways. 

Typically the `uploadData` callback will either call `getNextCrudTransaction` or `getCrudBatch` on the `PowerSyncDatabase`. 

- `getNextCrudTransaction` will return the next (Single) group of `CrudEntry`s which occurred in the same transaction as an instance of `CrudTransaction`. If an  operation did not occur in a transaction then only a single operation will be returned. 
- `getCrudBatch` returns `n` `CrudEntry`s as an instance of `CrudBatch` . These entires are not grouped by transaction.

The `CrudBatch` and `CrudTransaction` classes each have a `complete` method which will remove the `CrudEntry`s from the CRUD queue. This should be executed in the `uploadData` method after the items have successfully been uploaded.

Given the nature above, there may be more items in the queue than what was consumed by a single invocation of the  `uploadData` method. In this case the SDK will continuously check if `CrudEntry`s are present in the queue and call `uploadData` until the queue is empty. 

Issues can occur if the `uploadData` callback fetches CRUD items and uploads them without calling and awaiting the `CrudTransaction` or `CrudBatch` `complete` method.

Failing to `await` a `complete()` call in the `uploadData` method is mostly guarded in the SDK due to limits on concurrent SQLite operations. Previously the `SqliteBucketStorage` implementation used `.execute` methods for checking if CRUD items were available. Internal queues would (luckily) ensure the next upload iteration would essentially await for the `complete` action to complete. 

Failing to call the `complete()` method altogether is a much worse scenario. This would result in `CrudEntry`s not being removed from the queue (after they have been uploaded). The SDK previously would blindly check if `CrudEntry`s were still present and immediately call `uploadData` to upload them - this will result in an infinite loop of repeated uploads.

This PR replaces the use of the `hasCrud` check with getting the `CrudEntry` which is first in line to be uploaded (the behaviour of `hasCrud` is matched if the entry exists). The SDK can then keep track of this `CrudEntry` in the upload loop. If it sees the same entry that it already processed previously a warning will be printed and the upload loop will be delayed in order to slow down the infinite loop. This does not currently prevent the loop from continuing. 

This should help for issues such as https://github.com/powersync-ja/powersync-js/issues/247. 
