### PR TITLE
[diagnostics-app] support multiple audiences

### DIFF
--- a/.changeset/red-suits-explode.md
+++ b/.changeset/red-suits-explode.md
@@ -1,0 +1,5 @@
+---
+'@powersync/diagnostics-app': patch
+---
+
+Improve extracting endpoint from token audience.

--- a/tools/diagnostics-app/src/components/widgets/LoginDetailsWidget.tsx
+++ b/tools/diagnostics-app/src/components/widgets/LoginDetailsWidget.tsx
@@ -155,10 +155,23 @@ function getTokenEndpoint(token: string) {
   try {
     const [head, body, signature] = token.split('.');
     const payload = JSON.parse(atob(body));
-    const aud = payload.aud as string | undefined;
-    if (aud?.endsWith('.journeyapps.com')) {
-      return aud;
+    const aud = payload.aud as string | string[] | undefined;
+    const audiences = Array.isArray(aud) ? aud : [aud];
+
+    // Prioritize public powersync URL
+    for (let aud of audiences) {
+      if (aud?.match(/^https?:.*.journeyapps.com/)) {
+        return aud;
+      }
     }
+
+    // Fallback to any URL
+    for (let aud of audiences) {
+      if (aud?.match(/^https?:/)) {
+        return aud;
+      }
+    }
+
     return null;
   } catch (e) {
     return null;


### PR DESCRIPTION
 * Support extracting the endpoint from a token with multiple audiences
 * Support self-hosted / generic http endoints.

This can help to reduce friction slightly when using the diagnostics app for local development.

![image](https://github.com/user-attachments/assets/6d92075d-8369-4fa2-8a82-724c5200f89c)

