### PR TITLE
[web] debounce update notifications

### DIFF
--- a/.changeset/strange-feet-explain.md
+++ b/.changeset/strange-feet-explain.md
@@ -1,0 +1,5 @@
+---
+'@powersync/web': patch
+---
+
+Debounce update notifications to fix performance issue with large amounts of data synced

--- a/packages/web/src/db/adapters/wa-sqlite/WASQLiteDBAdapter.ts
+++ b/packages/web/src/db/adapters/wa-sqlite/WASQLiteDBAdapter.ts
@@ -90,16 +90,16 @@ export class WASQLiteDBAdapter extends BaseObserver<DBAdapterListener> implement
 
       this.methods = await dbOpener(this.options.dbFilename);
       this.methods.registerOnTableChange(
-        Comlink.proxy((opType: number, tableName: string, rowId: number) => {
-          this.iterateListeners((cb) => cb.tablesUpdated?.({ opType, table: tableName, rowId }));
+        Comlink.proxy((event) => {
+          this.iterateListeners((cb) => cb.tablesUpdated?.(event));
         })
       );
 
       return;
     }
     this.methods = await _openDB(this.options.dbFilename, { useWebWorker: false });
-    this.methods.registerOnTableChange((opType: number, tableName: string, rowId: number) => {
-      this.iterateListeners((cb) => cb.tablesUpdated?.({ opType, table: tableName, rowId }));
+    this.methods.registerOnTableChange((event) => {
+      this.iterateListeners((cb) => cb.tablesUpdated?.(event));
     });
   }
 

--- a/packages/web/src/shared/types.ts
+++ b/packages/web/src/shared/types.ts
@@ -1,4 +1,4 @@
-import type { QueryResult } from '@powersync/common';
+import type { BatchedUpdateNotification, QueryResult } from '@powersync/common';
 
 export type WASQLExecuteResult = Omit<QueryResult, 'rows'> & {
   rows: {
@@ -22,7 +22,7 @@ export type DBWorkerInterface = DBFunctionsInterface;
 
 export type WASQLiteExecuteMethod = (sql: string, params?: any[]) => Promise<WASQLExecuteResult>;
 export type WASQLiteExecuteBatchMethod = (sql: string, params?: any[]) => Promise<WASQLExecuteResult>;
-export type OnTableChangeCallback = (opType: number, tableName: string, rowId: number) => void;
+export type OnTableChangeCallback = (event: BatchedUpdateNotification) => void;
 export type OpenDB = (dbFileName: string) => DBWorkerInterface;
 
 export type SQLBatchTuple = [string] | [string, Array<any> | Array<Array<any>>];


### PR DESCRIPTION
Firing update notifications for each individual row adds a massive performance overhead.

This change debounces the notifications, only sending a single event per table changed (we never exposed the row ids of changes to the end-user API anyway).

In some test scenarios this gives a 20-25x speedup in initial sync times, for example going from 240s -> 10s for 40k operations.
