### PR TITLE
chore(common): improve enums export and clean up

### DIFF
--- a/.changeset/afraid-bulldogs-check.md
+++ b/.changeset/afraid-bulldogs-check.md
@@ -2,4 +2,4 @@
 '@powersync/common': patch
 ---
 
-Change internals of deleteBucket to use simpler action
+Change internals of `deleteBucket` to use simpler action

--- a/.changeset/hungry-eyes-enjoy.md
+++ b/.changeset/hungry-eyes-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Allow enums to be accessed at runtime by adding `preserveConstEnums` to tsconfig

--- a/packages/common/src/client/constants.ts
+++ b/packages/common/src/client/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_OP_ID = '9223372036854775807';

--- a/packages/common/src/client/sync/bucket/CrudEntry.ts
+++ b/packages/common/src/client/sync/bucket/CrudEntry.ts
@@ -23,7 +23,7 @@ export type CrudEntryJSON = {
   tx_id?: number;
 };
 
-export type CrudEntryDataJSON = {
+type CrudEntryDataJSON = {
   data: Record<string, any>;
   op: UpdateType;
   type: string;
@@ -33,7 +33,7 @@ export type CrudEntryDataJSON = {
 /**
  * The output JSON seems to be a third type of JSON, not the same as the input JSON.
  */
-export type CrudEntryOutputJSON = {
+type CrudEntryOutputJSON = {
   op_id: number;
   op: UpdateType;
   type: string;

--- a/packages/common/src/client/sync/bucket/SqliteBucketStorage.ts
+++ b/packages/common/src/client/sync/bucket/SqliteBucketStorage.ts
@@ -11,6 +11,7 @@ import {
   SyncLocalDatabaseResult
 } from './BucketStorageAdapter';
 import { CrudBatch } from './CrudBatch';
+import { MAX_OP_ID } from '../../constants';
 import { CrudEntry, CrudEntryJSON } from './CrudEntry';
 import { OpTypeEnum } from './OpType';
 import { SyncDataBatch } from './SyncDataBatch';
@@ -18,8 +19,6 @@ import { SyncDataBatch } from './SyncDataBatch';
 const COMPACT_OPERATION_INTERVAL = 1_000;
 
 export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> implements BucketStorageAdapter {
-  static MAX_OP_ID = '9223372036854775807';
-
   public tableNames: Set<string>;
   private pendingBucketDeletes: boolean;
   private _hasCompletedSync: boolean;
@@ -64,7 +63,7 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
   }
 
   getMaxOpId() {
-    return SqliteBucketStorage.MAX_OP_ID;
+    return MAX_OP_ID;
   }
   /**
    * Reset any caches.
@@ -245,7 +244,7 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
 
   async updateLocalTarget(cb: () => Promise<string>): Promise<boolean> {
     const rs1 = await this.db.getAll("SELECT target_op FROM ps_buckets WHERE name = '$local' AND target_op = ?", [
-      SqliteBucketStorage.MAX_OP_ID
+      MAX_OP_ID
     ]);
     if (!rs1.length) {
       // Nothing to update

--- a/packages/common/src/client/sync/bucket/SyncDataBucket.ts
+++ b/packages/common/src/client/sync/bucket/SyncDataBucket.ts
@@ -9,8 +9,6 @@ export type SyncDataBucketJSON = {
   data: OplogEntryJSON[];
 };
 
-export const MAX_OP_ID = '9223372036854775807';
-
 export class SyncDataBucket {
   static fromRow(row: SyncDataBucketJSON) {
     return new SyncDataBucket(

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -4,7 +4,7 @@ export * from './client/SQLOpenFactory';
 export * from './client/connection/PowerSyncBackendConnector';
 export * from './client/connection/PowerSyncCredentials';
 export * from './client/sync/bucket/BucketStorageAdapter';
-export * from './client/sync/bucket/CrudEntry';
+export { UpdateType, CrudEntry, OpId } from './client/sync/bucket/CrudEntry';
 export * from './client/sync/bucket/SqliteBucketStorage';
 export * from './client/sync/bucket/CrudBatch';
 export * from './client/sync/bucket/CrudTransaction';
@@ -15,6 +15,7 @@ export * from './client/sync/bucket/OplogEntry';
 export * from './client/sync/stream/AbstractRemote';
 export * from './client/sync/stream/AbstractStreamingSyncImplementation';
 export * from './client/sync/stream/streaming-sync-types';
+export { MAX_OP_ID } from './client/constants'
 
 export * from './db/crud/SyncStatus';
 export * from './db/crud/UploadQueueStatus';

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -8,6 +8,7 @@
     "outDir": "./lib",
     "lib": ["esnext"],
     "declaration": true,
+    "preserveConstEnums": true,
     "strictNullChecks": true
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
## Description

There is a runtime issue where enum values are not used because the enum values are ambient.

## Work Done

Added tsconfig option `preserveConstEnums`  to create enum values in JS file that can be used at runtime.

## Note

- [x] I am going to test this on users repo who is experiencing the problem before moving from draft