### PR TITLE
chore: rename action to be more intuative

### DIFF
--- a/.github/workflows/dev-packages.yaml
+++ b/.github/workflows/dev-packages.yaml
@@ -1,6 +1,6 @@
 # Action to publish packages under the `next` tag for testing
 # Packages are versioned as `0.0.0-{tag}-DATETIMESTAMP`
-name: Packages Deploy
+name: Create Dev Release
 
 on: workflow_dispatch
 


### PR DESCRIPTION
## Description
Right now deploying dev release action is called `Packages Deploy` which is not very intuative. This changes is to reflect what it is actually meant for which is `Create Dev Release`. 