### PR TITLE
[Feature] Added PowerSyncDatabase options validation

### DIFF
--- a/.changeset/dull-dancers-judge.md
+++ b/.changeset/dull-dancers-judge.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Added basic validations for required options in `PowerSyncDatabase` constructor.

--- a/packages/common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/common/src/client/AbstractPowerSyncDatabase.ts
@@ -182,7 +182,12 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
   constructor(options: PowerSyncDatabaseOptions); // Note this is important for extending this class and maintaining API compatibility
   constructor(protected options: PowerSyncDatabaseOptions) {
     super();
-    const { database } = options;
+
+    const { database, schema } = options;
+
+    if (false == schema instanceof Schema) {
+      throw new Error('The `schema` option should be provided and should be an instance of `Schema`.');
+    }
 
     if (isDBAdapter(database)) {
       this._database = database;
@@ -190,13 +195,15 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
       this._database = database.openDB();
     } else if (isPowerSyncDatabaseOptionsWithSettings(options)) {
       this._database = this.openDBAdapter(options);
+    } else {
+      throw new Error('The provided `database` option is invalid.');
     }
 
     this.bucketStorageAdapter = this.generateBucketStorageAdapter();
     this.closed = false;
     this.currentStatus = new SyncStatus({});
     this.options = { ...DEFAULT_POWERSYNC_DB_OPTIONS, ...options };
-    this._schema = options.schema;
+    this._schema = schema;
     this.ready = false;
     this.sdkVersion = '';
     // Start async init

--- a/packages/common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/common/src/client/AbstractPowerSyncDatabase.ts
@@ -185,7 +185,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
 
     const { database, schema } = options;
 
-    if (false == schema instanceof Schema) {
+    if (typeof schema?.toJSON != 'function') {
       throw new Error('The `schema` option should be provided and should be an instance of `Schema`.');
     }
 

--- a/packages/common/src/client/SQLOpenFactory.ts
+++ b/packages/common/src/client/SQLOpenFactory.ts
@@ -33,7 +33,8 @@ export interface SQLOpenFactory {
  * Tests if the input is a {@link SQLOpenOptions}
  */
 export const isSQLOpenOptions = (test: any): test is SQLOpenOptions => {
-  return typeof test == 'object' && 'dbFilename' in test;
+  // typeof null is `object`, but you cannot use the `in` operator on `null.
+  return test && typeof test == 'object' && 'dbFilename' in test;
 };
 
 /**

--- a/packages/web/tests/open.test.ts
+++ b/packages/web/tests/open.test.ts
@@ -1,4 +1,4 @@
-import { AbstractPowerSyncDatabase } from '@powersync/common';
+import { AbstractPowerSyncDatabase, Schema } from '@powersync/common';
 import {
   PowerSyncDatabase,
   WASQLiteDBAdapter,
@@ -126,5 +126,94 @@ describe('Open Methods', () => {
 
     expect(sharedSpy).toBeCalledTimes(0);
     expect(dedicatedSpy).toBeCalledTimes(0);
+  });
+
+  /**
+   * TypeScript should prevent this kind of error. This scenario could happen
+   * in pure JavaScript with no language server checking types.
+   */
+  it('Should throw if schema setting is not valid', async () => {
+    const schemaError = 'The `schema` option should be provided';
+
+    expect(
+      () =>
+        new PowerSyncDatabase({
+          database: { dbFilename: 'test.sqlite' },
+          // @ts-expect-error
+          schema: null
+        })
+    ).throws(schemaError);
+
+    expect(
+      () =>
+        new PowerSyncDatabase({
+          database: { dbFilename: 'test.sqlite' },
+          // @ts-expect-error
+          schema: {}
+        })
+    ).throws(schemaError);
+
+    expect(
+      () =>
+        new PowerSyncDatabase({
+          database: { dbFilename: 'test.sqlite' },
+          // @ts-expect-error
+          schema: 'schema'
+        })
+    ).throws(schemaError);
+
+    expect(
+      () =>
+        new PowerSyncDatabase({
+          database: { dbFilename: 'test.sqlite' },
+          // @ts-expect-error
+          schema: undefined
+        })
+    ).throws(schemaError);
+
+    // An Extended class should be fine
+    class ExtendedSchema extends Schema {}
+
+    const extendedClient = new PowerSyncDatabase({
+      database: { dbFilename: 'test.sqlite' },
+      schema: new ExtendedSchema([])
+    });
+
+    await extendedClient.close();
+  });
+
+  /**
+   * TypeScript should prevent this kind of error. This scenario could happen
+   * in pure JavaScript with no language server checking types.
+   */
+  it('Should throw if database setting is not valid', async () => {
+    const dbError = 'The provided `database` option is invalid.';
+
+    expect(
+      () =>
+        new PowerSyncDatabase({
+          // @ts-expect-error
+          database: null,
+          schema: new Schema([])
+        })
+    ).throws(dbError);
+
+    expect(
+      () =>
+        new PowerSyncDatabase({
+          // @ts-expect-error
+          database: {},
+          schema: new Schema([])
+        })
+    ).throws(dbError);
+
+    expect(
+      () =>
+        new PowerSyncDatabase({
+          // @ts-expect-error
+          database: 'db.sqlite',
+          schema: new Schema([])
+        })
+    ).throws(dbError);
   });
 });


### PR DESCRIPTION
# Overview

This adds some very basic checks for invalid options to the `PowerSyncDatabase` constructor. 

JavaScript users might incorrectly supply required options or fail to supply them at all. This should help those users identify issues. 

The warnings here are not detailed. But should be better than cryptic errors which could occur down-the-line if invalid arguments are provided.