### PR TITLE
[Fix] Flipper Warning

### DIFF
--- a/.changeset/pretty-waves-flow.md
+++ b/.changeset/pretty-waves-flow.md
@@ -1,0 +1,5 @@
+---
+'@powersync/react-native': patch
+---
+
+fixed Flipper warning still showing if an HTTP request rejected due to an error.

--- a/packages/react-native/src/sync/stream/ReactNativeRemote.ts
+++ b/packages/react-native/src/sync/stream/ReactNativeRemote.ts
@@ -63,23 +63,24 @@ export class ReactNativeRemote extends AbstractRemote {
           }, STREAMING_POST_TIMEOUT_MS)
         : null;
 
-    const result = await super.postStream({
-      ...options,
-      fetchOptions: {
-        ...options.fetchOptions,
-        /**
-         * The `react-native-fetch-api` polyfill provides streaming support via
-         * this non-standard flag
-         * https://github.com/react-native-community/fetch#enable-text-streaming
-         */
-        // @ts-expect-error https://github.com/react-native-community/fetch#enable-text-streaming
-        reactNative: { textStreaming: true }
+    try {
+      return await super.postStream({
+        ...options,
+        fetchOptions: {
+          ...options.fetchOptions,
+          /**
+           * The `react-native-fetch-api` polyfill provides streaming support via
+           * this non-standard flag
+           * https://github.com/react-native-community/fetch#enable-text-streaming
+           */
+          // @ts-expect-error https://github.com/react-native-community/fetch#enable-text-streaming
+          reactNative: { textStreaming: true }
+        }
+      });
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
       }
-    });
-
-    if (timeout) {
-      clearTimeout(timeout);
     }
-    return result;
   }
 }


### PR DESCRIPTION
# Overview

A debug log is printed if using Android and the HTTP network request failed to resolve in 30 seconds. This is usually due to the Flipper debug tool causing HTTP stream requests to never resolve (or reject). The timeout for this log was cleared if the HTTP request resolves.

The Flipper warning log would still show after the timeout expired even if the network request rejected. This updates the logic to clear the timeout if the HTTP request rejects or resolves.

## Testing

Verified that the timeout is cleared if the request resolves or rejects. HTTP streaming also functions normally. 
