### PR TITLE
[Fix] Custom Query Executor Hooks

### DIFF
--- a/.changeset/nervous-ducks-develop.md
+++ b/.changeset/nervous-ducks-develop.md
@@ -1,0 +1,5 @@
+---
+'@powersync/kysely-driver': minor
+---
+
+Made `dialect` in `wrapPowerSyncWithKysely` options optional since the method provides a PowerSync dialect by default.

--- a/.changeset/orange-points-speak.md
+++ b/.changeset/orange-points-speak.md
@@ -3,4 +3,4 @@
 '@powersync/vue': patch
 ---
 
-React and Vue helpers should execute queries from capatible query executor methods. This should allow Kysely queries with plugins to function correctly.
+React and Vue helpers should execute queries from compatible query executor methods. This should allow Kysely queries with plugins to function correctly.

--- a/.changeset/orange-points-speak.md
+++ b/.changeset/orange-points-speak.md
@@ -1,0 +1,6 @@
+---
+'@powersync/react': patch
+'@powersync/vue': patch
+---
+
+React and Vue helpers should execute queries from capatible query executor methods. This should allow Kysely queries with plugins to function correctly.

--- a/packages/kysely-driver/src/sqlite/db.ts
+++ b/packages/kysely-driver/src/sqlite/db.ts
@@ -1,8 +1,15 @@
-import { PowerSyncDialect } from './sqlite-dialect';
-import { Kysely, type KyselyConfig } from 'kysely';
 import { type AbstractPowerSyncDatabase } from '@powersync/common';
+import { Dialect, Kysely, type KyselyConfig } from 'kysely';
+import { PowerSyncDialect } from './sqlite-dialect';
 
-export const wrapPowerSyncWithKysely = <T>(db: AbstractPowerSyncDatabase, options?: KyselyConfig) => {
+/**
+ * An extension of {@link KyselyConfig} which uses the {@link PowerSyncDialect} by default.
+ */
+export type PowerSyncKyselyOptions = Omit<KyselyConfig, 'dialect'> & {
+  dialect?: Dialect;
+};
+
+export const wrapPowerSyncWithKysely = <T>(db: AbstractPowerSyncDatabase, options?: PowerSyncKyselyOptions) => {
   return new Kysely<T>({
     dialect: new PowerSyncDialect({
       db

--- a/packages/react/src/hooks/useQuery.ts
+++ b/packages/react/src/hooks/useQuery.ts
@@ -1,4 +1,4 @@
-import { type SQLWatchOptions, parseQuery, type CompilableQuery, type ParsedQuery } from '@powersync/common';
+import { parseQuery, type CompilableQuery, type ParsedQuery, type SQLWatchOptions } from '@powersync/common';
 import React from 'react';
 import { usePowerSync } from './PowerSyncContext';
 
@@ -85,7 +85,8 @@ export const useQuery = <T = any>(
   const fetchData = async () => {
     setIsFetching(true);
     try {
-      const result = await powerSync.getAll<T>(sqlStatement, queryParameters);
+      const result =
+        typeof query == 'string' ? await powerSync.getAll<T>(sqlStatement, queryParameters) : await query.execute();
       handleResult(result);
     } catch (e) {
       console.error('Failed to fetch data:', e);

--- a/packages/react/tests/useQuery.test.tsx
+++ b/packages/react/tests/useQuery.test.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
-import { vi, describe, expect, it, afterEach } from 'vitest';
-import { useQuery } from '../src/hooks/useQuery';
-import { PowerSyncContext } from '../src/hooks/PowerSyncContext';
 import * as commonSdk from '@powersync/common';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PowerSyncContext } from '../src/hooks/PowerSyncContext';
+import { useQuery } from '../src/hooks/useQuery';
 
 const mockPowerSync = {
   currentStatus: { status: 'initial' },
@@ -154,6 +154,23 @@ describe('useQuery', () => {
     );
     const currentResult = result.current;
     expect(currentResult.isLoading).toEqual(true);
+  });
+
+  it('should execute compatible queries', async () => {
+    const wrapper = ({ children }) => (
+      <PowerSyncContext.Provider value={mockPowerSync as any}>{children}</PowerSyncContext.Provider>
+    );
+
+    const query = () =>
+      useQuery({
+        execute: () => [{ test: 'custom' }] as any,
+        compile: () => ({ sql: 'SELECT * from lists', parameters: [] })
+      });
+    const { result } = renderHook(query, { wrapper });
+
+    await vi.waitFor(() => {
+      expect(result.current.data[0]?.test).toEqual('custom');
+    });
   });
 
   // The test returns unhandled errors when run with all the others.

--- a/packages/vue/tests/useQuery.test.ts
+++ b/packages/vue/tests/useQuery.test.ts
@@ -144,6 +144,22 @@ describe('useQuery', () => {
     expect(isLoading.value).toEqual(false);
   });
 
+  it('should execute compilable queries', async () => {
+    vi.spyOn(PowerSync, 'usePowerSync').mockReturnValue(ref(mockPowerSync) as any);
+
+    const [{ isLoading, data }] = withSetup(() =>
+      useQuery({
+        execute: () => [{ test: 'custom' }] as any,
+        compile: () => ({ sql: 'SELECT * from lists', parameters: [] })
+      })
+    );
+
+    expect(isLoading.value).toEqual(true);
+    await flushPromises();
+    expect(isLoading.value).toEqual(false);
+    expect(data.value[0].test).toEqual('custom');
+  });
+
   it('should set error for compilable query on useQuery parameters', async () => {
     vi.spyOn(PowerSync, 'usePowerSync').mockReturnValue(ref(mockPowerSync) as any);
 


### PR DESCRIPTION
# Overview

Packages such as the Kysely driver provide a `.execute()` method on query objects. This execute method could perform pluggable modifications based on installed plugins. 

This PR allows the `useQuery` hooks and composibles from `@powersync/react` and `@powersync/vue` to use the `execute` method from compatible queries. 

Related issue: https://github.com/powersync-ja/powersync-js/issues/292

The `dialect` option in the  `wrapPowerSyncWithKysely` has been made optional since the method provides a PowerSync dialect by default.

## Testing

This was verified with unit tests and by implementing a simple Kysely plugin which overwrites the query result.

```TypeScript
const k = wrapPowerSyncWithKysely<Database>(db, {
  plugins: [
    {
      transformQuery: (p) => p.node as any,
      transformResult: async (args) => {
        return {
          rows: [{ hello: 's' }]
        };
      }
    }
  ]
});

k.selectFrom('lists')
  .selectAll()
  .execute()
  .then((r) => console.log(`Got test`, r));
```
![image](https://github.com/user-attachments/assets/08ad9340-ed23-4fc8-8b96-df3594db89e3)


