### PR TITLE
[Fix] SSR Mode Detection

### DIFF
--- a/.changeset/four-birds-raise.md
+++ b/.changeset/four-birds-raise.md
@@ -1,0 +1,6 @@
+---
+'@powersync/common': minor
+'@powersync/web': minor
+---
+
+Fixed SSR Mode detection for DB adapters. Removed the potential for SSR Web Streamining implementations from to perform syncing operations.

--- a/packages/common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/common/src/client/AbstractPowerSyncDatabase.ts
@@ -23,7 +23,6 @@ import { CrudBatch } from './sync/bucket/CrudBatch';
 import { CrudEntry, CrudEntryJSON } from './sync/bucket/CrudEntry';
 import { CrudTransaction } from './sync/bucket/CrudTransaction';
 import {
-  AbstractStreamingSyncImplementation,
   DEFAULT_CRUD_UPLOAD_THROTTLE_MS,
   PowerSyncConnectionOptions,
   StreamingSyncImplementation,
@@ -239,7 +238,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
 
   protected abstract generateSyncStreamImplementation(
     connector: PowerSyncBackendConnector
-  ): AbstractStreamingSyncImplementation;
+  ): StreamingSyncImplementation;
 
   protected abstract generateBucketStorageAdapter(): BucketStorageAdapter;
 

--- a/packages/web/src/db/PowerSyncDatabase.ts
+++ b/packages/web/src/db/PowerSyncDatabase.ts
@@ -1,5 +1,4 @@
 import {
-  type AbstractStreamingSyncImplementation,
   type BucketStorageAdapter,
   type PowerSyncBackendConnector,
   type PowerSyncCloseOptions,
@@ -11,7 +10,8 @@ import {
   PowerSyncDatabaseOptionsWithDBAdapter,
   PowerSyncDatabaseOptionsWithOpenFactory,
   PowerSyncDatabaseOptionsWithSettings,
-  SqliteBucketStorage
+  SqliteBucketStorage,
+  StreamingSyncImplementation
 } from '@powersync/common';
 import { Mutex } from 'async-mutex';
 import { WASQLiteOpenFactory } from './adapters/wa-sqlite/WASQLiteOpenFactory';
@@ -138,9 +138,7 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
     return navigator.locks.request(`lock-${this.database.name}`, cb);
   }
 
-  protected generateSyncStreamImplementation(
-    connector: PowerSyncBackendConnector
-  ): AbstractStreamingSyncImplementation {
+  protected generateSyncStreamImplementation(connector: PowerSyncBackendConnector): StreamingSyncImplementation {
     const remote = new WebRemote(connector);
 
     const syncOptions: WebStreamingSyncImplementationOptions = {

--- a/packages/web/src/db/adapters/AbstractWebSQLOpenFactory.ts
+++ b/packages/web/src/db/adapters/AbstractWebSQLOpenFactory.ts
@@ -19,8 +19,10 @@ export abstract class AbstractWebSQLOpenFactory implements SQLOpenFactory {
    * A SSR implementation is loaded if SSR mode is detected.
    */
   openDB() {
-    const isSSR = isServerSide();
-    if (isSSR && !this.resolvedFlags.disableSSRWarning) {
+    const {
+      resolvedFlags: { disableSSRWarning, enableMultiTabs, ssrMode = isServerSide() }
+    } = this;
+    if (ssrMode && !disableSSRWarning) {
       console.warn(
         `
   Running PowerSync in SSR mode.
@@ -29,13 +31,13 @@ export abstract class AbstractWebSQLOpenFactory implements SQLOpenFactory {
       );
     }
 
-    if (!this.resolvedFlags.enableMultiTabs) {
+    if (!enableMultiTabs) {
       console.warn(
         'Multiple tab support is not enabled. Using this site across multiple tabs may not function correctly.'
       );
     }
 
-    if (isSSR) {
+    if (ssrMode) {
       return new SSRDBAdapter();
     }
 

--- a/packages/web/src/db/sync/SSRWebStreamingSyncImplementation.ts
+++ b/packages/web/src/db/sync/SSRWebStreamingSyncImplementation.ts
@@ -1,23 +1,76 @@
 import {
-  AbstractStreamingSyncImplementation,
   AbstractStreamingSyncImplementationOptions,
+  BaseObserver,
   LockOptions,
-  LockType
+  LockType,
+  PowerSyncConnectionOptions,
+  StreamingSyncImplementation,
+  SyncStatus,
+  SyncStatusOptions
 } from '@powersync/common';
 import { Mutex } from 'async-mutex';
 
-export class SSRStreamingSyncImplementation extends AbstractStreamingSyncImplementation {
+export class SSRStreamingSyncImplementation extends BaseObserver implements StreamingSyncImplementation {
   syncMutex: Mutex;
   crudMutex: Mutex;
 
+  isConnected: boolean;
+  lastSyncedAt?: Date | undefined;
+  syncStatus: SyncStatus;
+
   constructor(options: AbstractStreamingSyncImplementationOptions) {
-    super(options);
+    super();
     this.syncMutex = new Mutex();
     this.crudMutex = new Mutex();
+    this.syncStatus = new SyncStatus({});
+    this.isConnected = false;
   }
 
   obtainLock<T>(lockOptions: LockOptions<T>): Promise<T> {
     const mutex = lockOptions.type == LockType.CRUD ? this.crudMutex : this.syncMutex;
     return mutex.runExclusive(lockOptions.callback);
   }
+
+  /**
+   * This is a no-op in SSR mode
+   */
+  async connect(options?: PowerSyncConnectionOptions): Promise<void> {}
+
+  async dispose() {}
+
+  /**
+   * This is a no-op in SSR mode
+   */
+  async disconnect(): Promise<void> {}
+
+  /**
+   * This SSR Mode implementation is immediately ready.
+   */
+  async waitForReady() {}
+
+  /**
+   * This will never resolve in SSR Mode.
+   */
+  async waitForStatus(status: SyncStatusOptions) {
+    return new Promise<void>((r) => {});
+  }
+
+  /**
+   * Returns a placeholder checkpoint. This should not be used.
+   */
+  async getWriteCheckpoint() {
+    return '1';
+  }
+
+  /**
+   * The SSR mode adapter will never complete syncing.
+   */
+  async hasCompletedSync() {
+    return false;
+  }
+
+  /**
+   * This is a no-op in SSR mode.
+   */
+  triggerCrudUpload() {}
 }


### PR DESCRIPTION
# Overview

This fixes an issue where manually specifying `ssrMode: true` in the `PowerSyncDatabase` constructor `flags` could cause unexpected syncing behaviour to occur in the browser client.

Previously the `WASQLiteOpenFactory` did not account for the `ssrMode` flag. This would create a `DBAdapter` based on the detected environment. Specifying `ssrMode: true` would result in a functional `WASQLiteDBAdapter` being created (on the client). 

Previously the `SSRStreamingSyncImplementation` extended `AbstractStreamingSyncImplementation` which contains logic for processing sync commands from the server. Sync commands would be a `no-op` if the suppled `DBAdapter` was a placeholder SSR DBAdapter, but as described above this was not the case if `ssrMode: true` was specified.

The locks in `SSRStreamingSyncImplementation` are not exclusive, which could result in multiple clients processing sync commands into a single SQLite DB. This PR removes the ability for `SSRStreamingSyncImplementation` to perform any actual syncing. This implementation is just meant to be a placeholder for cases where the PowerSyncDatabase client is accidentally used or exposed on the server.



