### PR TITLE
docs: fix table examples

### DIFF
--- a/packages/common/src/db/schema/Table.ts
+++ b/packages/common/src/db/schema/Table.ts
@@ -88,8 +88,8 @@ export class Table<Columns extends ColumnsType = ColumnsType> {
    * @param {TableV2Options} [v2Options] - Optional configuration options for V2 syntax
    *
    * @example
-   * <caption>New constructor example</caption>
    * ```javascript
+   * // New Constructor
    * const table = new Table(
    *   {
    *     name: column.text,
@@ -101,8 +101,8 @@ export class Table<Columns extends ColumnsType = ColumnsType> {
    *
    *
    * @example
-   * <caption>Deprecated constructor example</caption>
    * ```javascript
+   * // Deprecated Constructor
    * const table = new Table({
    *   name: 'users',
    *   columns: [


### PR DESCRIPTION
## Description
`Table` examples in JS Docs are broken

## Work Done
Fixed `Table` examples in JS Docs

<img width="738" alt="image" src="https://github.com/user-attachments/assets/6b0b84d9-b470-443b-99ce-cd1cd8baa586">
