### PR TITLE
fix: CRUD Upload Queue Monitoring

### DIFF
--- a/.changeset/afraid-apples-learn.md
+++ b/.changeset/afraid-apples-learn.md
@@ -1,0 +1,7 @@
+---
+'@powersync/common': patch
+'@powersync/web': patch
+'@powersync/react-native': patch
+---
+
+Fixed issue where sequentially mutating the same row multiple times could cause the CRUD upload queue monitoring to think CRUD operations have not been processed correctly by the `BackendConnector` `uploadData` method.

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -3,6 +3,7 @@ import Logger, { ILogger } from 'js-logger';
 import { SyncStatus, SyncStatusOptions } from '../../../db/crud/SyncStatus.js';
 import { AbortOperation } from '../../../utils/AbortOperation.js';
 import { BaseListener, BaseObserver, Disposable } from '../../../utils/BaseObserver.js';
+import { throttleLeadingTrailing } from '../../../utils/throttle.js';
 import { BucketChecksum, BucketStorageAdapter, Checkpoint } from '../bucket/BucketStorageAdapter.js';
 import { CrudEntry } from '../bucket/CrudEntry.js';
 import { SyncDataBucket } from '../bucket/SyncDataBucket.js';
@@ -16,7 +17,6 @@ import {
   isStreamingSyncCheckpointDiff,
   isStreamingSyncData
 } from './streaming-sync-types.js';
-import { throttleLeadingTrailing } from '../../../utils/throttle.js';
 
 export enum LockType {
   CRUD = 'crud',
@@ -230,7 +230,7 @@ export abstract class AbstractStreamingSyncImplementation
              */
             const nextCrudItem = await this.options.adapter.nextCrudItem();
             if (nextCrudItem) {
-              if (nextCrudItem.id == checkedCrudItem?.id) {
+              if (nextCrudItem.clientId == checkedCrudItem?.clientId) {
                 // This will force a higher log level than exceptions which are caught here.
                 this.logger.warn(`Potentially previously uploaded CRUD entries are still present in the upload queue.
 Make sure to handle uploads and complete CRUD transactions or batches by calling and awaiting their [.complete()] method.

--- a/packages/web/src/db/PowerSyncDatabase.ts
+++ b/packages/web/src/db/PowerSyncDatabase.ts
@@ -16,8 +16,8 @@ import {
 import { Mutex } from 'async-mutex';
 import { WASQLiteOpenFactory } from './adapters/wa-sqlite/WASQLiteOpenFactory';
 import {
-  ResolvedWebSQLOpenOptions,
   DEFAULT_WEB_SQL_FLAGS,
+  ResolvedWebSQLOpenOptions,
   resolveWebSQLFlags,
   WebSQLFlags
 } from './adapters/web-sql-flags';

--- a/packages/web/tests/uploads.test.ts
+++ b/packages/web/tests/uploads.test.ts
@@ -1,0 +1,116 @@
+import Logger from 'js-logger';
+import p from 'p-defer';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectedDatabaseUtils, generateConnectedDatabase } from './stream.test';
+
+describe('CRUD Uploads', () => {
+  let connectedUtils: ConnectedDatabaseUtils;
+  const logger = Logger.get('crud-logger');
+
+  beforeAll(() => Logger.useDefaults());
+
+  beforeEach(async () => {
+    connectedUtils = await generateConnectedDatabase({
+      powerSyncOptions: {
+        logger,
+        /**
+         * The timeout here is set to longer than the default test timeout
+         * A retry wil cause tests to fail.
+         */
+        crudUploadThrottleMs: 10_000,
+        flags: {
+          enableMultiTabs: false
+        }
+      }
+    });
+  });
+
+  afterEach(async () => {
+    connectedUtils.remote.streamController?.close();
+    await connectedUtils.powersync.disconnectAndClear();
+    await connectedUtils.powersync.close();
+  });
+
+  it('should warn for missing upload operations in uploadData', async () => {
+    const { powersync, uploadSpy } = connectedUtils;
+    const loggerSpy = vi.spyOn(logger, 'warn');
+
+    const deferred = p();
+
+    uploadSpy.mockImplementation(async (db) => {
+      // This upload method does not perform an upload
+      deferred.resolve();
+    });
+
+    // Create something with CRUD in it.
+    await powersync.execute('INSERT into users (id, name) VALUES (uuid(), ?)', ['steven']);
+
+    // The empty upload handler should have been called
+    // Timeouts seem to be weird in Vitest Browser mode.
+    // This makes the check below more stable.
+    await deferred.promise;
+
+    await vi.waitFor(
+      () => {
+        expect(
+          loggerSpy.mock.calls.find((logArgs) =>
+            logArgs[0].includes('Potentially previously uploaded CRUD entries are still present')
+          )
+        ).exist;
+      },
+      {
+        timeout: 500
+      }
+    );
+  });
+
+  it('should immediately upload sequential transactions', async () => {
+    const { powersync, uploadSpy } = connectedUtils;
+    const deferred = p();
+
+    uploadSpy.mockImplementation(async (db) => {
+      // This upload method does not perform an upload
+      const nextTransaction = await db.getNextCrudTransaction();
+      console.log('uploading trans', nextTransaction);
+      if (!nextTransaction) {
+        return;
+      }
+
+      // Mockingly delete the crud op in order to progress through the CRUD queue
+      for (const op of nextTransaction.crud) {
+        await db.execute(`DELETE FROM ps_crud WHERE id = ?`, [op.clientId]);
+      }
+
+      deferred.resolve();
+    });
+
+    // Create the first item
+    await powersync.execute('INSERT into users (id, name) VALUES (uuid(), ?)', ['steven']);
+
+    // Modify the first item in a new transaction
+    await powersync.execute(`
+        UPDATE
+            users
+        SET
+            name = 'Mugi'
+        WHERE
+            name = 'steven'`);
+
+    // Create a second item
+    await powersync.execute('INSERT into users (id, name) VALUES (uuid(), ?)', ['steven2']);
+
+    // The empty upload handler should have been called
+    // Timeouts seem to be weird in Vitest Browser mode.
+    // This makes the check below more stable.
+    await deferred.promise;
+
+    await vi.waitFor(
+      () => {
+        expect(uploadSpy.mock.calls.length).eq(3);
+      },
+      {
+        timeout: 5_000
+      }
+    );
+  });
+});

--- a/packages/web/tests/uploads.test.ts
+++ b/packages/web/tests/uploads.test.ts
@@ -71,7 +71,6 @@ describe('CRUD Uploads', () => {
     uploadSpy.mockImplementation(async (db) => {
       // This upload method does not perform an upload
       const nextTransaction = await db.getNextCrudTransaction();
-      console.log('uploading trans', nextTransaction);
       if (!nextTransaction) {
         return;
       }
@@ -99,7 +98,7 @@ describe('CRUD Uploads', () => {
     // Create a second item
     await powersync.execute('INSERT into users (id, name) VALUES (uuid(), ?)', ['steven2']);
 
-    // The empty upload handler should have been called
+    // The empty upload handler should have been called.
     // Timeouts seem to be weird in Vitest Browser mode.
     // This makes the check below more stable.
     await deferred.promise;

--- a/packages/web/tests/utils/MockStreamOpenFactory.ts
+++ b/packages/web/tests/utils/MockStreamOpenFactory.ts
@@ -133,6 +133,7 @@ export class MockedStreamPowerSync extends PowerSyncDatabase {
     connector: PowerSyncBackendConnector
   ): AbstractStreamingSyncImplementation {
     return new WebStreamingSyncImplementation({
+      logger: this.options.logger,
       adapter: this.bucketStorageAdapter,
       remote: this.remote,
       uploadCrud: async () => {
@@ -140,7 +141,7 @@ export class MockedStreamPowerSync extends PowerSyncDatabase {
         await connector.uploadData(this);
       },
       identifier: this.database.name,
-      retryDelayMs: 0
+      retryDelayMs: this.options.crudUploadThrottleMs ?? 0 // The zero here makes tests faster
     });
   }
 }


### PR DESCRIPTION
# Overview

https://github.com/powersync-ja/powersync-js/pull/254 Added monitoring of the `ps_crud` CRUD upload operations. 

The monitoring relies on `ps_crud` rows being consumed and removed by the `BackendConnector` `uploadData` method. An upload delay is added if the CRUD entry at the head of the queue has not been changed between calls to `uploadData`.

The `ps_crud` table contains `id` and `data` columns. `id` Should be a unique incrementing integer while the `data` column contains JSON of the CRUD data change operation.
<img width="859" alt="image" src="https://github.com/user-attachments/assets/18e1ca6c-ce7c-4aff-bb4c-91ac2df9f1e7">

The raw `ps_crud` entry is parsed into a `CrudEntry` instance which exposes the data above. The mapping in the parsing maps `ps_crud:id` => `CrudEntry.clientId` and `ps_crud:data:id` to `CrudEntry.id`.

The previous implementation incorrectly assumed `CrudEntry.id` was the `ps_crud:id` column value. This causes the monitoring check to think CRUD operations have not been consumed if there are multiple `ps_crud` operations for the same row (with the same data id). This causes a delay in uploads if a single row has been mutated multiple times.

This PR updates the CRUD monitoring to use the correct `id` value. Unit tests are also added to ensure the delay functions as planned.