### PR TITLE
Fix auto docker image release for diagnostics app

### DIFF
--- a/.changeset/lemon-turtles-act.md
+++ b/.changeset/lemon-turtles-act.md
@@ -1,0 +1,5 @@
+---
+'@powersync/diagnostics-app': patch
+---
+
+Fix docker image release for diagnostics-app

--- a/.github/workflows/diagnostics-image-release.yaml
+++ b/.github/workflows/diagnostics-image-release.yaml
@@ -14,7 +14,6 @@ jobs:
   release-docker-image:
     name: Build and Release diagnostics-app Docker Image
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The workflow was triggered on tag push, but then the job is ignored since `github.ref` isn't `main`. This fixes it.