### PR TITLE
Optional Sync Demo: Fixed updating schema when moving todos to synced table

### DIFF
--- a/demos/react-supabase-todolist-optional-sync/src/library/powersync/AppSchema.ts
+++ b/demos/react-supabase-todolist-optional-sync/src/library/powersync/AppSchema.ts
@@ -95,7 +95,10 @@ export async function switchToSyncedSchema(db: AbstractPowerSyncDatabase, userId
       [userId]
     );
 
-    await tx.execute('INSERT INTO todos SELECT * FROM inactive_local_todos');
+    await tx.execute(
+      'INSERT INTO todos(id, list_id, created_at, completed_at, description, completed, created_by) SELECT id, list_id, created_at, completed_at, description, completed, ? FROM inactive_local_todos',
+      [userId]
+    );
 
     // Delete the local-only data.
     await tx.execute('DELETE FROM inactive_local_todos');

--- a/demos/react-supabase-todolist-optional-sync/src/library/powersync/AppSchema.ts
+++ b/demos/react-supabase-todolist-optional-sync/src/library/powersync/AppSchema.ts
@@ -90,11 +90,13 @@ export async function switchToSyncedSchema(db: AbstractPowerSyncDatabase, userId
   await db.writeTransaction(async (tx) => {
     // Copy local-only data to the sync-enabled views.
     // This records each operation in the upload queue.
+    // Overwrites the local-only owner_id value with the logged-in user's id.
     await tx.execute(
       'INSERT INTO lists(id, name, created_at, owner_id) SELECT id, name, created_at, ? FROM inactive_local_lists',
       [userId]
     );
 
+    // Overwrites the local-only created_by value with the logged-in user's id.
     await tx.execute(
       'INSERT INTO todos(id, list_id, created_at, completed_at, description, completed, created_by) SELECT id, list_id, created_at, completed_at, description, completed, ? FROM inactive_local_todos',
       [userId]


### PR DESCRIPTION
Original issue reported in dart optional sync demo https://github.com/powersync-ja/powersync.dart/discussions/174.
This ensures that we correctly copy over the todos with the authed user ID instead of the default local ID.
Instead of copying the local data over to the sync table verbatim (and getting the owner ID from the local table), we use the newly logged in user's ID.




