### PR TITLE
[Fix] `packages/react` issue with `useQuery` not supporting dynamic query parameters

### DIFF
--- a/.changeset/few-jeans-prove.md
+++ b/.changeset/few-jeans-prove.md
@@ -1,0 +1,5 @@
+---
+'@powersync/react': patch
+---
+
+Fixed issue with `useQuery` not supporting dynamic query parameters.

--- a/packages/react/src/hooks/useQuery.ts
+++ b/packages/react/src/hooks/useQuery.ts
@@ -62,7 +62,7 @@ export const useQuery = <T = any>(
   const [isFetching, setIsFetching] = React.useState(true);
   const [tables, setTables] = React.useState([]);
 
-  const memoizedParams = React.useMemo(() => queryParameters, [...queryParameters]);
+  const memoizedParams = React.useMemo(() => queryParameters, [JSON.stringify(queryParameters)]);
   const memoizedOptions = React.useMemo(() => options, [JSON.stringify(options)]);
   const abortController = React.useRef(new AbortController());
 


### PR DESCRIPTION
Original issue reported at https://github.com/powersync-ja/powersync-js/issues/323.
Dynamic query dependencies would warn with the following if the query parameter array changed in size:
 `Warning: The final argument passed to useMemo changed size between renders. The order and size of this array must remain constant. Previous: [] Incoming: [xxxxxxxxxxxxx]
`

Tested with the following to verify that it works now:
```
const [params, setParams] = React.useState<string[]>([]);
const { data } = useQuery(`select * from lists where id=?`, params);

onclick:: setParams(["some-uuid"])
```

The change from `React.useMemo(() => {}, [...array]);` to `React.useMemo(() => {},[JSON.stringify(array)])` should not introduce any issues, as valid query parameters are expected to be serialisable.