### PR TITLE
docs(react-native): add note about metro config

### DIFF
--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -73,7 +73,7 @@ module.exports = function (api) {
 
 ## Metro config (optional)
 
-When using a bare react native app without a framework like Expo, the `@powersync/react-native` package does not work well with inline requires.
+When using a bare React Native app without a framework like Expo, the `@powersync/react-native` package does not work well with inline requires.
 
 If you see the following error message
 

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -71,6 +71,26 @@ module.exports = function (api) {
 };
 ```
 
+# Metro config
+
+The `@powersync/react-native` has issues with inline requires. If you are not using Expo then you may see this error `Super expression must either be null or a function` in which case you need to add this to your `metro.config.js`:
+
+```js
+const config = {
+    transformer: {
+        getTransformOptions: async () => ({
+            transform: {
+                inlineRequires: {
+                  blockList: {
+                    [require.resolve("@powersync/react-native")]: true,
+                  },
+                },
+              },
+        })
+    }
+};
+```
+
 # Native Projects
 
 This package uses native libraries. Create native Android and iOS projects (if not created already) by running:

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -71,15 +71,18 @@ module.exports = function (api) {
 };
 ```
 
-# Metro config
+## Metro config (optional)
 
-The `@powersync/react-native` has issues with inline requires. If you are not using Expo then you may see this error
+When using a bare react native app without a framework like Expo, the `@powersync/react-native` package does not work well with inline requires.
+
+If you see the following error message
+
 
 ```bash
 Super expression must either be null or a function
 ```
 
-in which case you need to add this to your `metro.config.js`:
+then you will need to add this to your `metro.config.js`:
 
 ```js
 const config = {

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -73,7 +73,13 @@ module.exports = function (api) {
 
 # Metro config
 
-The `@powersync/react-native` has issues with inline requires. If you are not using Expo then you may see this error `Super expression must either be null or a function` in which case you need to add this to your `metro.config.js`:
+The `@powersync/react-native` has issues with inline requires. If you are not using Expo then you may see this error
+
+```bash
+Super expression must either be null or a function
+```
+
+in which case you need to add this to your `metro.config.js`:
 
 ```js
 const config = {


### PR DESCRIPTION
## Description
Added a note in the docs about `metro.config.js` changes that need to be made to get the package to work with non-Expo React Native projects. This should hopefully avoid these issues for users in the future https://discord.com/channels/1138230179878154300/1290949501049110623 and https://discord.com/channels/1138230179878154300/1194710422960472175/1290907741568765964