### PR TITLE
Fix: Generate lib files before releasing @powersync/op-sqlite

### DIFF
--- a/.changeset/witty-starfishes-retire.md
+++ b/.changeset/witty-starfishes-retire.md
@@ -1,0 +1,5 @@
+---
+'@powersync/op-sqlite': patch
+---
+
+Build generated lib files before release.

--- a/packages/powersync-op-sqlite/package.json
+++ b/packages/powersync-op-sqlite/package.json
@@ -38,6 +38,7 @@
   ],
   "scripts": {
     "build": "bob build",
+    "build:prod": "bob build",
     "typecheck": "tsc",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build lib"


### PR DESCRIPTION
## Description

Currently the package is published without the generated javascript lib files. This ensures that the files are built before the package is published.