### PR TITLE
fix: tanstack-react-query prod build

### DIFF
--- a/.changeset/fifty-cars-laugh.md
+++ b/.changeset/fifty-cars-laugh.md
@@ -1,0 +1,5 @@
+---
+'@powersync/tanstack-react-query': patch
+---
+
+Fix for some build files being excluded.

--- a/packages/tanstack-react-query/package.json
+++ b/packages/tanstack-react-query/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "build": "tsc -b",
+    "build:prod": "tsc -b --sourceMap false",
     "clean": "rm -rf lib tsconfig.tsbuildinfo",
     "watch": "tsc -b -w"
   },


### PR DESCRIPTION
Prod builds weren't being correctly kicked off for the `tanstack-react-query` package.