### PR TITLE
fix: Tanstack react query watch issues

### DIFF
--- a/.changeset/gorgeous-pens-give.md
+++ b/.changeset/gorgeous-pens-give.md
@@ -1,0 +1,5 @@
+---
+'@powersync/tanstack-react-query': patch
+---
+
+Fixed issue with queries not reacting to local data changes or causing an infinite loop on certain sql parameters.

--- a/packages/tanstack-react-query/src/hooks/useQuery.ts
+++ b/packages/tanstack-react-query/src/hooks/useQuery.ts
@@ -89,6 +89,9 @@ function useQueryCore<
     }
   }
 
+  const memoizedParams = React.useMemo(() => queryParameters, [JSON.stringify(queryParameters)]);
+  const memoizedKey = React.useMemo(() => options.queryKey, [JSON.stringify(options.queryKey)]);
+
   const fetchTables = async () => {
     try {
       const tables = await powerSync.resolveTables(sqlStatement, queryParameters);
@@ -104,7 +107,7 @@ function useQueryCore<
     (async () => {
       await fetchTables();
     })();
-  }, [powerSync, sqlStatement, queryParameters]);
+  }, [powerSync, sqlStatement, memoizedParams]);
 
   const queryFn = React.useCallback(async () => {
     if (error) {
@@ -116,7 +119,7 @@ function useQueryCore<
     } catch (e) {
       return Promise.reject(e);
     }
-  }, [powerSync, query, parameters, options.queryKey, error]);
+  }, [powerSync, query, parameters, memoizedKey, error]);
 
   React.useEffect(() => {
     if (error || !query) return () => {};
@@ -126,7 +129,7 @@ function useQueryCore<
       {
         onChange: () => {
           queryClient.invalidateQueries({
-            queryKey: options.queryKey
+            queryKey: memoizedKey
           });
         },
         onError: (e) => {
@@ -139,7 +142,7 @@ function useQueryCore<
       }
     );
     return () => abort.abort();
-  }, [powerSync, options.queryKey, queryClient, tables, error]);
+  }, [powerSync, memoizedKey, queryClient, tables, error]);
 
   return useQueryFn(
     {

--- a/packages/tanstack-react-query/src/hooks/useQuery.ts
+++ b/packages/tanstack-react-query/src/hooks/useQuery.ts
@@ -89,8 +89,8 @@ function useQueryCore<
     }
   }
 
-  const memoizedParams = React.useMemo(() => queryParameters, [JSON.stringify(queryParameters)]);
-  const memoizedKey = React.useMemo(() => options.queryKey, [JSON.stringify(options.queryKey)]);
+  const stringifiedParams = JSON.stringify(queryParameters);
+  const stringifiedKey = JSON.stringify(options.queryKey);
 
   const fetchTables = async () => {
     try {
@@ -107,7 +107,7 @@ function useQueryCore<
     (async () => {
       await fetchTables();
     })();
-  }, [powerSync, sqlStatement, memoizedParams]);
+  }, [powerSync, sqlStatement, stringifiedParams]);
 
   const queryFn = React.useCallback(async () => {
     if (error) {
@@ -119,7 +119,7 @@ function useQueryCore<
     } catch (e) {
       return Promise.reject(e);
     }
-  }, [powerSync, query, parameters, memoizedKey, error]);
+  }, [powerSync, query, parameters, stringifiedKey, error]);
 
   React.useEffect(() => {
     if (error || !query) return () => {};
@@ -129,7 +129,7 @@ function useQueryCore<
       {
         onChange: () => {
           queryClient.invalidateQueries({
-            queryKey: memoizedKey
+            queryKey: options.queryKey
           });
         },
         onError: (e) => {
@@ -142,7 +142,7 @@ function useQueryCore<
       }
     );
     return () => abort.abort();
-  }, [powerSync, memoizedKey, queryClient, tables, error]);
+  }, [powerSync, queryClient, stringifiedKey, tables, error]);
 
   return useQueryFn(
     {


### PR DESCRIPTION
Fixed issue with queries not reacting to local data changes and sometimes causing an infinite loop on certain sql parameters.

Both issues were related to parameters for `useQuery()/useSuspenseQuery()` triggering `useEffect` redundantly.