### PR TITLE
chore: add audit check

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -19,4 +19,4 @@ jobs:
           version: 9
           run_install: false
       - name: Audit for vulnerabilities
-        run: npx audit-ci@^6 --config ./audit-ci.jsonc
+        run: npx audit-ci@^7 --config ./audit-ci.jsonc

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,0 +1,22 @@
+name: Audit
+
+on:
+  push:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        with:
+          version: 9
+          run_install: false
+      - name: Audit for vulnerabilities
+        run: npx audit-ci@^6 --config ./audit-ci.jsonc

--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -1,0 +1,5 @@
+{
+  "critical": true,
+  "package-manager": "auto",
+  "registry": "https://registry.npmjs.org"
+}


### PR DESCRIPTION
## Description
Add audit check to GitHub pipeline basic checks. This uses [audit-ci](https://github.com/IBM/audit-ci) to check for critical vulnerabilities in this repo. If a vulnerability is critical it will fail the audit check resulting in the PR not being allowed to be merged due to checks needing to pass.

## Testing
You can see the audit run here https://github.com/powersync-ja/powersync-js/actions/runs/11593616269/job/32278028624