### PR TITLE
Feat: Queue read connections OPSQLite

### DIFF
--- a/.changeset/kind-cats-check.md
+++ b/.changeset/kind-cats-check.md
@@ -2,4 +2,4 @@
 '@powersync/op-sqlite': patch
 ---
 
-Added queueing for read connections
+Improved queueing for read connections

--- a/.changeset/kind-cats-check.md
+++ b/.changeset/kind-cats-check.md
@@ -1,0 +1,5 @@
+---
+'@powersync/op-sqlite': patch
+---
+
+Added queueing for read connections

--- a/packages/powersync-op-sqlite/src/db/OPSqliteAdapter.ts
+++ b/packages/powersync-op-sqlite/src/db/OPSqliteAdapter.ts
@@ -166,6 +166,7 @@ export class OPSQLiteDBAdapter extends BaseObserver<DBAdapterListener> implement
           } catch (error) {
             reject(error);
           } finally {
+            availableConnection.busy = false;
             // After query execution, process any queued tasks
             this.processQueue();
           }

--- a/packages/powersync-op-sqlite/src/db/OPSqliteAdapter.ts
+++ b/packages/powersync-op-sqlite/src/db/OPSqliteAdapter.ts
@@ -105,8 +105,7 @@ export class OPSQLiteDBAdapter extends BaseObserver<DBAdapterListener> implement
     await DB.execute('SELECT powersync_init()');
 
     return new OPSQLiteConnection({
-      baseDB: DB,
-      name: dbFilename
+      baseDB: DB
     });
   }
 
@@ -187,7 +186,7 @@ export class OPSQLiteDBAdapter extends BaseObserver<DBAdapterListener> implement
     });
   }
 
-  private async processQueue() {
+  private async processQueue(): Promise<void> {
     if (this.readQueue.length > 0) {
       const next = this.readQueue.shift();
       if (next) {

--- a/packages/powersync-op-sqlite/src/db/OPSqliteAdapter.ts
+++ b/packages/powersync-op-sqlite/src/db/OPSqliteAdapter.ts
@@ -90,7 +90,6 @@ export class OPSQLiteDBAdapter extends BaseObserver<DBAdapterListener> implement
       let dbName = './'.repeat(i + 1) + dbFilename;
       const conn = await this.openConnection(dbName);
       await conn.execute('PRAGMA query_only = true');
-      // this.readConnections.push(conn);
       this.readConnections.push({ lockKey: `${LockType.READ}-${i}`, connection: conn });
     }
   }

--- a/packages/powersync-op-sqlite/src/db/OPSqliteAdapter.ts
+++ b/packages/powersync-op-sqlite/src/db/OPSqliteAdapter.ts
@@ -167,7 +167,6 @@ export class OPSQLiteDBAdapter extends BaseObserver<DBAdapterListener> implement
             availableConnection.lockKey,
             async () => {
               try {
-                console.log('Executing read query on connection', availableConnection.connection.name);
                 resolve(await fn(availableConnection.connection));
               } catch (error) {
                 reject(error);


### PR DESCRIPTION
## Work done

- 5 concurrent read-only connections
- Use a queue to manage queries when all connections are busy
- Process queued operations as soon as connections become available

## Testing

Tested locally running multiple queries running at the same time with random delays between the queries.