### PR TITLE
feat: getCrudBatch default limit

### DIFF
--- a/.changeset/perfect-zebras-marry.md
+++ b/.changeset/perfect-zebras-marry.md
@@ -1,0 +1,7 @@
+---
+'@powersync/common': patch
+'@powersync/web': patch
+'@powersync/react-native': patch
+---
+
+Improved `getCrudBatch` to use a default limit of 100 CRUD entries.

--- a/packages/common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/common/src/client/AbstractPowerSyncDatabase.ts
@@ -132,6 +132,8 @@ export const DEFAULT_POWERSYNC_DB_OPTIONS = {
   crudUploadThrottleMs: DEFAULT_CRUD_UPLOAD_THROTTLE_MS
 };
 
+export const DEFAULT_CRUD_BATCH_LIMIT = 100;
+
 /**
  * Requesting nested or recursive locks can block the application in some circumstances.
  * This default lock timeout will act as a failsafe to throw an error if a lock cannot
@@ -492,7 +494,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
    * data by transaction. One batch may contain data from multiple transactions,
    * and a single transaction may be split over multiple batches.
    */
-  async getCrudBatch(limit: number): Promise<CrudBatch | null> {
+  async getCrudBatch(limit: number = DEFAULT_CRUD_BATCH_LIMIT): Promise<CrudBatch | null> {
     const result = await this.getAll<CrudEntryJSON>(
       `SELECT id, tx_id, data FROM ${PSInternalTable.CRUD} ORDER BY id ASC LIMIT ?`,
       [limit + 1]


### PR DESCRIPTION
# Overview

This PR aligns the `getCrudBatch` method with the [Dart SDK](https://github.com/powersync-ja/powersync.dart/blob/84fc5649e8ebf71153fe041e2b5968d137ff78aa/packages/powersync/lib/src/database/powersync_db_mixin.dart#L327) by providing a default limit for the number of CRUD entries returned. 