### PR TITLE
powersync-sqlite-core 0.3.6 for op-sqlite

### DIFF
--- a/.changeset/gentle-llamas-ring.md
+++ b/.changeset/gentle-llamas-ring.md
@@ -1,0 +1,5 @@
+---
+'@powersync/op-sqlite': patch
+---
+
+Update powersync-sqlite-core to 0.3.6 to fix issue with dangling rows

--- a/packages/powersync-op-sqlite/android/build.gradle
+++ b/packages/powersync-op-sqlite/android/build.gradle
@@ -107,7 +107,7 @@ repositories {
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
-  implementation 'co.powersync:powersync-sqlite-core:0.3.0'
+  implementation 'co.powersync:powersync-sqlite-core:0.3.6'
   // For < 0.71, this will be from the local maven repo
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion

--- a/packages/powersync-op-sqlite/powersync-op-sqlite.podspec
+++ b/packages/powersync-op-sqlite/powersync-op-sqlite.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React-callinvoker"
   s.dependency "React"
-  s.dependency "powersync-sqlite-core", "~> 0.3.0"
+  s.dependency "powersync-sqlite-core", "~> 0.3.6"
   if defined?(install_modules_dependencies())
     install_modules_dependencies(s)
   else


### PR DESCRIPTION
Missed this update in #395.

