### PR TITLE
set drizzle-orm as peer dependency

### DIFF
--- a/packages/drizzle-driver/package.json
+++ b/packages/drizzle-driver/package.json
@@ -26,10 +26,8 @@
     "test": "vitest"
   },
   "peerDependencies": {
-    "@powersync/common": "workspace:^1.19.0"
-  },
-  "dependencies": {
-    "drizzle-orm": "0.35.2"
+    "@powersync/common": "workspace:^1.19.0",
+    "drizzle-orm": "^0.35.2"
   },
   "devDependencies": {
     "@powersync/web": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1601,7 +1601,7 @@ importers:
         specifier: workspace:^1.19.0
         version: link:../common
       drizzle-orm:
-        specifier: 0.35.2
+        specifier: ^0.35.2
         version: 0.35.2(@op-engineering/op-sqlite@9.2.1(react-native@0.75.3(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.3.11)(encoding@0.1.13)(react@18.3.1)(typescript@5.6.3))(react@18.3.1))(@types/react@18.3.11)(kysely@0.27.4)(react@18.3.1)
     devDependencies:
       '@journeyapps/wa-sqlite':


### PR DESCRIPTION
The latest `drizzle-orm` version is `0.36.1`, but `@powersync/drizzle-driver` now requires a `drizzle-orm@0.35.2` dependency (This indicates `>=0.35.2 & < 0.36`).

This PR:
1. use peer dependency instead of dependency
2. allow a more wide range version of drizzle-orm (`>=0.35.2 & <1`)
