### PR TITLE
allow using drizzle-orm casing option

### DIFF
--- a/.changeset/hip-mugs-beam.md
+++ b/.changeset/hip-mugs-beam.md
@@ -1,0 +1,5 @@
+---
+'@powersync/drizzle-driver': minor
+---
+
+Added support for casing option.

--- a/packages/drizzle-driver/src/sqlite/db.ts
+++ b/packages/drizzle-driver/src/sqlite/db.ts
@@ -27,7 +27,7 @@ export function wrapPowerSyncWithDrizzle<TSchema extends Record<string, unknown>
   db: AbstractPowerSyncDatabase,
   config: DrizzleConfig<TSchema> = {}
 ): PowerSyncSQLiteDatabase<TSchema> {
-  const dialect = new SQLiteAsyncDialect();
+  const dialect = new SQLiteAsyncDialect({casing: config.casing});
   let logger;
   if (config.logger === true) {
     logger = new DefaultLogger();


### PR DESCRIPTION
drizzle-orm supports a [casing](https://orm.drizzle.team/docs/sql-schema-declaration#camel-and-snake-casing) option to support defining schema in the following format (without explicit column name):

```
export const users = sqliteTable('users', {
  id: integer(),
  firstName: varchar()
})
```

This PR makes `wrapPowerSyncWithDrizzle` supports this as well:

```
export const db = wrapPowerSyncWithDrizzle(powerSyncDb, {
  schema: drizzleSchema,
  casing: 'snake_case'
});
```