### PR TITLE
chore: drizzle-orm as peer dependency

### DIFF
--- a/.changeset/sixty-penguins-unite.md
+++ b/.changeset/sixty-penguins-unite.md
@@ -1,0 +1,5 @@
+---
+'@powersync/drizzle-driver': minor
+---
+
+Changed drizzle-orm to a peer dependency, supporting a wider set of versions in downstream projects.

--- a/packages/drizzle-driver/package.json
+++ b/packages/drizzle-driver/package.json
@@ -26,16 +26,15 @@
     "test": "vitest"
   },
   "peerDependencies": {
-    "@powersync/common": "workspace:^1.19.0"
-  },
-  "dependencies": {
-    "drizzle-orm": "0.35.2"
+    "@powersync/common": "workspace:^1.19.0",
+    "drizzle-orm": "*"
   },
   "devDependencies": {
     "@powersync/web": "workspace:*",
     "@journeyapps/wa-sqlite": "^0.4.1",
     "@types/node": "^20.17.6",
     "@vitest/browser": "^2.1.4",
+    "drizzle-orm": "^0.35.2",
     "ts-loader": "^9.5.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3",

--- a/packages/drizzle-driver/package.json
+++ b/packages/drizzle-driver/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "@powersync/common": "workspace:^1.19.0",
-    "drizzle-orm": "*"
+    "drizzle-orm": "<1.0.0"
   },
   "devDependencies": {
     "@powersync/web": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1600,9 +1600,6 @@ importers:
       '@powersync/common':
         specifier: workspace:^1.19.0
         version: link:../common
-      drizzle-orm:
-        specifier: 0.35.2
-        version: 0.35.2(@op-engineering/op-sqlite@9.2.1(react-native@0.75.3(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.3.11)(encoding@0.1.13)(react@18.3.1)(typescript@5.6.3))(react@18.3.1))(@types/react@18.3.11)(kysely@0.27.4)(react@18.3.1)
     devDependencies:
       '@journeyapps/wa-sqlite':
         specifier: ^0.4.1
@@ -1616,6 +1613,9 @@ importers:
       '@vitest/browser':
         specifier: ^2.1.4
         version: 2.1.4(@types/node@20.17.6)(typescript@5.6.3)(vite@5.4.10(@types/node@20.17.6)(less@4.2.0)(sass@1.79.4)(terser@5.34.1))(vitest@2.1.4)(webdriverio@9.2.8)
+      drizzle-orm:
+        specifier: ^0.35.2
+        version: 0.35.2(@op-engineering/op-sqlite@9.2.1(react-native@0.75.3(@babel/core@7.25.7)(@babel/preset-env@7.25.7(@babel/core@7.25.7))(@types/react@18.3.11)(encoding@0.1.13)(react@18.3.1)(typescript@5.6.3))(react@18.3.1))(@types/react@18.3.11)(kysely@0.27.4)(react@18.3.1)
       ts-loader:
         specifier: ^9.5.1
         version: 9.5.1(typescript@5.6.3)(webpack@5.95.0(@swc/core@1.7.26(@swc/helpers@0.5.5)))
@@ -19070,9 +19070,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.25.8(@babel/core@7.25.7)(eslint@8.57.1)':
+  '@babel/eslint-parser@7.25.8(@babel/core@7.24.5)(eslint@8.57.1)':
     dependencies:
-      '@babel/core': 7.25.7
+      '@babel/core': 7.24.5
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
       eslint: 8.57.1
       eslint-visitor-keys: 2.1.0
@@ -26872,7 +26872,7 @@ snapshots:
   '@react-native/eslint-config@0.73.2(eslint@8.57.1)(prettier@3.3.3)(typescript@5.5.4)':
     dependencies:
       '@babel/core': 7.24.5
-      '@babel/eslint-parser': 7.25.8(@babel/core@7.25.7)(eslint@8.57.1)
+      '@babel/eslint-parser': 7.25.8(@babel/core@7.24.5)(eslint@8.57.1)
       '@react-native/eslint-plugin': 0.73.1
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1)(typescript@5.5.4)
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
@@ -33333,7 +33333,7 @@ snapshots:
 
   eslint-plugin-ft-flow@2.0.3(@babel/eslint-parser@7.25.8(@babel/core@7.24.5)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
-      '@babel/eslint-parser': 7.25.8(@babel/core@7.25.7)(eslint@8.57.1)
+      '@babel/eslint-parser': 7.25.8(@babel/core@7.24.5)(eslint@8.57.1)
       eslint: 8.57.1
       lodash: 4.17.21
       string-natural-compare: 3.0.1


### PR DESCRIPTION
Addresses problem that was tackled in https://github.com/powersync-ja/powersync-js/pull/402. Using `^0.35.2` wasn't sufficient as it would cap at `<0.36.0`. Per Semver docs `Allows changes that do not modify the left-most non-zero element in the [major, minor, patch] tuple.`.
Tested as a dev release on their side.