### PR TITLE
feat: Web CLI utility for copying assets from node_modules to public

### DIFF
--- a/.changeset/curly-poets-explode.md
+++ b/.changeset/curly-poets-explode.md
@@ -1,0 +1,5 @@
+---
+'@powersync/web': patch
+---
+
+Added a bin/cli utilty that can be invoked with `npx powersync-web copy-assets` or `pnpm powersync-web copy-assets`.

--- a/demos/react-native-web-supabase-todolist/README.md
+++ b/demos/react-native-web-supabase-todolist/README.md
@@ -50,7 +50,7 @@ bucket_definitions:
 
 ### Configure the app
 
-#### 1. Set up environment variables: 
+#### 1. Set up environment variables:
 
 Copy the `.env.local.template` file:
 
@@ -65,7 +65,7 @@ Then edit `.env.local` to insert your Supabase and PowerSync project credentials
 This is required for the React Native Web implementation. Learn more in [our docs](https://docs.powersync.com/client-sdk-references/react-native-and-expo/react-native-web-support).
 
 ```bash
-mkdir -p public/@powersync && cp -r node_modules/@powersync/web/dist/* public/@powersync/
+pnpm powersync-web copy-assets
 ```
 
 ### Run the app

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -4,7 +4,7 @@
 
 # PowerSync SDK for Web
 
-*[PowerSync](https://www.powersync.com) is a sync engine for building local-first apps with instantly-responsive UI/UX and simplified state transfer. Syncs between SQLite on the client-side and Postgres, MongoDB or MySQL on the server-side.*
+_[PowerSync](https://www.powersync.com) is a sync engine for building local-first apps with instantly-responsive UI/UX and simplified state transfer. Syncs between SQLite on the client-side and Postgres, MongoDB or MySQL on the server-side._
 
 This package (`packages/web`) is the PowerSync SDK for JavaScript Web clients. It is an extension of `packages/common`.
 
@@ -39,6 +39,15 @@ See the [example Vite config](https://github.com/powersync-ja/powersync-js/blob/
 # Getting Started
 
 Our [full SDK reference](https://docs.powersync.com/client-sdk-references/js-web) contains everything you need to know to get started implementing PowerSync in your project.
+
+# Public Workers
+
+For some frameworks, it may be required to configure the web workers ([see the docs](https://docs.powersync.com/client-sdk-references/react-native-and-expo/react-native-web-support)).
+The `@powersync/web` package includes a CLI utility which can copy the required assets to the `public` directory (configurable with the `--output` option).
+
+```bash
+pnpm powersync-web copy-assets
+```
 
 # Changelog
 

--- a/packages/web/bin/powersync.js
+++ b/packages/web/bin/powersync.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+const { Command } = require('commander');
+const program = new Command();
+const path = require('path');
+const fsPromise = require('fs/promises');
+
+program
+  .name('powersync-web')
+  .description('CLI for PowerSync Web SDK utilities')
+  .version('0.0.1');
+
+program
+  .command('copy-assets')
+  .description('Copy assets to the specified output directory')
+  .option('-o, --output <directory>', 'output directory for assets', 'public')
+  .action(async(options) => {
+    const outputDir = options.output;
+    
+    console.log(`Target directory: ${outputDir}`);
+    
+    const cwd = process.cwd();
+    const source = path.join(cwd, 'node_modules', '@powersync', 'web', 'dist');
+    const destination = path.join(cwd, outputDir, '@powersync');
+    
+    await fsPromise.rm(destination, { recursive: true, force: true }); // Clear old assets
+
+    await copyDirectory(source, destination)
+  });
+
+
+program.parse(process.argv);
+
+async function copyDirectory(source, destination) {
+  try {
+    await fsPromise.cp(source, destination, { recursive: true });
+    console.log(`Assets copied from ${source} to ${destination}`);
+  } catch (err) {
+    console.error(`Error copying directory: ${err.message}`);
+  }
+}

--- a/packages/web/bin/powersync.js
+++ b/packages/web/bin/powersync.js
@@ -36,6 +36,6 @@ async function copyDirectory(source, destination) {
     await fsPromise.cp(source, destination, { recursive: true });
     console.log(`Assets copied from ${source} to ${destination}`);
   } catch (err) {
-    console.error(`Error copying directory: ${err.message}`);
+    console.error(`Error copying assets: ${err.message}`);
   }
 }

--- a/packages/web/bin/powersync.js
+++ b/packages/web/bin/powersync.js
@@ -4,11 +4,12 @@ const { Command } = require('commander');
 const program = new Command();
 const path = require('path');
 const fsPromise = require('fs/promises');
-
+const { version } = require('../package.json');
+  
 program
   .name('powersync-web')
   .description('CLI for PowerSync Web SDK utilities')
-  .version('0.0.1');
+  .version(version);
 
 program
   .command('copy-assets')
@@ -37,5 +38,6 @@ async function copyDirectory(source, destination) {
     console.log(`Assets copied from ${source} to ${destination}`);
   } catch (err) {
     console.error(`Error copying assets: ${err.message}`);
+    process.exit(1);
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -4,7 +4,11 @@
   "description": "A Web SDK for JourneyApps PowerSync",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
+  "bin": {
+    "powersync-web": "bin/powersync.js"
+  },
   "files": [
+    "bin",
     "lib",
     "!lib/tests",
     "dist"
@@ -64,6 +68,7 @@
     "async-mutex": "^0.4.0",
     "bson": "^6.6.0",
     "comlink": "^4.4.1",
+    "commander": "^12.1.0",
     "js-logger": "^1.6.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -690,10 +690,10 @@ importers:
         version: 6.3.1(expo@51.0.27(@babel/core@7.24.5)(@babel/preset-env@7.25.7(@babel/core@7.24.5))(encoding@0.1.13))
       expo-router:
         specifier: ^3.5.15
-        version: 3.5.21(4zj2oqn5mqa2u4b4ptcn2bpgaq)
+        version: 3.5.21(jkwxlpmfbfhcgszmypnf2vq7pa)
       expo-splash-screen:
         specifier: ~0.27.4
-        version: 0.27.6(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(expo@51.0.27(@babel/core@7.24.5)(@babel/preset-env@7.25.7(@babel/core@7.24.5))(encoding@0.1.13))
+        version: 0.27.6(encoding@0.1.13)(expo-modules-autolinking@1.11.3)(expo@51.0.27(@babel/core@7.24.5)(@babel/preset-env@7.25.7(@babel/core@7.24.5))(encoding@0.1.13))
       expo-status-bar:
         specifier: ~1.12.1
         version: 1.12.1
@@ -745,7 +745,7 @@ importers:
         version: 18.3.11
       eas-cli:
         specifier: ^7.2.0
-        version: 7.8.5(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@22.7.4)(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(typescript@5.3.3)
+        version: 7.8.5(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@22.7.4)(encoding@0.1.13)(expo-modules-autolinking@1.11.3)(typescript@5.3.3)
       eslint:
         specifier: 8.55.0
         version: 8.55.0
@@ -1892,6 +1892,9 @@ importers:
       comlink:
         specifier: ^4.4.1
         version: 4.4.1
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
       js-logger:
         specifier: ^1.6.1
         version: 1.6.1
@@ -23874,7 +23877,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@expo/prebuild-config@6.7.3(encoding@0.1.13)(expo-modules-autolinking@1.11.1)':
+  '@expo/prebuild-config@6.7.3(encoding@0.1.13)(expo-modules-autolinking@1.11.3)':
     dependencies:
       '@expo/config': 8.5.4
       '@expo/config-plugins': 7.8.4
@@ -23882,28 +23885,10 @@ snapshots:
       '@expo/image-utils': 0.4.2(encoding@0.1.13)
       '@expo/json-file': 8.2.37
       debug: 4.3.7(supports-color@8.1.1)
-      expo-modules-autolinking: 1.11.1
+      expo-modules-autolinking: 1.11.3
       fs-extra: 9.1.0
       resolve-from: 5.0.0
       semver: 7.5.3
-      xml2js: 0.6.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
-  '@expo/prebuild-config@7.0.6(encoding@0.1.13)(expo-modules-autolinking@1.11.1)':
-    dependencies:
-      '@expo/config': 9.0.4
-      '@expo/config-plugins': 8.0.10
-      '@expo/config-types': 51.0.3
-      '@expo/image-utils': 0.5.1(encoding@0.1.13)
-      '@expo/json-file': 8.3.3
-      '@react-native/normalize-colors': 0.74.84
-      debug: 4.3.7(supports-color@8.1.1)
-      expo-modules-autolinking: 1.11.1
-      fs-extra: 9.1.0
-      resolve-from: 5.0.0
-      semver: 7.6.3
       xml2js: 0.6.0
     transitivePeerDependencies:
       - encoding
@@ -32725,7 +32710,7 @@ snapshots:
 
   duplexer@0.1.2: {}
 
-  eas-cli@7.8.5(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@22.7.4)(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(typescript@5.3.3):
+  eas-cli@7.8.5(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@22.7.4)(encoding@0.1.13)(expo-modules-autolinking@1.11.3)(typescript@5.3.3):
     dependencies:
       '@expo/apple-utils': 1.7.0
       '@expo/code-signing-certificates': 0.0.5
@@ -32743,7 +32728,7 @@ snapshots:
       '@expo/plist': 0.0.20
       '@expo/plugin-help': 5.1.23(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@22.7.4)(typescript@5.3.3)
       '@expo/plugin-warn-if-update-available': 2.5.1(@swc/core@1.7.26(@swc/helpers@0.5.5))(@types/node@22.7.4)(typescript@5.3.3)
-      '@expo/prebuild-config': 6.7.3(encoding@0.1.13)(expo-modules-autolinking@1.11.1)
+      '@expo/prebuild-config': 6.7.3(encoding@0.1.13)(expo-modules-autolinking@1.11.3)
       '@expo/results': 1.0.0
       '@expo/rudder-sdk-node': 1.1.1(encoding@0.1.13)
       '@expo/spawn-async': 1.7.0
@@ -33983,7 +33968,7 @@ snapshots:
     dependencies:
       invariant: 2.2.4
 
-  expo-router@3.5.21(4zj2oqn5mqa2u4b4ptcn2bpgaq):
+  expo-router@3.5.21(jkwxlpmfbfhcgszmypnf2vq7pa):
     dependencies:
       '@expo/metro-runtime': 3.2.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.25.7(@babel/core@7.24.5))(@types/react@18.3.11)(encoding@0.1.13)(react@18.2.0))
       '@expo/server': 0.4.4(typescript@5.3.3)
@@ -33994,7 +33979,7 @@ snapshots:
       expo: 51.0.27(@babel/core@7.24.5)(@babel/preset-env@7.25.7(@babel/core@7.24.5))(encoding@0.1.13)
       expo-constants: 16.0.2(expo@51.0.27(@babel/core@7.24.5)(@babel/preset-env@7.25.7(@babel/core@7.24.5))(encoding@0.1.13))
       expo-linking: 6.3.1(expo@51.0.27(@babel/core@7.24.5)(@babel/preset-env@7.25.7(@babel/core@7.24.5))(encoding@0.1.13))
-      expo-splash-screen: 0.27.5(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(expo@51.0.27(@babel/core@7.24.5)(@babel/preset-env@7.25.7(@babel/core@7.24.5))(encoding@0.1.13))
+      expo-splash-screen: 0.27.5(encoding@0.1.13)(expo-modules-autolinking@1.11.3)(expo@51.0.27(@babel/core@7.24.5)(@babel/preset-env@7.25.7(@babel/core@7.24.5))(encoding@0.1.13))
       expo-status-bar: 1.12.1
       react-native-helmet-async: 2.0.4(react@18.2.0)
       react-native-safe-area-context: 4.10.1(react-native@0.74.1(@babel/core@7.24.5)(@babel/preset-env@7.25.7(@babel/core@7.24.5))(@types/react@18.3.11)(encoding@0.1.13)(react@18.2.0))(react@18.2.0)
@@ -34103,15 +34088,6 @@ snapshots:
     dependencies:
       expo: 51.0.37(@babel/core@7.24.5)(@babel/preset-env@7.25.7(@babel/core@7.24.5))(encoding@0.1.13)
 
-  expo-splash-screen@0.27.5(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(expo@51.0.27(@babel/core@7.24.5)(@babel/preset-env@7.25.7(@babel/core@7.24.5))(encoding@0.1.13)):
-    dependencies:
-      '@expo/prebuild-config': 7.0.6(encoding@0.1.13)(expo-modules-autolinking@1.11.1)
-      expo: 51.0.27(@babel/core@7.24.5)(@babel/preset-env@7.25.7(@babel/core@7.24.5))(encoding@0.1.13)
-    transitivePeerDependencies:
-      - encoding
-      - expo-modules-autolinking
-      - supports-color
-
   expo-splash-screen@0.27.5(encoding@0.1.13)(expo-modules-autolinking@1.11.3)(expo@51.0.27(@babel/core@7.24.5)(@babel/preset-env@7.25.7(@babel/core@7.24.5))(encoding@0.1.13)):
     dependencies:
       '@expo/prebuild-config': 7.0.6(encoding@0.1.13)(expo-modules-autolinking@1.11.3)
@@ -34134,15 +34110,6 @@ snapshots:
     dependencies:
       '@expo/prebuild-config': 7.0.6(encoding@0.1.13)(expo-modules-autolinking@1.11.3)
       expo: 51.0.37(@babel/core@7.24.5)(@babel/preset-env@7.25.7(@babel/core@7.24.5))(encoding@0.1.13)
-    transitivePeerDependencies:
-      - encoding
-      - expo-modules-autolinking
-      - supports-color
-
-  expo-splash-screen@0.27.6(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(expo@51.0.27(@babel/core@7.24.5)(@babel/preset-env@7.25.7(@babel/core@7.24.5))(encoding@0.1.13)):
-    dependencies:
-      '@expo/prebuild-config': 7.0.8(encoding@0.1.13)(expo-modules-autolinking@1.11.1)
-      expo: 51.0.27(@babel/core@7.24.5)(@babel/preset-env@7.25.7(@babel/core@7.24.5))(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
       - expo-modules-autolinking


### PR DESCRIPTION
Some platforms/projects like react-native-web require configuration of the webworkers, which include copying assets from the dist directory of `@powersync/web` to somewhere like `public`. This PR introduces a CLI utility, which can in the future house other CLI commands.