### PR TITLE
fix: Tanstack error handling improvements

### DIFF
--- a/.changeset/brown-moose-chew.md
+++ b/.changeset/brown-moose-chew.md
@@ -1,0 +1,5 @@
+---
+'@powersync/tanstack-react-query': patch
+---
+
+Fixed issue with compilable queries needing a parameter value specified and fixed issue related to compilable query errors causing infinite rendering.

--- a/packages/tanstack-react-query/package.json
+++ b/packages/tanstack-react-query/package.json
@@ -15,6 +15,7 @@
     "build": "tsc -b",
     "build:prod": "tsc -b --sourceMap false",
     "clean": "rm -rf lib tsconfig.tsbuildinfo",
+    "test": "vitest",
     "watch": "tsc -b -w"
   },
   "repository": {
@@ -37,6 +38,7 @@
     "@tanstack/react-query": "^5.55.4"
   },
   "devDependencies": {
+    "@testing-library/react": "^15.0.2",
     "@types/react": "^18.2.34",
     "jsdom": "^24.0.0",
     "react": "18.2.0",

--- a/packages/tanstack-react-query/tests/tsconfig.json
+++ b/packages/tanstack-react-query/tests/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "esModuleInterop": true,
+    "jsx": "react",
+    "rootDir": "../",
+    "composite": true,
+    "outDir": "./lib",
+    "lib": ["esnext", "DOM"],
+    "module": "esnext",
+    "sourceMap": true,
+    "moduleResolution": "node",
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noImplicitUseStrict": false,
+    "noStrictGenericChecks": false,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "target": "esnext"
+  },
+  "include": ["../src/**/*"]
+}

--- a/packages/tanstack-react-query/tests/useQuery.test.tsx
+++ b/packages/tanstack-react-query/tests/useQuery.test.tsx
@@ -1,0 +1,114 @@
+import * as commonSdk from '@powersync/common';
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PowerSyncContext } from '@powersync/react/';
+import { useQuery } from '../src/hooks/useQuery';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockPowerSync = {
+  currentStatus: { status: 'initial' },
+  registerListener: vi.fn(() => { }),
+  resolveTables: vi.fn(() => ['table1', 'table2']),
+  onChangeWithCallback: vi.fn(),
+  getAll: vi.fn(() => Promise.resolve(['list1', 'list2']))
+};
+
+vi.mock('./PowerSyncContext', () => ({
+  useContext: vi.fn(() => mockPowerSync)
+}));
+
+describe('useQuery', () => {
+  let queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    }
+  })
+
+  const wrapper = ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      <PowerSyncContext.Provider value={mockPowerSync as any}>{children}</PowerSyncContext.Provider>
+    </QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    queryClient.clear();
+
+    vi.clearAllMocks();
+    cleanup(); // Cleanup the DOM after each test
+  });
+
+
+  it('should set loading states on initial load', async () => {
+    const { result } = renderHook(() => useQuery({
+      queryKey: ['lists'],
+      query: 'SELECT * from lists'
+    }), { wrapper });
+    const currentResult = result.current;
+    expect(currentResult.isLoading).toEqual(true);
+    expect(currentResult.isFetching).toEqual(true);
+  });
+
+  it('should execute string queries', async () => {
+    const query = () =>
+      useQuery({
+        queryKey: ['lists'],
+        query: "SELECT * from lists"
+      });
+    const { result } = renderHook(query, { wrapper });
+
+    await vi.waitFor(() => {
+      expect(result.current.data![0]).toEqual('list1');
+      expect(result.current.data![1]).toEqual('list2');
+    }, { timeout: 500 });
+  });
+
+  it('should execute compatible queries', async () => {
+    const compilableQuery = {
+      execute: () => [{ test: 'custom' }] as any,
+      compile: () => ({ sql: 'SELECT * from lists' })
+    } as commonSdk.CompilableQuery<any>;
+
+    const query = () =>
+      useQuery({
+        queryKey: ['lists'],
+        query: compilableQuery
+      });
+    const { result } = renderHook(query, { wrapper });
+
+    await vi.waitFor(() => {
+      expect(result.current.data![0].test).toEqual('custom');
+    }, { timeout: 500 });
+  });
+
+  it('should show an error if parsing the query results in an error', async () => {
+    const compilableQuery = {
+      execute: () => [] as any,
+      compile: () => ({ sql: 'SELECT * from lists', parameters: ['param'] })
+    } as commonSdk.CompilableQuery<any>;
+
+    const { result } = renderHook(
+      () =>
+        useQuery({
+          queryKey: ['lists'],
+          query: compilableQuery,
+          parameters: ['redundant param']
+        }),
+      { wrapper }
+    );
+
+    await waitFor(
+      async () => {
+        const currentResult = result.current;
+        expect(currentResult.isLoading).toEqual(false);
+        expect(currentResult.isFetching).toEqual(false);
+        expect(currentResult.error).toEqual(Error('You cannot pass parameters to a compiled query.'));
+        expect(currentResult.data).toBeUndefined()
+      },
+      { timeout: 100 }
+    );
+  });
+
+});

--- a/packages/tanstack-react-query/vitest.config.ts
+++ b/packages/tanstack-react-query/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig, UserConfigExport } from 'vitest/config';
+
+const config: UserConfigExport = {
+  test: {
+    environment: 'jsdom'
+  }
+};
+
+export default defineConfig(config);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,16 +234,16 @@ importers:
     dependencies:
       '@capacitor/android':
         specifier: ^6.0.0
-        version: 6.1.2(@capacitor/core@6.1.2)
+        version: 6.1.2(@capacitor/core@6.2.0)
       '@capacitor/core':
         specifier: latest
-        version: 6.1.2
+        version: 6.2.0
       '@capacitor/ios':
         specifier: ^6.0.0
-        version: 6.1.2(@capacitor/core@6.1.2)
+        version: 6.1.2(@capacitor/core@6.2.0)
       '@capacitor/splash-screen':
         specifier: latest
-        version: 6.0.2(@capacitor/core@6.1.2)
+        version: 6.0.3(@capacitor/core@6.2.0)
       '@journeyapps/wa-sqlite':
         specifier: ^1.0.0
         version: 1.0.0
@@ -1843,6 +1843,9 @@ importers:
         specifier: ^5.55.4
         version: 5.59.14(react@18.2.0)
     devDependencies:
+      '@testing-library/react':
+        specifier: ^15.0.2
+        version: 15.0.7(@types/react@18.3.11)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@types/react':
         specifier: ^18.2.34
         version: 18.3.11
@@ -3199,16 +3202,16 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@capacitor/core@6.1.2':
-    resolution: {integrity: sha512-xFy1/4qLFLp5WCIzIhtwUuVNNoz36+V7/BzHmLqgVJcvotc4MMjswW/TshnPQaLLujEOaLkA4h8ZJ0uoK3ImGg==}
+  '@capacitor/core@6.2.0':
+    resolution: {integrity: sha512-B9IlJtDpUqhhYb+T8+cp2Db/3RETX36STgjeU2kQZBs/SLAcFiMama227o+msRjLeo3DO+7HJjWVA1+XlyyPEg==}
 
   '@capacitor/ios@6.1.2':
     resolution: {integrity: sha512-HaeW68KisBd/7TmavzPDlL2bpoDK5AjR2ZYrqU4TlGwM88GtQfvduBCAlSCj20X0w/4+rWMkseD9dAAkacjiyQ==}
     peerDependencies:
       '@capacitor/core': ^6.1.0
 
-  '@capacitor/splash-screen@6.0.2':
-    resolution: {integrity: sha512-WC0KYZ+ev15up03xs4fTnoTKwBVUSxXsKKQr/8XAncvi/nAG8qrpanW8OlavSC5zF5e1IZZDLsI2GSv0SkZ7VQ==}
+  '@capacitor/splash-screen@6.0.3':
+    resolution: {integrity: sha512-tpVljeNGSwVCIc8lMQkyiCQFokk2PwgYPdDtPnGjFthqmXW/WhIxW8QYl4MUqyLwwgwTEbp4u3Kcv2zqQu2L6Q==}
     peerDependencies:
       '@capacitor/core': ^6.0.0
 
@@ -19100,9 +19103,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.25.8(@babel/core@7.24.5)(eslint@8.57.1)':
+  '@babel/eslint-parser@7.25.8(@babel/core@7.25.7)(eslint@8.57.1)':
     dependencies:
-      '@babel/core': 7.24.5
+      '@babel/core': 7.25.7
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
       eslint: 8.57.1
       eslint-visitor-keys: 2.1.0
@@ -21542,9 +21545,9 @@ snapshots:
       '@types/tough-cookie': 4.0.5
       tough-cookie: 4.1.4
 
-  '@capacitor/android@6.1.2(@capacitor/core@6.1.2)':
+  '@capacitor/android@6.1.2(@capacitor/core@6.2.0)':
     dependencies:
-      '@capacitor/core': 6.1.2
+      '@capacitor/core': 6.2.0
 
   '@capacitor/cli@6.1.2':
     dependencies:
@@ -21569,17 +21572,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@capacitor/core@6.1.2':
+  '@capacitor/core@6.2.0':
     dependencies:
       tslib: 2.7.0
 
-  '@capacitor/ios@6.1.2(@capacitor/core@6.1.2)':
+  '@capacitor/ios@6.1.2(@capacitor/core@6.2.0)':
     dependencies:
-      '@capacitor/core': 6.1.2
+      '@capacitor/core': 6.2.0
 
-  '@capacitor/splash-screen@6.0.2(@capacitor/core@6.1.2)':
+  '@capacitor/splash-screen@6.0.3(@capacitor/core@6.2.0)':
     dependencies:
-      '@capacitor/core': 6.1.2
+      '@capacitor/core': 6.2.0
 
   '@changesets/apply-release-plan@7.0.5':
     dependencies:
@@ -26897,7 +26900,7 @@ snapshots:
   '@react-native/eslint-config@0.73.2(eslint@8.57.1)(prettier@3.3.3)(typescript@5.5.4)':
     dependencies:
       '@babel/core': 7.24.5
-      '@babel/eslint-parser': 7.25.8(@babel/core@7.24.5)(eslint@8.57.1)
+      '@babel/eslint-parser': 7.25.8(@babel/core@7.25.7)(eslint@8.57.1)
       '@react-native/eslint-plugin': 0.73.1
       '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1)(typescript@5.5.4)
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
@@ -33377,7 +33380,7 @@ snapshots:
 
   eslint-plugin-ft-flow@2.0.3(@babel/eslint-parser@7.25.8(@babel/core@7.24.5)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
-      '@babel/eslint-parser': 7.25.8(@babel/core@7.24.5)(eslint@8.57.1)
+      '@babel/eslint-parser': 7.25.8(@babel/core@7.25.7)(eslint@8.57.1)
       eslint: 8.57.1
       lodash: 4.17.21
       string-natural-compare: 3.0.1


### PR DESCRIPTION
Originally spurred on by https://github.com/powersync-ja/powersync-js/issues/417 where compilable queries would error without having a parameter value specified.
Added a default value in the hook and improved how the error state is tracked so that the infinite rendering issue doesn't happen anymore.

Also added basic unit tests.