### PR TITLE
fix: Drizzle query returning an array-in-array type:

### DIFF
--- a/.changeset/honest-mugs-yawn.md
+++ b/.changeset/honest-mugs-yawn.md
@@ -1,0 +1,5 @@
+---
+'@powersync/drizzle-driver': patch
+---
+
+Fixed a typing issue related to queries returning multiple results when used in `db.watch()`.

--- a/packages/drizzle-driver/src/sqlite/db.ts
+++ b/packages/drizzle-driver/src/sqlite/db.ts
@@ -21,7 +21,7 @@ import type { DrizzleConfig } from 'drizzle-orm/utils';
 import { toCompilableQuery } from './../utils/compilableQuery';
 import { PowerSyncSQLiteSession, PowerSyncSQLiteTransactionConfig } from './sqlite-session';
 
-export type DrizzleQuery<T> = { toSQL(): Query; execute(): Promise<T> };
+export type DrizzleQuery<T> = { toSQL(): Query; execute(): Promise<T | T[]> };
 
 export class PowerSyncSQLiteDatabase<
   TSchema extends Record<string, unknown> = Record<string, never>


### PR DESCRIPTION
Resolved an issue where `.findMany` (and other multiple row results) queries had a type of `[][]` instead of `[]`. 

When checking the `db.watch(query, {onResult})`'s onResult type:
### before
#### find-many:
```
(results: {
    id: string | null;
    assets: {
        id: string | null;
        customer_id: string | null;
    }[];
}[][]) => void
```
#### find-first:
```
results: ({
    id: string | null;
    customer_id: string | null;
    customer: {
        ...;
    } | null;
} | undefined)[]) => void
```

### After
#### find-many:
```
(results: {
    id: string | null;
    assets: {
        customer_id: string | null;
        id: string | null;
    }[];
}[]) => void
```

#### find-first:
```
(results: ({
    id: string | null;
    customer_id: string | null;
    customer: {
        ...;
    } | null;
} | undefined)[]) => void
```