### PR TITLE
make drizzle toPowerSyncTable support mode

### DIFF
--- a/.changeset/flat-toes-judge.md
+++ b/.changeset/flat-toes-judge.md
@@ -1,0 +1,5 @@
+---
+'@powersync/drizzle-driver': minor
+---
+
+Added support for column "mode" option. This allows the ORM to expose values as complex types such as JSON and Timestamp, but store them as primitives such as text and integer.

--- a/packages/drizzle-driver/src/utils/schema.ts
+++ b/packages/drizzle-driver/src/utils/schema.ts
@@ -7,7 +7,7 @@ import {
   type BaseColumnType,
   type TableV2Options
 } from '@powersync/common';
-import { InferSelectModel, isTable, Relations } from 'drizzle-orm';
+import { entityKind, InferSelectModel, isTable, Relations } from 'drizzle-orm';
 import {
   getTableConfig,
   SQLiteInteger,
@@ -41,16 +41,16 @@ export function toPowerSyncTable<T extends SQLiteTableWithColumns<any>>(
 
     let mappedType: BaseColumnType<number | string | null>;
     switch (drizzleColumn.columnType) {
-      case SQLiteText.name:
-      case SQLiteTextJson.name:
+      case SQLiteText[entityKind]:
+      case SQLiteTextJson[entityKind]:
         mappedType = column.text;
         break;
-      case SQLiteInteger.name:
-      case SQLiteTimestamp.name:
-      case SQLiteBoolean.name:
+      case SQLiteInteger[entityKind]:
+      case SQLiteTimestamp[entityKind]:
+      case SQLiteBoolean[entityKind]:
         mappedType = column.integer;
         break;
-      case SQLiteReal.name:
+      case SQLiteReal[entityKind]:
         mappedType = column.real;
         break;
       default:

--- a/packages/drizzle-driver/src/utils/schema.ts
+++ b/packages/drizzle-driver/src/utils/schema.ts
@@ -13,6 +13,9 @@ import {
   SQLiteInteger,
   SQLiteReal,
   SQLiteText,
+  SQLiteTextJson,
+  SQLiteTimestamp,
+  SQLiteBoolean,
   type SQLiteTableWithColumns,
   type TableConfig
 } from 'drizzle-orm/sqlite-core';
@@ -39,9 +42,12 @@ export function toPowerSyncTable<T extends SQLiteTableWithColumns<any>>(
     let mappedType: BaseColumnType<number | string | null>;
     switch (drizzleColumn.columnType) {
       case SQLiteText.name:
+      case SQLiteTextJson.name:
         mappedType = column.text;
         break;
       case SQLiteInteger.name:
+      case SQLiteTimestamp.name:
+      case SQLiteBoolean.name:
         mappedType = column.integer;
         break;
       case SQLiteReal.name:

--- a/packages/drizzle-driver/tests/sqlite/schema.test.ts
+++ b/packages/drizzle-driver/tests/sqlite/schema.test.ts
@@ -8,13 +8,13 @@ describe('toPowerSyncTable', () => {
     const lists = sqliteTable('lists', {
       id: text('id').primaryKey(),
       name: text('name').notNull(),
-      verified: integer('verified', {mode: 'boolean'}),
+      verified: integer('verified', { mode: 'boolean' }),
       owner_id: text('owner_id'),
       counter: integer('counter'),
       completion: real('completion'),
-      info: text('info', {mode: 'json'}),
-      created_at: integer('created_at', {mode: 'timestamp'}),
-      updated_at: integer('updated_at', {mode: 'timestamp'}),
+      info: text('info', { mode: 'json' }),
+      created_at: integer('created_at', { mode: 'timestamp' }),
+      updated_at: integer('updated_at', { mode: 'timestamp' })
     });
     const convertedList = toPowerSyncTable(lists);
 
@@ -26,7 +26,7 @@ describe('toPowerSyncTable', () => {
       completion: column.real,
       info: column.text,
       created_at: column.integer,
-      updated_at: column.integer,
+      updated_at: column.integer
     });
 
     expect(convertedList).toEqual(expectedLists);

--- a/packages/drizzle-driver/tests/sqlite/schema.test.ts
+++ b/packages/drizzle-driver/tests/sqlite/schema.test.ts
@@ -8,23 +8,23 @@ describe('toPowerSyncTable', () => {
     const lists = sqliteTable('lists', {
       id: text('id').primaryKey(),
       name: text('name').notNull(),
-      verified: integer('verified', { mode: 'boolean' }),
+      info: text('info', { mode: 'json' }),
       owner_id: text('owner_id'),
       counter: integer('counter'),
       completion: real('completion'),
-      info: text('info', { mode: 'json' }),
+      verified: integer('verified', { mode: 'boolean' }),
       created_at: integer('created_at', { mode: 'timestamp' }),
-      updated_at: integer('updated_at', { mode: 'timestamp' })
+      updated_at: integer('updated_at', { mode: 'timestamp_ms' })
     });
     const convertedList = toPowerSyncTable(lists);
 
     const expectedLists = new Table({
       name: column.text,
-      verified: column.integer,
+      info: column.text,
       owner_id: column.text,
       counter: column.integer,
       completion: column.real,
-      info: column.text,
+      verified: column.integer,
       created_at: column.integer,
       updated_at: column.integer
     });

--- a/packages/drizzle-driver/tests/sqlite/schema.test.ts
+++ b/packages/drizzle-driver/tests/sqlite/schema.test.ts
@@ -8,17 +8,25 @@ describe('toPowerSyncTable', () => {
     const lists = sqliteTable('lists', {
       id: text('id').primaryKey(),
       name: text('name').notNull(),
+      verified: integer('verified', {mode: 'boolean'}),
       owner_id: text('owner_id'),
       counter: integer('counter'),
-      completion: real('completion')
+      completion: real('completion'),
+      info: text('info', {mode: 'json'}),
+      created_at: integer('created_at', {mode: 'timestamp'}),
+      updated_at: integer('updated_at', {mode: 'timestamp'}),
     });
     const convertedList = toPowerSyncTable(lists);
 
     const expectedLists = new Table({
       name: column.text,
+      verified: column.integer,
       owner_id: column.text,
       counter: column.integer,
-      completion: column.real
+      completion: column.real,
+      info: column.text,
+      created_at: column.integer,
+      updated_at: column.integer,
     });
 
     expect(convertedList).toEqual(expectedLists);


### PR DESCRIPTION
Drizzle schema supports some "mode," which behaves like a type in the JavaScript world and persists data as other types in SQLite.

For example, when using `text({mode: 'json'})`, in JavaScript it's JSON, but it stores data as text in SQLite.