### PR TITLE
toPowerSyncTable support casing

### DIFF
--- a/.changeset/strange-coins-leave.md
+++ b/.changeset/strange-coins-leave.md
@@ -1,0 +1,5 @@
+---
+'@powersync/drizzle-driver': minor
+---
+
+Added support for casing option in the Drizzle schema helper functions.

--- a/packages/drizzle-driver/src/index.ts
+++ b/packages/drizzle-driver/src/index.ts
@@ -3,6 +3,7 @@ import { toCompilableQuery } from './utils/compilableQuery';
 import {
   DrizzleAppSchema,
   toPowerSyncTable,
+  type DrizzleAppSchemaOptions,
   type DrizzleTablePowerSyncOptions,
   type DrizzleTableWithPowerSyncOptions,
   type Expand,
@@ -13,6 +14,7 @@ import {
 
 export {
   DrizzleAppSchema,
+  DrizzleAppSchemaOptions,
   DrizzleTablePowerSyncOptions,
   DrizzleTableWithPowerSyncOptions,
   DrizzleQuery,

--- a/packages/drizzle-driver/src/utils/schema.ts
+++ b/packages/drizzle-driver/src/utils/schema.ts
@@ -16,7 +16,8 @@ import {
   SQLiteReal,
   SQLiteText,
   type SQLiteTableWithColumns,
-  type TableConfig
+  type TableConfig,
+  SQLiteColumn
 } from 'drizzle-orm/sqlite-core';
 
 export type ExtractPowerSyncColumns<T extends SQLiteTableWithColumns<any>> = {
@@ -66,7 +67,9 @@ export function toPowerSyncTable<T extends SQLiteTableWithColumns<any>>(
     }
     const columns: string[] = [];
     for (const indexColumn of index.config.columns) {
-      columns.push((indexColumn as { name: string }).name);
+      const name = casingCache.getColumnCasing(indexColumn as SQLiteColumn);
+
+      columns.push(name);
     }
 
     indexes[index.config.name] = columns;

--- a/packages/drizzle-driver/src/utils/schema.ts
+++ b/packages/drizzle-driver/src/utils/schema.ts
@@ -8,7 +8,7 @@ import {
   type TableV2Options
 } from '@powersync/common';
 import { InferSelectModel, isTable, Relations } from 'drizzle-orm';
-import { Casing } from 'drizzle-orm';
+import type { Casing } from 'drizzle-orm';
 import { CasingCache } from 'drizzle-orm/casing';
 import {
   getTableConfig,
@@ -17,7 +17,7 @@ import {
   SQLiteText,
   type SQLiteTableWithColumns,
   type TableConfig,
-  SQLiteColumn
+  type SQLiteColumn
 } from 'drizzle-orm/sqlite-core';
 
 export type ExtractPowerSyncColumns<T extends SQLiteTableWithColumns<any>> = {
@@ -131,7 +131,7 @@ function toPowerSyncTables<
 
 export type DrizzleAppSchemaOptions = {
   casing?: Casing;
-}
+};
 export class DrizzleAppSchema<
   T extends Record<string, SQLiteTableWithColumns<any> | Relations | DrizzleTableWithPowerSyncOptions>
 > extends Schema {

--- a/packages/drizzle-driver/tests/sqlite/schema.test.ts
+++ b/packages/drizzle-driver/tests/sqlite/schema.test.ts
@@ -70,11 +70,16 @@ describe('toPowerSyncTable', () => {
 
 
   it('conversation with casing', () => {
-    const lists = sqliteTable('lists', {
-      id: text('id').primaryKey(),
-      myName: text().notNull(),
-      yourName: text('yourName').notNull(),
-    });
+    const lists = sqliteTable('lists', 
+      {
+        id: text('id').primaryKey(),
+        myName: text().notNull(),
+        yourName: text('yourName').notNull(),
+      },
+      (lists) => ({
+        names: index('names').on(lists.myName, lists.yourName)
+      })
+    );
 
     const convertedList = toPowerSyncTable(lists, new CasingCache('snake_case'));
 
@@ -82,7 +87,8 @@ describe('toPowerSyncTable', () => {
       {
         my_name: column.text,
         yourName: column.text,
-      }
+      },
+      { indexes: { names: ['my_name', 'yourName'] } }
     );
 
     expect(convertedList).toEqual(expectedLists);

--- a/packages/drizzle-driver/tests/sqlite/schema.test.ts
+++ b/packages/drizzle-driver/tests/sqlite/schema.test.ts
@@ -73,18 +73,27 @@ describe('toPowerSyncTable', () => {
   });
 
   it('conversion with casing', () => {
-    const lists = sqliteTable('lists', {
-      id: text('id').primaryKey(),
-      myName: text().notNull(),
-      yourName: text('yourName').notNull() // explicitly set casing
-    });
+    const lists = sqliteTable(
+      'lists',
+      {
+        id: text('id').primaryKey(),
+        myName: text().notNull(),
+        yourName: text('yourName').notNull() // explicitly set casing
+      },
+      (lists) => ({
+        names: index('names').on(lists.myName, lists.yourName)
+      })
+    );
 
     const convertedList = toPowerSyncTable(lists, { casingCache: new CasingCache('snake_case') });
 
-    const expectedLists = new Table({
-      my_name: column.text,
-      yourName: column.text
-    });
+    const expectedLists = new Table(
+      {
+        my_name: column.text,
+        yourName: column.text
+      },
+      { indexes: { names: ['my_name', 'yourName'] } }
+    );
 
     expect(convertedList).toEqual(expectedLists);
   });
@@ -221,11 +230,17 @@ describe('DrizzleAppSchema constructor', () => {
   });
 
   it('conversion with casing', () => {
-    const lists = sqliteTable('lists', {
-      id: text('id').primaryKey(),
-      myName: text().notNull(),
-      yourName: text('yourName').notNull() // explicitly set casing
-    });
+    const lists = sqliteTable(
+      'lists',
+      {
+        id: text('id').primaryKey(),
+        myName: text().notNull(),
+        yourName: text('yourName').notNull() // explicitly set casing
+      },
+      (lists) => ({
+        names: index('names').on(lists.myName, lists.yourName)
+      })
+    );
 
     const drizzleSchemaWithOptions = {
       lists
@@ -234,10 +249,13 @@ describe('DrizzleAppSchema constructor', () => {
     const convertedSchema = new DrizzleAppSchema(drizzleSchemaWithOptions, { casing: 'snake_case' });
 
     const expectedSchema = new Schema({
-      lists: new Table({
-        my_name: column.text,
-        yourName: column.text
-      })
+      lists: new Table(
+        {
+          my_name: column.text,
+          yourName: column.text
+        },
+        { indexes: { names: ['my_name', 'yourName'] } }
+      )
     });
 
     expect(convertedSchema.tables).toEqual(expectedSchema.tables);

--- a/packages/drizzle-driver/tests/sqlite/schema.test.ts
+++ b/packages/drizzle-driver/tests/sqlite/schema.test.ts
@@ -56,7 +56,11 @@ describe('toPowerSyncTable', () => {
       name: text('name').notNull()
     });
 
-    const convertedList = toPowerSyncTable(lists, new CasingCache(), { localOnly: true, insertOnly: true, viewName: 'listsView' });
+    const convertedList = toPowerSyncTable(lists, new CasingCache(), {
+      localOnly: true,
+      insertOnly: true,
+      viewName: 'listsView'
+    });
 
     const expectedLists = new Table(
       {
@@ -68,13 +72,13 @@ describe('toPowerSyncTable', () => {
     expect(convertedList).toEqual(expectedLists);
   });
 
-
   it('conversation with casing', () => {
-    const lists = sqliteTable('lists', 
+    const lists = sqliteTable(
+      'lists',
       {
         id: text('id').primaryKey(),
         myName: text().notNull(),
-        yourName: text('yourName').notNull(),
+        yourName: text('yourName').notNull()
       },
       (lists) => ({
         names: index('names').on(lists.myName, lists.yourName)
@@ -86,13 +90,13 @@ describe('toPowerSyncTable', () => {
     const expectedLists = new Table(
       {
         my_name: column.text,
-        yourName: column.text,
+        yourName: column.text
       },
       { indexes: { names: ['my_name', 'yourName'] } }
     );
 
     expect(convertedList).toEqual(expectedLists);
-  })
+  });
 });
 
 describe('DrizzleAppSchema constructor', () => {


### PR DESCRIPTION
drizzle-orm supports a [casing](https://orm.drizzle.team/docs/sql-schema-declaration#camel-and-snake-casing) option to support defining schema in the following format (without explicit column name):

```
export const users = sqliteTable('users', {
  id: integer(),
  firstName: varchar()
})
```

This PR makes toPowerSyncTable supports this as well:

```
export const AppSchema = new DrizzleAppSchema(drizzleSchema, {casing: 'snake_case'});
```