### PR TITLE
fix: Tanstack not deriving default client

### DIFF
--- a/.changeset/cold-grapes-occur.md
+++ b/.changeset/cold-grapes-occur.md
@@ -1,0 +1,5 @@
+---
+'@powersync/tanstack-react-query': minor
+---
+
+Changed how default query client is derived when not supplied as a function parameter. Fixes some cases where deriving the query client happens too early.


### PR DESCRIPTION
In some environments problems were encountered with deriving the default query client as the value for a function parameter. Simply resolving the value inside the function fixes this.