### PR TITLE
chore: optimize the useStatus hook and underlying isEqual

### DIFF
--- a/.changeset/two-plants-thank.md
+++ b/.changeset/two-plants-thank.md
@@ -1,0 +1,6 @@
+---
+"@powersync/common": patch
+"@powersync/react": patch
+---
+
+chore: optimize the useStatus hook and underlying isEqual

--- a/packages/common/src/db/crud/SyncStatus.ts
+++ b/packages/common/src/db/crud/SyncStatus.ts
@@ -11,7 +11,7 @@ export type SyncStatusOptions = {
 };
 
 export class SyncStatus {
-  constructor(protected options: SyncStatusOptions) {}
+  constructor(protected options: SyncStatusOptions) { }
 
   /**
    * true if currently connected.
@@ -56,7 +56,18 @@ export class SyncStatus {
   }
 
   isEqual(status: SyncStatus) {
-    return JSON.stringify(this.options) == JSON.stringify(status.options);
+    if (!status) return false;
+
+    const thisOpts = this.options;
+    const otherOpts = status.options;
+
+    return (
+      thisOpts.connected === otherOpts.connected &&
+      thisOpts.hasSynced === otherOpts.hasSynced &&
+      (thisOpts.lastSyncedAt?.getTime() === otherOpts.lastSyncedAt?.getTime()) &&
+      thisOpts.dataFlow?.downloading === otherOpts.dataFlow?.downloading &&
+      thisOpts.dataFlow?.uploading === otherOpts.dataFlow?.uploading
+    );
   }
 
   getMessage() {

--- a/packages/react/src/hooks/usePowerSyncStatus.ts
+++ b/packages/react/src/hooks/usePowerSyncStatus.ts
@@ -21,10 +21,13 @@ export const usePowerSyncStatus = () => {
 
   useEffect(() => {
     const listener = powerSync.registerListener({
-      statusChanged: (status) => {
-        setSyncStatus(status);
+      statusChanged: (newStatus) => {
+        setSyncStatus(prev => {
+          // Only update if the status is actually different
+          return prev.isEqual(newStatus) ? prev : newStatus
+        })
       }
-    });
+    })
 
     return () => listener?.();
   }, [powerSync]);


### PR DESCRIPTION
This prevents the 'spammy' useStatus behaviour
key changes:
- explicitly compare the values in the SyncStatus object, its more performant than the `JSON.stringify` alternative this is important since this is triggered often
- we use this isEqual in the usePowerSyncStatus hook to only update the state only when the value actually changes