### PR TITLE
fix: supabase integration guide links

### DIFF
--- a/demos/angular-supabase-todolist/README.md
+++ b/demos/angular-supabase-todolist/README.md
@@ -8,7 +8,7 @@ This demo is currently in an alpha release.
 
 Demo app demonstrating use of the [PowerSync SDK for Web](https://www.npmjs.com/package/@powersync/web) together with Supabase.
 
-A step-by-step guide on Supabase<>PowerSync integration is available [here](https://docs.powersync.com/integration-guides/supabase).
+A step-by-step guide on Supabase<>PowerSync integration is available [here](https://docs.powersync.com/integration-guides/supabase-+-powersync).
 
 ## Quick Start
 

--- a/demos/react-native-supabase-todolist/README.md
+++ b/demos/react-native-supabase-todolist/README.md
@@ -4,7 +4,7 @@
 
 Demo app demonstrating use of the [PowerSync SDK for React Native](https://www.npmjs.com/package/@powersync/react-native) together with Supabase.
 
-A step-by-step guide on Supabase<>PowerSync integration is available [here](https://docs.powersync.com/integration-guides/supabase).
+A step-by-step guide on Supabase<>PowerSync integration is available [here](https://docs.powersync.com/integration-guides/supabase-+-powersync).
 Follow all the steps until, but not including, [Test Everything (Using Our Demo App)](https://docs.powersync.com/integration-guides/supabase-+-powersync#test-everything-using-our-demo-app).
 
 ## Getting Started
@@ -51,4 +51,3 @@ General information on defining environment variables with Expo can be found her
 Check out [the PowerSync SDK for React Native on GitHub](https://github.com/powersync-ja/powersync-js/tree/main/packages/react-native) - your feedback and contributions are welcome!
 
 To learn more about PowerSync, see the [PowerSync docs](https://docs.powersync.com).
-

--- a/demos/react-native-web-supabase-todolist/README.md
+++ b/demos/react-native-web-supabase-todolist/README.md
@@ -21,7 +21,7 @@ pnpm build:packages
 
 ### Set up Supabase Project
 
-Detailed instructions for integrating PowerSync with Supabase can be found in the [integration guide](https://docs.powersync.com/integration-guides/supabase). Below are the main steps required to get this demo running.
+Detailed instructions for integrating PowerSync with Supabase can be found in the [integration guide](https://docs.powersync.com/integration-guides/supabase-+-powersync). Below are the main steps required to get this demo running.
 
 Create a new Supabase project, and paste and run the contents of [database.sql](./database.sql) in the Supabase SQL editor.
 

--- a/demos/react-supabase-todolist-optional-sync/README.md
+++ b/demos/react-supabase-todolist-optional-sync/README.md
@@ -46,7 +46,7 @@ Create Supabase and PowerSync projects, and add their credentials to `.env` to e
 
 ## Set up your Supabase project
 
-Detailed instructions for integrating PowerSync with Supabase can be found in [the integration guide](https://docs.powersync.com/integration-guides/supabase). Below are the main steps required to get this demo running.
+Detailed instructions for integrating PowerSync with Supabase can be found in [the integration guide](https://docs.powersync.com/integration-guides/supabase-+-powersync). Below are the main steps required to get this demo running.
 
 Create a new Supabase project, and paste an run the contents of [database.sql](./database.sql) in the Supabase SQL editor.
 

--- a/demos/react-supabase-todolist/README.md
+++ b/demos/react-supabase-todolist/README.md
@@ -4,7 +4,7 @@
 
 Demo app demonstrating use of the [PowerSync SDK for Web](https://www.npmjs.com/package/@powersync/web) together with Supabase.
 
-A step-by-step guide on Supabase<>PowerSync integration is available [here](https://docs.powersync.com/integration-guides/supabase).
+A step-by-step guide on Supabase<>PowerSync integration is available [here](https://docs.powersync.com/integration-guides/supabase-+-powersync).
 
 ## Getting Started
 

--- a/demos/vue-supabase-todolist/README.md
+++ b/demos/vue-supabase-todolist/README.md
@@ -8,7 +8,7 @@ The `powersync/vue` package is currently in a beta release.
 
 Demo app demonstrating use of the [PowerSync Vue](https://www.npmjs.com/package/@powersync/vue) together with Supabase.
 
-A step-by-step guide through the Supabase<>PowerSync integration is available [here](https://docs.powersync.com/integration-guides/supabase).
+A step-by-step guide through the Supabase<>PowerSync integration is available [here](https://docs.powersync.com/integration-guides/supabase-+-powersync).
 
 ## Recommended Setup
 


### PR DESCRIPTION
## Description
It appears this `https://docs.powersync.com/integration-guides/supabase` link has changed to `https://docs.powersync.com/integration-guides/supabase-+-powersync` so users were being redirected to the overview page. This fixes the links to map to the correct guide.