### PR TITLE
Fixed angular demo app issues related to newer versions of web SDK and wa-sqlite.

### DIFF
--- a/demos/angular-supabase-todolist/.gitignore
+++ b/demos/angular-supabase-todolist/.gitignore
@@ -166,3 +166,5 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+src/assets/@powersync

--- a/demos/angular-supabase-todolist/README.md
+++ b/demos/angular-supabase-todolist/README.md
@@ -13,17 +13,16 @@ A step-by-step guide on Supabase<>PowerSync integration is available [here](http
 ## Quick Start
 
 1. Run `pnpm install`
-2. Run `pnpm powersync-web copy-assets -o src/assets` to copy the worker assets into the project.
-3. Create a `.env` file by copying the template `cp .env.template .env`
-4. Populate the `.env` file with PowerSync and Supabase details
-5. Run `pnpm watch` to build application and check for code changes
-6. In a new terminal run `pnpm start` to start the server
-7. Go to <http://localhost:8080>
+2. Create a `.env` file by copying the template `cp .env.template .env`
+3. Populate the `.env` file with PowerSync and Supabase details
+4. Run `pnpm watch` to build application and check for code changes
+5. In a new terminal run `pnpm start` to start the server
+6. Go to <http://localhost:8080>
 
 ### Notes
 
 - The Angular development server (`pnpm serve`) doesn't support service worker applications
-- For Angular, workers need to be configured when instantiating `PowerSyncDatabase`. To do this, copy the worker assets (`step 2`) and ensure the worker paths are specified ([example here](./src/app/powersync.service.ts)).
+- For Angular, workers need to be configured when instantiating `PowerSyncDatabase`. To do this, copy the worker assets (`pnpm powersync-web copy-assets -o src/assets` - done automatically as a `postinstall` step in this demo) and ensure the worker paths are specified ([example here](./src/app/powersync.service.ts)).
 
 ## Development Server
 

--- a/demos/angular-supabase-todolist/README.md
+++ b/demos/angular-supabase-todolist/README.md
@@ -22,7 +22,7 @@ A step-by-step guide on Supabase<>PowerSync integration is available [here](http
 ### Notes
 
 - The Angular development server (`pnpm serve`) doesn't support service worker applications
-- For Angular, workers need to be configured when instantiating `PowerSyncDatabase`. To do this, copy the worker assets (`pnpm powersync-web copy-assets -o src/assets` - done automatically as `pre-` steps in this demo for serving and building) and ensure the worker paths are specified ([example here](./src/app/powersync.service.ts)).
+- For Angular, workers need to be configured when instantiating `PowerSyncDatabase`. To do this, copy the worker assets (`pnpm powersync-web copy-assets -o src/assets` - done automatically in this demo for serving and building) and ensure the worker paths are specified ([example here](./src/app/powersync.service.ts)).
 
 ## Development Server
 

--- a/demos/angular-supabase-todolist/README.md
+++ b/demos/angular-supabase-todolist/README.md
@@ -13,13 +13,17 @@ A step-by-step guide on Supabase<>PowerSync integration is available [here](http
 ## Quick Start
 
 1. Run `pnpm install`
-2. Create a `.env` file by copying the template `cp .env.template .env`
-3. Populate the `.env` file with PowerSync and Supabase details
-4. Run `pnpm watch` to build application and check for code changes
-5. In a new terminal run `pnpm start` to start the server
-6. Go to <http://localhost:8080>
+2. Run `pnpm powersync-web copy-assets -o src/assets` to copy the worker assets into the project.
+3. Create a `.env` file by copying the template `cp .env.template .env`
+4. Populate the `.env` file with PowerSync and Supabase details
+5. Run `pnpm watch` to build application and check for code changes
+6. In a new terminal run `pnpm start` to start the server
+7. Go to <http://localhost:8080>
 
-**Note:** The Angular development server (`pnpm serve`) doesn't support service worker applications
+### Notes
+
+- The Angular development server (`pnpm serve`) doesn't support service worker applications
+- For Angular, workers need to be configured when instantiating `PowerSyncDatabase`. To do this, copy the worker assets (`step 2`) and ensure the worker paths are specified ([example here](./src/app/powersync.service.ts)).
 
 ## Development Server
 

--- a/demos/angular-supabase-todolist/README.md
+++ b/demos/angular-supabase-todolist/README.md
@@ -22,7 +22,7 @@ A step-by-step guide on Supabase<>PowerSync integration is available [here](http
 ### Notes
 
 - The Angular development server (`pnpm serve`) doesn't support service worker applications
-- For Angular, workers need to be configured when instantiating `PowerSyncDatabase`. To do this, copy the worker assets (`pnpm powersync-web copy-assets -o src/assets` - done automatically as a `postinstall` step in this demo) and ensure the worker paths are specified ([example here](./src/app/powersync.service.ts)).
+- For Angular, workers need to be configured when instantiating `PowerSyncDatabase`. To do this, copy the worker assets (`pnpm powersync-web copy-assets -o src/assets` - done automatically as `pre-` steps in this demo for serving and building) and ensure the worker paths are specified ([example here](./src/app/powersync.service.ts)).
 
 ## Development Server
 

--- a/demos/angular-supabase-todolist/package.json
+++ b/demos/angular-supabase-todolist/package.json
@@ -8,7 +8,8 @@
     "build": "ng build",
     "format": "prettier --write .",
     "test:build": "pnpm build",
-    "watch": "ng build --watch --configuration development"
+    "watch": "ng build --watch --configuration development",
+    "postinstall": "pnpm powersync-web copy-assets -o src/assets"
   },
   "private": true,
   "dependencies": {

--- a/demos/angular-supabase-todolist/package.json
+++ b/demos/angular-supabase-todolist/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --write .",
     "test:build": "pnpm build",
     "watch": "ng build --watch --configuration development",
-    "postinstall": "pnpm powersync-web copy-assets -o src/assets"
+    "postinstall": "[ \"$GITHUB_ACTIONS\" = \"true\" ] || pnpm powersync-web copy-assets -o src/assets"
   },
   "private": true,
   "dependencies": {

--- a/demos/angular-supabase-todolist/package.json
+++ b/demos/angular-supabase-todolist/package.json
@@ -2,14 +2,17 @@
   "name": "angular-supabase-todolist",
   "version": "0.0.25",
   "scripts": {
+    "copy-assets": "pnpm powersync-web copy-assets -o src/assets",
     "ng": "ng",
+    "preserve": "pnpm copy-assets",
     "serve": "ng serve",
     "start": "http-server -p 8080 -c-1 dist/",
+    "prebuild": "pnpm copy-assets",
     "build": "ng build",
     "format": "prettier --write .",
     "test:build": "pnpm build",
-    "watch": "ng build --watch --configuration development",
-    "postinstall": "[ \"$GITHUB_ACTIONS\" = \"true\" ] || pnpm powersync-web copy-assets -o src/assets"
+    "prewatch": "pnpm copy-assets",
+    "watch": "ng build --watch --configuration development"
   },
   "private": true,
   "dependencies": {

--- a/demos/angular-supabase-todolist/package.json
+++ b/demos/angular-supabase-todolist/package.json
@@ -4,11 +4,9 @@
   "scripts": {
     "copy-assets": "pnpm powersync-web copy-assets -o src/assets",
     "ng": "ng",
-    "preserve": "pnpm copy-assets",
-    "serve": "ng serve",
+    "serve": "pnpm copy-assets && ng serve",
     "start": "http-server -p 8080 -c-1 dist/",
-    "prebuild": "pnpm copy-assets",
-    "build": "ng build",
+    "build": "pnpm copy-assets && ng build",
     "format": "prettier --write .",
     "test:build": "pnpm build",
     "prewatch": "pnpm copy-assets",

--- a/demos/angular-supabase-todolist/src/app/powersync.service.ts
+++ b/demos/angular-supabase-todolist/src/app/powersync.service.ts
@@ -6,9 +6,10 @@ import {
   Index,
   IndexedColumn,
   PowerSyncBackendConnector,
+  PowerSyncDatabase,
   Schema,
   Table,
-  WASQLitePowerSyncDatabaseOpenFactory
+  WASQLiteOpenFactory
 } from '@powersync/web';
 
 export interface ListRecord {
@@ -63,11 +64,21 @@ export class PowerSyncService {
   db: AbstractPowerSyncDatabase;
 
   constructor() {
-    const PowerSyncFactory = new WASQLitePowerSyncDatabaseOpenFactory({
-      schema: AppSchema,
-      dbFilename: 'test.db'
+    const factory = new WASQLiteOpenFactory({
+      dbFilename: 'test.db',
+
+      // Specify the path to the worker script
+      worker: 'assets/@powersync/worker/WASQLiteDB.umd.js'
     });
-    this.db = PowerSyncFactory.getInstance();
+
+    this.db = new PowerSyncDatabase({
+      schema: AppSchema,
+      database: factory,
+      sync: {
+        // Specify the path to the worker script
+        worker: 'assets/@powersync/worker/SharedSyncImplementation.umd.js'
+      }
+    });
   }
 
   setupPowerSync = async (connector: PowerSyncBackendConnector) => {


### PR DESCRIPTION
We identified an issue with the Angular demo app when running on versions of “@journeyapps/wa-sqlite” newer than “0.4.2” and “@powersync/web” newer than “1.10.2”. The problem appears to stem from the newer wa-sqlite code not interacting correctly `with Angular’s Zone.js` dependecy.

As a workaround, you can copy the worker assets directly into the project and configure them at instantiation, similar to the approach used in the `react-native-web` demo. This approach resolves the issue. The README and code have been updated accordingly. Copying happens automatically as part of the serve/build steps in the demo.