### PR TITLE
chore: change TableV2 to Table

### DIFF
--- a/demos/django-react-native-todolist/library/powersync/AppSchema.ts
+++ b/demos/django-react-native-todolist/library/powersync/AppSchema.ts
@@ -1,9 +1,9 @@
-import { column, Schema, TableV2 } from '@powersync/react-native';
+import { column, Schema, Table } from '@powersync/react-native';
 
 export const LIST_TABLE = 'lists';
 export const TODO_TABLE = 'todos';
 
-const todos = new TableV2(
+const todos = new Table(
   {
     list_id: column.text,
     created_at: column.text,
@@ -17,7 +17,7 @@ const todos = new TableV2(
   { indexes: { list: ['list_id'] } }
 );
 
-const lists = new TableV2({
+const lists = new Table({
   created_at: column.text,
   name: column.text,
   owner_id: column.text

--- a/demos/example-capacitor/src/library/powersync/AppSchema.ts
+++ b/demos/example-capacitor/src/library/powersync/AppSchema.ts
@@ -1,6 +1,6 @@
-import { column, Schema, TableV2 } from '@powersync/web';
+import { column, Schema, Table } from '@powersync/web';
 
-const customers = new TableV2({
+const customers = new Table({
   name: column.text,
   created_at: column.text
 });

--- a/demos/example-electron/src/library/powersync/AppSchema.ts
+++ b/demos/example-electron/src/library/powersync/AppSchema.ts
@@ -1,6 +1,6 @@
-import { column, Schema, TableV2 } from '@powersync/web';
+import { column, Schema, Table } from '@powersync/web';
 
-const customers = new TableV2({
+const customers = new Table({
   name: column.text,
   created_at: column.text
 });

--- a/demos/example-nextjs/src/library/powersync/AppSchema.ts
+++ b/demos/example-nextjs/src/library/powersync/AppSchema.ts
@@ -1,6 +1,6 @@
-import { column, Schema, TableV2 } from '@powersync/web';
+import { column, Schema, Table } from '@powersync/web';
 
-const customers = new TableV2({
+const customers = new Table({
   name: column.text,
   created_at: column.text
 });

--- a/demos/react-supabase-todolist-optional-sync/src/library/powersync/AppSchema.ts
+++ b/demos/react-supabase-todolist-optional-sync/src/library/powersync/AppSchema.ts
@@ -1,4 +1,4 @@
-import { AbstractPowerSyncDatabase, column, ColumnsType, Schema, Table, TableV2Options } from '@powersync/web';
+import { AbstractPowerSyncDatabase, column, Schema, Table } from '@powersync/web';
 import { setSyncEnabled } from './SyncMode';
 
 /**

--- a/demos/vue-supabase-todolist/src/library/powersync/AppSchema.ts
+++ b/demos/vue-supabase-todolist/src/library/powersync/AppSchema.ts
@@ -1,9 +1,9 @@
-import { column, Schema, TableV2 } from '@powersync/web';
+import { column, Schema, Table } from '@powersync/web';
 
 export const LISTS_TABLE = 'lists';
 export const TODOS_TABLE = 'todos';
 
-const todos = new TableV2(
+const todos = new Table(
   {
     list_id: column.text,
     created_at: column.text,
@@ -16,7 +16,7 @@ const todos = new TableV2(
   { indexes: { list: ['list_id'] } }
 );
 
-const lists = new TableV2({
+const lists = new Table({
   created_at: column.text,
   name: column.text,
   owner_id: column.text

--- a/demos/yjs-react-supabase-text-collab/src/library/powersync/AppSchema.ts
+++ b/demos/yjs-react-supabase-text-collab/src/library/powersync/AppSchema.ts
@@ -1,11 +1,11 @@
-import { column, Schema, TableV2 } from '@powersync/web';
+import { column, Schema, Table } from '@powersync/web';
 
-const documents = new TableV2({
+const documents = new Table({
   title: column.text,
   created_at: column.text
 });
 
-const document_updates = new TableV2(
+const document_updates = new Table(
   {
     document_id: column.text,
     created_at: column.text,


### PR DESCRIPTION
## Description
Change all references in demos from `TableV2` to `Table` as we have deprecated `TableV2`.