### PR TITLE
Add schema validation

### DIFF
--- a/packages/common/src/db/schema/Schema.ts
+++ b/packages/common/src/db/schema/Schema.ts
@@ -19,6 +19,18 @@ export class Schema<S extends SchemaType = SchemaType> {
 
   constructor(tables: Table[] | S) {
     if (Array.isArray(tables)) {
+      /*
+        We need to validate that the tables have a name here because a user could pass in an array
+        of Tables that don't have a name because they are using the V2 syntax.
+        Therefore, 'convertToClassicTables' won't be called on the tables resulting in a runtime error.
+      */
+      for (const table of tables) {
+        if (table.name === '') {
+          throw new Error(
+            "It appears you are trying to create a new Schema with an array instead of an object. Passing in an object instead of an array into 'new Schema()' may resolve your issue."
+          );
+        }
+      }
       this.tables = tables;
     } else {
       this.props = tables as S;

--- a/packages/common/tests/db/schema/Schema.test.ts
+++ b/packages/common/tests/db/schema/Schema.test.ts
@@ -5,13 +5,13 @@ import { column, ColumnType } from '../../../src/db/schema/Column';
 import { Column } from '../../../lib';
 
 describe('Schema', () => {
-  it('should fail if array is passed and not a table object', () => {
+  it('should fail if an array of tables using the new syntax is passed to schema', () => {
     const table1 = new Table({ name: column.text });
     const table2 = new Table({ age: { type: ColumnType.INTEGER } });
     expect(() => new Schema([table1, table2])).toThrow();
   });
 
-  it('should create a schema with an array of tables', () => {
+  it('should create a schema with an array of tables using the old syntax', () => {
     const table1 = new Table({
       name: 'table1',
       columns: [new Column({ name: 'name', type: ColumnType.TEXT })]

--- a/packages/common/tests/db/schema/Schema.test.ts
+++ b/packages/common/tests/db/schema/Schema.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { Schema } from '../../../src/db/schema/Schema';
 import { Table } from '../../../src/db/schema/Table';
-import { column, ColumnType } from '../../../src/db/schema/Column';
-import { Column } from '../../../lib';
+import { column, ColumnType, Column } from '../../../src/db/schema/Column';
 
 describe('Schema', () => {
   it('should fail if an array of tables using the new syntax is passed to schema', () => {

--- a/packages/common/tests/db/schema/Schema.test.ts
+++ b/packages/common/tests/db/schema/Schema.test.ts
@@ -2,14 +2,26 @@ import { describe, it, expect } from 'vitest';
 import { Schema } from '../../../src/db/schema/Schema';
 import { Table } from '../../../src/db/schema/Table';
 import { column, ColumnType } from '../../../src/db/schema/Column';
+import { Column } from '../../../lib';
 
 describe('Schema', () => {
+  it('should fail if array is passed and not a table object', () => {
+    const table1 = new Table({ name: column.text });
+    const table2 = new Table({ age: { type: ColumnType.INTEGER } });
+    expect(() => new Schema([table1, table2])).toThrow();
+  });
+
   it('should create a schema with an array of tables', () => {
-    const tables = [
-      new Table({ name: column.text, }),
-      new Table({ age: { type: ColumnType.INTEGER } })
-    ];
-    const schema = new Schema(tables);
+    const table1 = new Table({
+      name: 'table1',
+      columns: [new Column({ name: 'name', type: ColumnType.TEXT })]
+    });
+    const table2 = new Table({
+      name: 'table2',
+      columns: [new Column({ name: 'age', type: ColumnType.INTEGER })]
+    });
+    const schema = new Schema([table1, table2]);
+    expect(() => schema.validate()).not.toThrow();
 
     expect(schema.tables).toHaveLength(2);
     expect(schema.tables[0].columns[0].name).toBe('name');


### PR DESCRIPTION
This PR addresses https://github.com/powersync-ja/powersync-js/issues/431#issuecomment-2522158014.

Add validation to the Schema constructor.
- We need to validate that the tables have a name here because a user could pass in an array Tables that don't have a name because they are using the V2 syntax.  Therefore, 'convertToClassicTables' won't be called on the tables resulting in a runtime error. 

Additional Tests:
- Added a new Schema test which checks that an error is thrown when a Schema is created incorrectly.
