### PR TITLE
chore: rename docs headings

### DIFF
--- a/docs/utils/packageMap.ts
+++ b/docs/utils/packageMap.ts
@@ -30,14 +30,14 @@ export const packageMap: PackageMap = {
     id: Packages.ReactNativeSdk
   },
   [Packages.ReactSdk]: {
-    name: 'React SDK',
+    name: 'React Hooks',
     dirName: Packages.ReactSdk,
     entryPoints: ['../packages/react/src/index.ts'],
     tsconfig: '../packages/react/tsconfig.json',
     id: Packages.ReactSdk
   },
   [Packages.VueSdk]: {
-    name: 'Vue SDK',
+    name: 'Vue Composables',
     dirName: Packages.VueSdk,
     entryPoints: ['../packages/vue/src/index.ts'],
     tsconfig: '../packages/vue/tsconfig.json',
@@ -58,7 +58,7 @@ export const packageMap: PackageMap = {
     id: Packages.WebSdk
   },
   [Packages.TanstackReactQuerySdk]: {
-    name: 'Tanstack React Query SDK',
+    name: 'Tanstack React Query Hooks',
     dirName: Packages.TanstackReactQuerySdk,
     entryPoints: ['../packages/tanstack-react-query/src/index.ts'],
     tsconfig: '../packages/tanstack-react-query/tsconfig.json',

--- a/docs/utils/packageMap.ts
+++ b/docs/utils/packageMap.ts
@@ -29,12 +29,26 @@ export const packageMap: PackageMap = {
     tsconfig: '../packages/react-native/tsconfig.json',
     id: Packages.ReactNativeSdk
   },
+  [Packages.WebSdk]: {
+    name: 'Web SDK',
+    dirName: Packages.WebSdk,
+    entryPoints: ['../packages/web/src/index.ts'],
+    tsconfig: '../packages/web/tsconfig.json',
+    id: Packages.WebSdk
+  },
   [Packages.ReactSdk]: {
     name: 'React Hooks',
     dirName: Packages.ReactSdk,
     entryPoints: ['../packages/react/src/index.ts'],
     tsconfig: '../packages/react/tsconfig.json',
     id: Packages.ReactSdk
+  },
+  [Packages.TanstackReactQuerySdk]: {
+    name: 'Tanstack React Query Hooks',
+    dirName: Packages.TanstackReactQuerySdk,
+    entryPoints: ['../packages/tanstack-react-query/src/index.ts'],
+    tsconfig: '../packages/tanstack-react-query/tsconfig.json',
+    id: Packages.TanstackReactQuerySdk
   },
   [Packages.VueSdk]: {
     name: 'Vue Composables',
@@ -49,19 +63,5 @@ export const packageMap: PackageMap = {
     entryPoints: ['../packages/attachments/src/index.ts'],
     tsconfig: '../packages/attachments/tsconfig.json',
     id: Packages.AttachmentsSdk
-  },
-  [Packages.WebSdk]: {
-    name: 'Web SDK',
-    dirName: Packages.WebSdk,
-    entryPoints: ['../packages/web/src/index.ts'],
-    tsconfig: '../packages/web/tsconfig.json',
-    id: Packages.WebSdk
-  },
-  [Packages.TanstackReactQuerySdk]: {
-    name: 'Tanstack React Query Hooks',
-    dirName: Packages.TanstackReactQuerySdk,
-    entryPoints: ['../packages/tanstack-react-query/src/index.ts'],
-    tsconfig: '../packages/tanstack-react-query/tsconfig.json',
-    id: Packages.TanstackReactQuerySdk
   }
 };


### PR DESCRIPTION
## Description
Rename JS Doc headings to use the frameworks nomenclature.

<img width="229" alt="image" src="https://github.com/user-attachments/assets/fb6b5392-e554-493d-9b0a-e45a4672b136" />
