### PR TITLE
chore: add concurrency to actions

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -4,7 +4,7 @@ on:
   push:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -3,7 +3,9 @@ name: Build docs
 on:
   push:
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -3,6 +3,8 @@ name: Build docs
 on:
   push:
 
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-packages.yaml
+++ b/.github/workflows/build-packages.yaml
@@ -4,7 +4,9 @@ name: Build Packages
 on:
   push:
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/build-packages.yaml
+++ b/.github/workflows/build-packages.yaml
@@ -4,6 +4,8 @@ name: Build Packages
 on:
   push:
 
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   build:
     name: Build Packages

--- a/.github/workflows/dev-packages.yaml
+++ b/.github/workflows/dev-packages.yaml
@@ -4,7 +4,9 @@ name: Create Dev Release
 
 on: workflow_dispatch
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   publish:

--- a/.github/workflows/dev-packages.yaml
+++ b/.github/workflows/dev-packages.yaml
@@ -4,6 +4,8 @@ name: Create Dev Release
 
 on: workflow_dispatch
 
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   publish:
     name: Publish Dev Packages

--- a/.github/workflows/diagnostics-image-build.yaml
+++ b/.github/workflows/diagnostics-image-build.yaml
@@ -3,7 +3,9 @@ name: Diagnostics Image Build
 on:
   push:
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-docker-image:

--- a/.github/workflows/diagnostics-image-release.yaml
+++ b/.github/workflows/diagnostics-image-release.yaml
@@ -8,7 +8,9 @@ on:
     tags:
       - '@powersync/diagnostics-app*'
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   release-docker-image:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,9 @@ on:
     branches:
       - main
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   release:

--- a/.github/workflows/test-isolated.yaml
+++ b/.github/workflows/test-isolated.yaml
@@ -4,6 +4,8 @@ name: Test Isolated Demos
 on:
   push:
 
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   test:
     name: Test Isolated Demos

--- a/.github/workflows/test-isolated.yaml
+++ b/.github/workflows/test-isolated.yaml
@@ -4,7 +4,9 @@ name: Test Isolated Demos
 on:
   push:
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ name: Test Packages
 on:
   push:
 
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   test:
     name: Test Packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,9 @@ name: Test Packages
 on:
   push:
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
## Description
Add concurrency to actions to avoid duplicate actions running after new commit. 

More info here https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-using-concurrency-to-cancel-any-in-progress-job-or-run