### PR TITLE
fix: OP-sqlite write transaction single operation notification

### DIFF
--- a/.changeset/metal-fans-argue.md
+++ b/.changeset/metal-fans-argue.md
@@ -2,4 +2,5 @@
 '@powersync/op-sqlite': minor
 ---
 
-Fixed single write transanaction operations in `ps_crud` not being processed. Batching update notifications per write lock.
+Fixed single write transaction operations in `ps_crud` not being processed. Batching update notifications per write lock.
+This will also affect/fix downstream features such as watched queries and reactive query hooks.

--- a/.changeset/metal-fans-argue.md
+++ b/.changeset/metal-fans-argue.md
@@ -1,0 +1,5 @@
+---
+'@powersync/op-sqlite': minor
+---
+
+Fixed single write transanaction operations in `ps_crud` not being processed. Batching update notifications per write lock.

--- a/.changeset/metal-fans-argue.md
+++ b/.changeset/metal-fans-argue.md
@@ -3,4 +3,4 @@
 ---
 
 Fixed single write transaction operations in `ps_crud` not being processed. Batching update notifications per write lock.
-This will also affect/fix downstream features such as watched queries and reactive query hooks.
+This will also fix downstream features such as watched queries and reactive query hooks in cases where the query is fired before the data was committed, and batching will improve performance specifically in cases where a lot of data changes occur. 


### PR DESCRIPTION
This PR addresses a timing issue in OPsqlite where the SQLite update hook triggers before the commit completes when performing single-write transactions (Resulting in `ps_crud` not being processed). As a result, `nextCrudItem` was returning undefined because the data was not yet committed at the time the hook fired. 

Using `react-native-quick-sqlite` as reference, updates are now batched and only flushed after a write lock is released.