### PR TITLE
chore: Navigate to login page when accessing pages that require auth

### DIFF
--- a/demos/react-supabase-todolist/src/app/router.tsx
+++ b/demos/react-supabase-todolist/src/app/router.tsx
@@ -31,7 +31,6 @@ const AuthGuard = ({ children }: AuthGuardProps) => {
 
     connector.client.auth.onAuthStateChange(async (event, _session) => {
       if (event === 'SIGNED_OUT') {
-        console.log("here");
         navigate(LOGIN_ROUTE);
       }
     });

--- a/demos/react-supabase-todolist/src/app/router.tsx
+++ b/demos/react-supabase-todolist/src/app/router.tsx
@@ -28,6 +28,14 @@ const AuthGuard = ({ children }: AuthGuardProps) => {
       console.error(`No Supabase connector has been created yet.`);
       return;
     }
+
+    connector.client.auth.onAuthStateChange(async (event, _session) => {
+      if (event === 'SIGNED_OUT') {
+        console.log("here");
+        navigate(LOGIN_ROUTE);
+      }
+    });
+
     const loginGuard = () => {
       if (!connector.currentSession) {
         navigate(LOGIN_ROUTE);


### PR DESCRIPTION
This PR adds an auth guard that navigates the app to the login page if you navigate to a page that requires auth, or when the session expires.

Will apply this pattern to the other demos when this is accepted.