### PR TITLE
fix: Drizzle transactions not using lock context for React-Native

### DIFF
--- a/.changeset/lovely-ligers-sleep.md
+++ b/.changeset/lovely-ligers-sleep.md
@@ -1,0 +1,5 @@
+---
+'@powersync/drizzle-driver': patch
+---
+
+Fixed Drizzle transactions breaking for react-native projects, correctly using lock context for transactions.

--- a/packages/drizzle-driver/src/index.ts
+++ b/packages/drizzle-driver/src/index.ts
@@ -1,4 +1,8 @@
-import { wrapPowerSyncWithDrizzle, type DrizzleQuery, type PowerSyncSQLiteDatabase } from './sqlite/db';
+import {
+  wrapPowerSyncWithDrizzle,
+  type DrizzleQuery,
+  type PowerSyncSQLiteDatabase
+} from './sqlite/PowerSyncSQLiteDatabase';
 import { toCompilableQuery } from './utils/compilableQuery';
 import {
   DrizzleAppSchema,

--- a/packages/drizzle-driver/src/sqlite/PowerSyncSQLiteBaseSession.ts
+++ b/packages/drizzle-driver/src/sqlite/PowerSyncSQLiteBaseSession.ts
@@ -39,7 +39,7 @@ export class PowerSyncSQLiteBaseSession<
   protected logger: Logger;
 
   constructor(
-    private db: LockContext,
+    protected db: LockContext,
     protected dialect: SQLiteAsyncDialect,
     protected schema: RelationalSchemaConfig<TSchema> | undefined,
     protected options: PowerSyncSQLiteSessionOptions = {}
@@ -66,7 +66,7 @@ export class PowerSyncSQLiteBaseSession<
     );
   }
 
-  override transaction<T>(
+  transaction<T>(
     _transaction: (tx: PowerSyncSQLiteTransaction<TFullSchema, TSchema>) => T,
     _config: PowerSyncSQLiteTransactionConfig = {}
   ): T {

--- a/packages/drizzle-driver/src/sqlite/PowerSyncSQLiteBaseSession.ts
+++ b/packages/drizzle-driver/src/sqlite/PowerSyncSQLiteBaseSession.ts
@@ -1,9 +1,9 @@
-import { AbstractPowerSyncDatabase, QueryResult } from '@powersync/common';
+import { LockContext, QueryResult } from '@powersync/common';
 import { entityKind } from 'drizzle-orm/entity';
 import type { Logger } from 'drizzle-orm/logger';
 import { NoopLogger } from 'drizzle-orm/logger';
 import type { RelationalSchemaConfig, TablesRelationalConfig } from 'drizzle-orm/relations';
-import { type Query, sql } from 'drizzle-orm/sql/sql';
+import { type Query } from 'drizzle-orm/sql/sql';
 import type { SQLiteAsyncDialect } from 'drizzle-orm/sqlite-core/dialect';
 import type { SelectedFieldsOrdered } from 'drizzle-orm/sqlite-core/query-builders/select.types';
 import {
@@ -13,7 +13,7 @@ import {
   SQLiteTransaction,
   type SQLiteTransactionConfig
 } from 'drizzle-orm/sqlite-core/session';
-import { PowerSyncSQLitePreparedQuery } from './sqlite-query';
+import { PowerSyncSQLitePreparedQuery } from './PowerSyncSQLitePreparedQuery';
 
 export interface PowerSyncSQLiteSessionOptions {
   logger?: Logger;
@@ -30,19 +30,19 @@ export class PowerSyncSQLiteTransaction<
   static readonly [entityKind]: string = 'PowerSyncSQLiteTransaction';
 }
 
-export class PowerSyncSQLiteSession<
+export class PowerSyncSQLiteBaseSession<
   TFullSchema extends Record<string, unknown>,
   TSchema extends TablesRelationalConfig
 > extends SQLiteSession<'async', QueryResult, TFullSchema, TSchema> {
-  static readonly [entityKind]: string = 'PowerSyncSQLiteSession';
+  static readonly [entityKind]: string = 'PowerSyncSQLiteBaseSession';
 
-  private logger: Logger;
+  protected logger: Logger;
 
   constructor(
-    private db: AbstractPowerSyncDatabase,
-    dialect: SQLiteAsyncDialect,
-    private schema: RelationalSchemaConfig<TSchema> | undefined,
-    options: PowerSyncSQLiteSessionOptions = {}
+    private db: LockContext,
+    protected dialect: SQLiteAsyncDialect,
+    protected schema: RelationalSchemaConfig<TSchema> | undefined,
+    protected options: PowerSyncSQLiteSessionOptions = {}
   ) {
     super(dialect);
     this.logger = options.logger ?? new NoopLogger();
@@ -67,32 +67,9 @@ export class PowerSyncSQLiteSession<
   }
 
   override transaction<T>(
-    transaction: (tx: PowerSyncSQLiteTransaction<TFullSchema, TSchema>) => T,
-    config: PowerSyncSQLiteTransactionConfig = {}
+    _transaction: (tx: PowerSyncSQLiteTransaction<TFullSchema, TSchema>) => T,
+    _config: PowerSyncSQLiteTransactionConfig = {}
   ): T {
-    const { accessMode = 'read write' } = config;
-
-    if (accessMode === 'read only') {
-      return this.db.readLock(async () => this.internalTransaction(transaction, config)) as T;
-    }
-
-    return this.db.writeLock(async () => this.internalTransaction(transaction, config)) as T;
-  }
-
-  async internalTransaction<T>(
-    transaction: (tx: PowerSyncSQLiteTransaction<TFullSchema, TSchema>) => T,
-    config: PowerSyncSQLiteTransactionConfig = {}
-  ): Promise<T> {
-    const tx = new PowerSyncSQLiteTransaction('async', (this as any).dialect, this, this.schema);
-
-    await this.run(sql.raw(`begin${config?.behavior ? ' ' + config.behavior : ''}`));
-    try {
-      const result = await transaction(tx);
-      await this.run(sql`commit`);
-      return result;
-    } catch (err) {
-      await this.run(sql`rollback`);
-      throw err;
-    }
+    throw new Error('Nested transactions are not supported');
   }
 }

--- a/packages/drizzle-driver/src/sqlite/PowerSyncSQLiteDatabase.ts
+++ b/packages/drizzle-driver/src/sqlite/PowerSyncSQLiteDatabase.ts
@@ -56,7 +56,7 @@ export class PowerSyncSQLiteDatabase<
     this.db = db;
   }
 
-  override transaction<T>(
+  transaction<T>(
     transaction: (
       tx: SQLiteTransaction<'async', QueryResult, TSchema, ExtractTablesWithRelations<TSchema>>
     ) => Promise<T>,

--- a/packages/drizzle-driver/src/sqlite/PowerSyncSQLiteDatabase.ts
+++ b/packages/drizzle-driver/src/sqlite/PowerSyncSQLiteDatabase.ts
@@ -19,7 +19,8 @@ import { BaseSQLiteDatabase } from 'drizzle-orm/sqlite-core/db';
 import { SQLiteAsyncDialect } from 'drizzle-orm/sqlite-core/dialect';
 import type { DrizzleConfig } from 'drizzle-orm/utils';
 import { toCompilableQuery } from './../utils/compilableQuery';
-import { PowerSyncSQLiteSession, PowerSyncSQLiteTransactionConfig } from './sqlite-session';
+import { PowerSyncSQLiteSession } from './PowerSyncSQLiteSession';
+import { PowerSyncSQLiteTransactionConfig } from './PowerSyncSQLiteBaseSession';
 
 export type DrizzleQuery<T> = { toSQL(): Query; execute(): Promise<T | T[]> };
 

--- a/packages/drizzle-driver/src/sqlite/PowerSyncSQLitePreparedQuery.ts
+++ b/packages/drizzle-driver/src/sqlite/PowerSyncSQLitePreparedQuery.ts
@@ -1,4 +1,4 @@
-import { AbstractPowerSyncDatabase, QueryResult } from '@powersync/common';
+import { LockContext, QueryResult } from '@powersync/common';
 import { Column, DriverValueDecoder, getTableName, SQL } from 'drizzle-orm';
 import { entityKind, is } from 'drizzle-orm/entity';
 import type { Logger } from 'drizzle-orm/logger';
@@ -26,7 +26,7 @@ export class PowerSyncSQLitePreparedQuery<
   static readonly [entityKind]: string = 'PowerSyncSQLitePreparedQuery';
 
   constructor(
-    private db: AbstractPowerSyncDatabase,
+    private db: LockContext,
     query: Query,
     private logger: Logger,
     private fields: SelectedFieldsOrdered | undefined,

--- a/packages/drizzle-driver/src/sqlite/PowerSyncSQLiteSession.ts
+++ b/packages/drizzle-driver/src/sqlite/PowerSyncSQLiteSession.ts
@@ -32,25 +32,7 @@ export class PowerSyncSQLiteSession<
     this.client = db;
   }
 
-  prepareQuery<T extends PreparedQueryConfigBase & { type: 'async' }>(
-    query: Query,
-    fields: SelectedFieldsOrdered | undefined,
-    executeMethod: SQLiteExecuteMethod,
-    isResponseInArrayMode: boolean,
-    customResultMapper?: (rows: unknown[][], mapColumnValue?: (value: unknown) => unknown) => unknown
-  ): PowerSyncSQLitePreparedQuery<T> {
-    return new PowerSyncSQLitePreparedQuery(
-      this.client,
-      query,
-      this.logger,
-      fields,
-      executeMethod,
-      isResponseInArrayMode,
-      customResultMapper
-    );
-  }
-
-  override transaction<T>(
+  transaction<T>(
     transaction: (tx: PowerSyncSQLiteTransaction<TFullSchema, TSchema>) => T,
     config: PowerSyncSQLiteTransactionConfig = {}
   ): T {

--- a/packages/drizzle-driver/src/sqlite/PowerSyncSQLiteSession.ts
+++ b/packages/drizzle-driver/src/sqlite/PowerSyncSQLiteSession.ts
@@ -1,0 +1,88 @@
+import { AbstractPowerSyncDatabase, DBAdapter } from '@powersync/common';
+import { entityKind } from 'drizzle-orm/entity';
+import type { RelationalSchemaConfig, TablesRelationalConfig } from 'drizzle-orm/relations';
+import { type Query } from 'drizzle-orm/sql/sql';
+import type { SQLiteAsyncDialect } from 'drizzle-orm/sqlite-core/dialect';
+import type { SelectedFieldsOrdered } from 'drizzle-orm/sqlite-core/query-builders/select.types';
+import {
+  type PreparedQueryConfig as PreparedQueryConfigBase,
+  type SQLiteExecuteMethod
+} from 'drizzle-orm/sqlite-core/session';
+import { PowerSyncSQLitePreparedQuery } from './PowerSyncSQLitePreparedQuery';
+import {
+  PowerSyncSQLiteSessionOptions,
+  PowerSyncSQLiteTransaction,
+  PowerSyncSQLiteTransactionConfig,
+  PowerSyncSQLiteBaseSession
+} from './PowerSyncSQLiteBaseSession';
+
+export class PowerSyncSQLiteSession<
+  TFullSchema extends Record<string, unknown>,
+  TSchema extends TablesRelationalConfig
+> extends PowerSyncSQLiteBaseSession<TFullSchema, TSchema> {
+  static readonly [entityKind]: string = 'PowerSyncSQLiteSession';
+  protected client: AbstractPowerSyncDatabase;
+  constructor(
+    db: AbstractPowerSyncDatabase,
+    dialect: SQLiteAsyncDialect,
+    schema: RelationalSchemaConfig<TSchema> | undefined,
+    options: PowerSyncSQLiteSessionOptions = {}
+  ) {
+    super(db, dialect, schema, options);
+    this.client = db;
+  }
+
+  prepareQuery<T extends PreparedQueryConfigBase & { type: 'async' }>(
+    query: Query,
+    fields: SelectedFieldsOrdered | undefined,
+    executeMethod: SQLiteExecuteMethod,
+    isResponseInArrayMode: boolean,
+    customResultMapper?: (rows: unknown[][], mapColumnValue?: (value: unknown) => unknown) => unknown
+  ): PowerSyncSQLitePreparedQuery<T> {
+    return new PowerSyncSQLitePreparedQuery(
+      this.client,
+      query,
+      this.logger,
+      fields,
+      executeMethod,
+      isResponseInArrayMode,
+      customResultMapper
+    );
+  }
+
+  override transaction<T>(
+    transaction: (tx: PowerSyncSQLiteTransaction<TFullSchema, TSchema>) => T,
+    config: PowerSyncSQLiteTransactionConfig = {}
+  ): T {
+    const { accessMode = 'read write' } = config;
+
+    if (accessMode === 'read only') {
+      return this.client.readLock(async (ctx) => this.internalTransaction(ctx, transaction, config)) as T;
+    }
+
+    return this.client.writeLock(async (ctx) => this.internalTransaction(ctx, transaction, config)) as T;
+  }
+
+  protected async internalTransaction<T>(
+    connection: DBAdapter,
+    fn: (tx: PowerSyncSQLiteTransaction<TFullSchema, TSchema>) => T,
+    config: PowerSyncSQLiteTransactionConfig = {}
+  ): Promise<T> {
+    const tx = new PowerSyncSQLiteTransaction<TFullSchema, TSchema>(
+      'async',
+      (this as any).dialect,
+      new PowerSyncSQLiteBaseSession(connection, this.dialect, this.schema, this.options),
+      this.schema
+    );
+
+    await connection.execute(`begin${config?.behavior ? ' ' + config.behavior : ''}`);
+    try {
+      const result = await fn(tx);
+      await connection.execute(`commit`);
+      return result;
+    } catch (err) {
+      await connection.execute(`rollback`);
+      throw err;
+    }
+  }
+}

--- a/packages/drizzle-driver/tests/setup/db.ts
+++ b/packages/drizzle-driver/tests/setup/db.ts
@@ -1,6 +1,6 @@
-import { Schema, PowerSyncDatabase, column, Table, AbstractPowerSyncDatabase } from '@powersync/web';
+import { AbstractPowerSyncDatabase, column, PowerSyncDatabase, Schema, Table } from '@powersync/web';
 import { sqliteTable, text } from 'drizzle-orm/sqlite-core';
-import { wrapPowerSyncWithDrizzle, PowerSyncSQLiteDatabase } from '../../src/sqlite/db';
+import { wrapPowerSyncWithDrizzle } from '../../src/sqlite/PowerSyncSQLiteDatabase';
 
 const users = new Table({
   name: column.text

--- a/packages/drizzle-driver/tests/sqlite/db.test.ts
+++ b/packages/drizzle-driver/tests/sqlite/db.test.ts
@@ -1,7 +1,7 @@
 import { AbstractPowerSyncDatabase } from '@powersync/common';
 import { eq, sql } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import * as SUT from '../../src/sqlite/db';
+import * as SUT from '../../src/sqlite/PowerSyncSQLiteDatabase';
 import { DrizzleSchema, drizzleUsers, getDrizzleDb, getPowerSyncDb } from '../setup/db';
 
 describe('Database operations', () => {

--- a/packages/drizzle-driver/tests/sqlite/query.test.ts
+++ b/packages/drizzle-driver/tests/sqlite/query.test.ts
@@ -1,7 +1,7 @@
 import { AbstractPowerSyncDatabase } from '@powersync/web';
 import { Query } from 'drizzle-orm/sql/sql';
-import { PowerSyncSQLiteDatabase } from '../../src/sqlite/db';
-import { PowerSyncSQLitePreparedQuery } from '../../src/sqlite/sqlite-query';
+import { PowerSyncSQLiteDatabase } from '../../src/sqlite/PowerSyncSQLiteDatabase';
+import { PowerSyncSQLitePreparedQuery } from '../../src/sqlite/PowerSyncSQLitePreparedQuery';
 import { DrizzleSchema, drizzleUsers, getDrizzleDb, getPowerSyncDb } from '../setup/db';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 

--- a/packages/drizzle-driver/tests/sqlite/watch.test.ts
+++ b/packages/drizzle-driver/tests/sqlite/watch.test.ts
@@ -3,7 +3,7 @@ import { PowerSyncDatabase } from '@powersync/web';
 import { count, eq, relations, sql } from 'drizzle-orm';
 import { integer, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import * as SUT from '../../src/sqlite/db';
+import * as SUT from '../../src/sqlite/PowerSyncSQLiteDatabase';
 
 vi.useRealTimers();
 


### PR DESCRIPTION
## Description
As part of https://github.com/powersync-ja/powersync-js/pull/463 locks were fixed for `React-Native`, which resulted in Drizzle transactions on RN projects to never be executed. This was due to the original Drizzle transaction implementation not using the correct lock context. I could confirm that this issue was happening for both `RNQS` and `OPSqlite`, but not for web.

## Fix
`PowerSyncSQLiteSession` has been broken into `PowerSyncSQLiteSession` and `PowerSyncSQLiteBaseSession`, which ensures that a transaction uses the constrained LockContext instead of the db context (allowing transactions to be executed in the lock context).

This also makes room to eventually implement nested transactions/save points in `PowerSyncSqliteBaseSession`.

## Test
To verify this works across the board, I tested the fix for `RNQS`, `OPSqlite`, and Web.

------------

The source files have also been renamed to better match class names.