### PR TITLE
feat: Drizzle - added support for custom column types in schema conversion

### DIFF
--- a/.changeset/lemon-moles-lie.md
+++ b/.changeset/lemon-moles-lie.md
@@ -1,0 +1,5 @@
+---
+'@powersync/drizzle-driver': patch
+---
+
+Added support for custom column types in schema definition.

--- a/packages/drizzle-driver/src/utils/schema.ts
+++ b/packages/drizzle-driver/src/utils/schema.ts
@@ -78,7 +78,7 @@ function mapDrizzleColumnToType(drizzleColumn: SQLiteColumn<any, object>): BaseC
     case SQLiteReal[entityKind]:
       return column.real;
     case SQLiteCustomColumn[entityKind]:
-      const sqlName = (drizzleColumn as any).sqlName; // Not exposed in the public API
+      const sqlName = (drizzleColumn as SQLiteCustomColumn<any>).getSQLType();
       switch (sqlName) {
         case 'text':
           return column.text;

--- a/packages/drizzle-driver/tests/sqlite/schema.test.ts
+++ b/packages/drizzle-driver/tests/sqlite/schema.test.ts
@@ -1,5 +1,5 @@
 import { column, Schema, Table } from '@powersync/common';
-import { index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { customType, index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 import { describe, expect, it } from 'vitest';
 import { DrizzleAppSchema, DrizzleTableWithPowerSyncOptions, toPowerSyncTable } from '../../src/utils/schema';
 import { CasingCache } from 'drizzle-orm/casing';
@@ -102,6 +102,61 @@ describe('toPowerSyncTable', () => {
       },
       { indexes: { names: ['my_name', 'yourName'] } }
     );
+
+    expect(convertedList).toEqual(expectedLists);
+  });
+
+  it('custom column conversion', () => {
+    const customSqliteText = customType<{ data: string; driverData: string }>({
+      dataType() {
+        return 'text';
+      },
+      fromDriver(value) {
+        return value;
+      },
+      toDriver(value) {
+        return value;
+      }
+    });
+
+    const customSqliteInteger = customType<{ data: number; driverData: number }>({
+      dataType() {
+        return 'integer';
+      },
+      fromDriver(value) {
+        return Number(value);
+      },
+      toDriver(value) {
+        return value;
+      }
+    });
+
+    const customSqliteReal = customType<{ data: number; driverData: number }>({
+      dataType() {
+        return 'real';
+      },
+      fromDriver(value) {
+        return Number(value);
+      },
+      toDriver(value) {
+        return value;
+      }
+    });
+
+    const lists = sqliteTable('lists', {
+      id: text('id').primaryKey(),
+      text_col: customSqliteText('text_col'),
+      int_col: customSqliteInteger('int_col'),
+      real_col: customSqliteReal('real_col')
+    });
+
+    const convertedList = toPowerSyncTable(lists);
+
+    const expectedLists = new Table({
+      text_col: column.text,
+      int_col: column.integer,
+      real_col: column.real
+    });
 
     expect(convertedList).toEqual(expectedLists);
   });


### PR DESCRIPTION
Adds support for custom types in the Drizzle/PowerSync schema definition - specifically with translating a Drizzle schema to PowerSync's app schema.

Bulk of the code was provided in this issue https://github.com/powersync-ja/powersync-js/issues/471.