### PR TITLE
feat: add throttle and delay to connect

### DIFF
--- a/.changeset/slow-crews-watch.md
+++ b/.changeset/slow-crews-watch.md
@@ -1,0 +1,6 @@
+---
+'@powersync/react-native': minor
+'@powersync/common': minor
+---
+
+Add `retryDelayMs` and `crudUploadThrottleMs` to `connect` so that the values can be dynamically changed upon reconnecting.

--- a/packages/common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/common/src/client/AbstractPowerSyncDatabase.ts
@@ -39,6 +39,10 @@ export interface DisconnectAndClearOptions {
 export interface BasePowerSyncDatabaseOptions extends AdditionalConnectionOptions {
   /** Schema used for the local database. */
   schema: Schema;
+  /**
+   * @deprecated Use {@link retryDelayMs} instead as this will be removed in future releases.
+   */
+  retryDelay?: number;
   logger?: ILogger;
 }
 

--- a/packages/common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/common/src/client/AbstractPowerSyncDatabase.ts
@@ -394,7 +394,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
 
     this.syncStreamImplementation = this.generateSyncStreamImplementation(connector, {
       crudUploadThrottleMs: options?.crudUploadThrottleMs,
-      retryDelay: options?.retryDelayMs
+      retryDelayMs: options?.retryDelayMs
     });
     this.syncStatusListenerDisposer = this.syncStreamImplementation.registerListener({
       statusChanged: (status) => {

--- a/packages/common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/common/src/client/AbstractPowerSyncDatabase.ts
@@ -243,7 +243,11 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
   protected abstract openDBAdapter(options: PowerSyncDatabaseOptionsWithSettings): DBAdapter;
 
   protected abstract generateSyncStreamImplementation(
-    connector: PowerSyncBackendConnector
+    connector: PowerSyncBackendConnector,
+    options?: {
+      retryDelayMs?: number;
+      crudUploadThrottleMs?: number;
+    }
   ): StreamingSyncImplementation;
 
   protected abstract generateBucketStorageAdapter(): BucketStorageAdapter;
@@ -388,7 +392,10 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
       throw new Error('Cannot connect using a closed client');
     }
 
-    this.syncStreamImplementation = this.generateSyncStreamImplementation(connector);
+    this.syncStreamImplementation = this.generateSyncStreamImplementation(connector, {
+      crudUploadThrottleMs: options?.crudUploadThrottleMs,
+      retryDelay: options?.retryDelayMs
+    });
     this.syncStatusListenerDisposer = this.syncStreamImplementation.registerListener({
       statusChanged: (status) => {
         this.currentStatus = new SyncStatus({

--- a/packages/common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/common/src/client/AbstractPowerSyncDatabase.ts
@@ -24,7 +24,7 @@ import { CrudEntry, CrudEntryJSON } from './sync/bucket/CrudEntry.js';
 import { CrudTransaction } from './sync/bucket/CrudTransaction.js';
 import {
   DEFAULT_CRUD_UPLOAD_THROTTLE_MS,
-  type PowerSyncConnectionOptionalOptions,
+  type AdditionalConnectionOptions,
   type PowerSyncConnectionOptions,
   StreamingSyncImplementation,
   StreamingSyncImplementationListener
@@ -36,7 +36,7 @@ export interface DisconnectAndClearOptions {
   clearLocal?: boolean;
 }
 
-export interface BasePowerSyncDatabaseOptions extends PowerSyncConnectionOptionalOptions {
+export interface BasePowerSyncDatabaseOptions extends AdditionalConnectionOptions {
   /** Schema used for the local database. */
   schema: Schema;
   logger?: ILogger;
@@ -233,7 +233,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
 
   protected abstract generateSyncStreamImplementation(
     connector: PowerSyncBackendConnector,
-    options?: PowerSyncConnectionOptionalOptions
+    options?: AdditionalConnectionOptions
   ): StreamingSyncImplementation;
 
   protected abstract generateBucketStorageAdapter(): BucketStorageAdapter;

--- a/packages/common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/common/src/client/AbstractPowerSyncDatabase.ts
@@ -24,7 +24,8 @@ import { CrudEntry, CrudEntryJSON } from './sync/bucket/CrudEntry.js';
 import { CrudTransaction } from './sync/bucket/CrudTransaction.js';
 import {
   DEFAULT_CRUD_UPLOAD_THROTTLE_MS,
-  PowerSyncConnectionOptions,
+  type PowerSyncConnectionOptionalOptions,
+  type PowerSyncConnectionOptions,
   StreamingSyncImplementation,
   StreamingSyncImplementationListener
 } from './sync/stream/AbstractStreamingSyncImplementation.js';
@@ -35,21 +36,9 @@ export interface DisconnectAndClearOptions {
   clearLocal?: boolean;
 }
 
-export interface BasePowerSyncDatabaseOptions {
+export interface BasePowerSyncDatabaseOptions extends PowerSyncConnectionOptionalOptions {
   /** Schema used for the local database. */
   schema: Schema;
-
-  /**
-   * Delay for retrying sync streaming operations
-   * from the PowerSync backend after an error occurs.
-   */
-  retryDelay?: number;
-  /**
-   * Backend Connector CRUD operations are throttled
-   * to occur at most every `crudUploadThrottleMs`
-   * milliseconds.
-   */
-  crudUploadThrottleMs?: number;
   logger?: ILogger;
 }
 
@@ -129,7 +118,7 @@ export const DEFAULT_POWERSYNC_CLOSE_OPTIONS: PowerSyncCloseOptions = {
 export const DEFAULT_WATCH_THROTTLE_MS = 30;
 
 export const DEFAULT_POWERSYNC_DB_OPTIONS = {
-  retryDelay: 5000,
+  retryDelayMs: 5000,
   logger: Logger.get('PowerSyncDatabase'),
   crudUploadThrottleMs: DEFAULT_CRUD_UPLOAD_THROTTLE_MS
 };
@@ -244,10 +233,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
 
   protected abstract generateSyncStreamImplementation(
     connector: PowerSyncBackendConnector,
-    options?: {
-      retryDelayMs?: number;
-      crudUploadThrottleMs?: number;
-    }
+    options?: PowerSyncConnectionOptionalOptions
   ): StreamingSyncImplementation;
 
   protected abstract generateBucketStorageAdapter(): BucketStorageAdapter;

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -65,10 +65,10 @@ export interface StreamingSyncImplementationListener extends BaseListener {
  * Configurable options to be used when connecting to the PowerSync
  * backend instance.
  */
-export interface PowerSyncConnectionOptions extends DefaultConnectionOptions, AdditionalConnectionOptions {}
+export interface PowerSyncConnectionOptions extends BaseConnectionOptions, AdditionalConnectionOptions {}
 
  /** @internal */
-export interface DefaultConnectionOptions {
+export interface BaseConnectionOptions {
   /**
    * The connection method to use when streaming updates from
    * the PowerSync backend instance.
@@ -96,6 +96,10 @@ export interface AdditionalConnectionOptions {
    */
   crudUploadThrottleMs?: number;
 }
+
+
+/** @internal */
+export type RequiredAdditionalConnectionOptions = Required<AdditionalConnectionOptions>
 
 export interface StreamingSyncImplementation extends BaseObserver<StreamingSyncImplementationListener>, Disposable {
   /**
@@ -126,7 +130,7 @@ export const DEFAULT_STREAMING_SYNC_OPTIONS = {
   crudUploadThrottleMs: DEFAULT_CRUD_UPLOAD_THROTTLE_MS
 };
 
-export type RequiredPowerSyncConnectionOptions = Required<DefaultConnectionOptions>;
+export type RequiredPowerSyncConnectionOptions = Required<BaseConnectionOptions>;
 
 export const DEFAULT_STREAM_CONNECTION_OPTIONS: RequiredPowerSyncConnectionOptions = {
   connectionMethod: SyncStreamConnectionMethod.WEB_SOCKET,

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -91,6 +91,7 @@ export interface PowerSyncConnectionOptions {
    */
   crudUploadThrottleMs?: number;
 }
+export type PowerSyncConnectionRequiredOptions = Required<Omit<PowerSyncConnectionOptions, 'retryDelayMs' | 'crudUploadThrottleMs'>>;
 
 export interface StreamingSyncImplementation extends BaseObserver<StreamingSyncImplementationListener>, Disposable {
   /**
@@ -439,7 +440,7 @@ The next upload iteration will be delayed.`);
       type: LockType.SYNC,
       signal,
       callback: async () => {
-        const resolvedOptions: Required<Omit<PowerSyncConnectionOptions, 'retryDelayMs' |  'crudUploadThrottleMs'>> = {
+        const resolvedOptions: Required<PowerSyncConnectionRequiredOptions> = {
           ...DEFAULT_STREAM_CONNECTION_OPTIONS,
           ...(options ?? {})
         };

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -75,12 +75,12 @@ export interface PowerSyncConnectionRequiredOptions {
    * the PowerSync backend instance.
    * Defaults to a HTTP streaming connection.
    */
-  connectionMethod?: SyncStreamConnectionMethod;
+  connectionMethod: SyncStreamConnectionMethod;
 
   /**
    * These parameters are passed to the sync rules, and will be available under the`user_parameters` object.
    */
-  params?: Record<string, StreamingSyncRequestParameterType>;
+  params: Record<string, StreamingSyncRequestParameterType>;
 }
 
 export interface PowerSyncConnectionOptionalOptions {
@@ -126,7 +126,7 @@ export const DEFAULT_STREAMING_SYNC_OPTIONS = {
   crudUploadThrottleMs: DEFAULT_CRUD_UPLOAD_THROTTLE_MS
 };
 
-export const DEFAULT_STREAM_CONNECTION_OPTIONS: Required<Omit<PowerSyncConnectionOptions, 'retryDelayMs' |  'crudUploadThrottleMs'>> = {
+export const DEFAULT_STREAM_CONNECTION_OPTIONS: PowerSyncConnectionRequiredOptions = {
   connectionMethod: SyncStreamConnectionMethod.WEB_SOCKET,
   params: {}
 };
@@ -444,7 +444,7 @@ The next upload iteration will be delayed.`);
       type: LockType.SYNC,
       signal,
       callback: async () => {
-        const resolvedOptions: Required<PowerSyncConnectionRequiredOptions> = {
+        const resolvedOptions: PowerSyncConnectionRequiredOptions = {
           ...DEFAULT_STREAM_CONNECTION_OPTIONS,
           ...(options ?? {})
         };

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -67,7 +67,9 @@ export interface StreamingSyncImplementationListener extends BaseListener {
  * Configurable options to be used when connecting to the PowerSync
  * backend instance.
  */
-export interface PowerSyncConnectionOptions {
+export interface PowerSyncConnectionOptions extends PowerSyncConnectionOptionalOptions, PowerSyncConnectionRequiredOptions {}
+
+export interface PowerSyncConnectionRequiredOptions {
   /**
    * The connection method to use when streaming updates from
    * the PowerSync backend instance.
@@ -79,19 +81,21 @@ export interface PowerSyncConnectionOptions {
    * These parameters are passed to the sync rules, and will be available under the`user_parameters` object.
    */
   params?: Record<string, StreamingSyncRequestParameterType>;
-  /**
+}
+
+export interface PowerSyncConnectionOptionalOptions {
+    /**
    * Delay for retrying sync streaming operations
    * from the PowerSync backend after an error occurs.
    */
-  retryDelayMs?: number;
-  /**
-   * Backend Connector CRUD operations are throttled
-   * to occur at most every `crudUploadThrottleMs`
-   * milliseconds.
-   */
-  crudUploadThrottleMs?: number;
+    retryDelayMs?: number;
+    /**
+     * Backend Connector CRUD operations are throttled
+     * to occur at most every `crudUploadThrottleMs`
+     * milliseconds.
+     */
+    crudUploadThrottleMs?: number;
 }
-export type PowerSyncConnectionRequiredOptions = Required<Omit<PowerSyncConnectionOptions, 'retryDelayMs' | 'crudUploadThrottleMs'>>;
 
 export interface StreamingSyncImplementation extends BaseObserver<StreamingSyncImplementationListener>, Disposable {
   /**

--- a/packages/react-native/src/db/PowerSyncDatabase.ts
+++ b/packages/react-native/src/db/PowerSyncDatabase.ts
@@ -44,7 +44,6 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
 
   protected generateSyncStreamImplementation(
     connector: PowerSyncBackendConnector,
-    // This is used to pass in options on connection instead of only during database creation
     options: Required<AdditionalConnectionOptions>
   ): AbstractStreamingSyncImplementation {
     const remote = new ReactNativeRemote(connector);

--- a/packages/react-native/src/db/PowerSyncDatabase.ts
+++ b/packages/react-native/src/db/PowerSyncDatabase.ts
@@ -1,11 +1,11 @@
 import {
   AbstractPowerSyncDatabase,
   AbstractStreamingSyncImplementation,
-  AdditionalConnectionOptions,
   BucketStorageAdapter,
   DBAdapter,
   PowerSyncBackendConnector,
   PowerSyncDatabaseOptionsWithSettings,
+  type RequiredAdditionalConnectionOptions,
   SqliteBucketStorage
 } from '@powersync/common';
 import { ReactNativeRemote } from '../sync/stream/ReactNativeRemote';
@@ -44,7 +44,7 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
 
   protected generateSyncStreamImplementation(
     connector: PowerSyncBackendConnector,
-    options: Required<AdditionalConnectionOptions>
+    options: RequiredAdditionalConnectionOptions
   ): AbstractStreamingSyncImplementation {
     const remote = new ReactNativeRemote(connector);
 

--- a/packages/react-native/src/db/PowerSyncDatabase.ts
+++ b/packages/react-native/src/db/PowerSyncDatabase.ts
@@ -43,13 +43,16 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
 
   protected generateSyncStreamImplementation(
     connector: PowerSyncBackendConnector,
-    // This is used to pass in options on connection instead of only during db creation
+    // This is used to pass in options on connection instead of only during database creation
     options?: {
       retryDelayMs: number;
       crudUploadThrottleMs: number;
     }
   ): AbstractStreamingSyncImplementation {
     const remote = new ReactNativeRemote(connector);
+    // Use the options passed in during connect, or fallback to the options set during database creation
+    const retryDelayMs = options?.retryDelayMs || this.options.retryDelay;
+    const crudUploadThrottleMs = options?.crudUploadThrottleMs || this.options.crudUploadThrottleMs;
 
     return new ReactNativeStreamingSyncImplementation({
       adapter: this.bucketStorageAdapter,
@@ -58,8 +61,8 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
         await this.waitForReady();
         await connector.uploadData(this);
       },
-      retryDelayMs: options?.retryDelayMs || this.options.retryDelay,
-      crudUploadThrottleMs: options?.crudUploadThrottleMs || this.options.crudUploadThrottleMs,
+      retryDelayMs,
+      crudUploadThrottleMs,
       identifier: this.database.name
     });
   }

--- a/packages/react-native/src/db/PowerSyncDatabase.ts
+++ b/packages/react-native/src/db/PowerSyncDatabase.ts
@@ -51,8 +51,8 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
   ): AbstractStreamingSyncImplementation {
     const remote = new ReactNativeRemote(connector);
     // Use the options passed in during connect, or fallback to the options set during database creation
-    const retryDelayMs = options?.retryDelayMs || this.options.retryDelay;
-    const crudUploadThrottleMs = options?.crudUploadThrottleMs || this.options.crudUploadThrottleMs;
+    const retryDelayMs = options?.retryDelayMs ?? this.options.retryDelayMs;
+    const crudUploadThrottleMs = options?.crudUploadThrottleMs ?? this.options.crudUploadThrottleMs;
 
     return new ReactNativeStreamingSyncImplementation({
       adapter: this.bucketStorageAdapter,

--- a/packages/react-native/src/db/PowerSyncDatabase.ts
+++ b/packages/react-native/src/db/PowerSyncDatabase.ts
@@ -45,12 +45,9 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
   protected generateSyncStreamImplementation(
     connector: PowerSyncBackendConnector,
     // This is used to pass in options on connection instead of only during database creation
-    options?: AdditionalConnectionOptions
+    options: Required<AdditionalConnectionOptions>
   ): AbstractStreamingSyncImplementation {
     const remote = new ReactNativeRemote(connector);
-    // Use the options passed in during connect, or fallback to the options set during database creation
-    const retryDelayMs = options?.retryDelayMs ?? this.options.retryDelayMs ?? this.options.retryDelay;
-    const crudUploadThrottleMs = options?.crudUploadThrottleMs ?? this.options.crudUploadThrottleMs;
 
     return new ReactNativeStreamingSyncImplementation({
       adapter: this.bucketStorageAdapter,
@@ -59,8 +56,8 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
         await this.waitForReady();
         await connector.uploadData(this);
       },
-      retryDelayMs,
-      crudUploadThrottleMs,
+      retryDelayMs: options.retryDelayMs,
+      crudUploadThrottleMs: options.crudUploadThrottleMs,
       identifier: this.database.name
     });
   }

--- a/packages/react-native/src/db/PowerSyncDatabase.ts
+++ b/packages/react-native/src/db/PowerSyncDatabase.ts
@@ -1,6 +1,7 @@
 import {
   AbstractPowerSyncDatabase,
   AbstractStreamingSyncImplementation,
+  AdditionalConnectionOptions,
   BucketStorageAdapter,
   DBAdapter,
   PowerSyncBackendConnector,
@@ -44,14 +45,11 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
   protected generateSyncStreamImplementation(
     connector: PowerSyncBackendConnector,
     // This is used to pass in options on connection instead of only during database creation
-    options?: {
-      retryDelayMs: number;
-      crudUploadThrottleMs: number;
-    }
+    options?: AdditionalConnectionOptions
   ): AbstractStreamingSyncImplementation {
     const remote = new ReactNativeRemote(connector);
     // Use the options passed in during connect, or fallback to the options set during database creation
-    const retryDelayMs = options?.retryDelayMs ?? this.options.retryDelayMs;
+    const retryDelayMs = options?.retryDelayMs ?? this.options.retryDelayMs ?? this.options.retryDelay;
     const crudUploadThrottleMs = options?.crudUploadThrottleMs ?? this.options.crudUploadThrottleMs;
 
     return new ReactNativeStreamingSyncImplementation({

--- a/packages/react-native/src/db/PowerSyncDatabase.ts
+++ b/packages/react-native/src/db/PowerSyncDatabase.ts
@@ -42,7 +42,12 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
   }
 
   protected generateSyncStreamImplementation(
-    connector: PowerSyncBackendConnector
+    connector: PowerSyncBackendConnector,
+    // This is used to pass in options on connection instead of only during db creation
+    options?: {
+      retryDelayMs: number;
+      crudUploadThrottleMs: number;
+    }
   ): AbstractStreamingSyncImplementation {
     const remote = new ReactNativeRemote(connector);
 
@@ -53,8 +58,8 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
         await this.waitForReady();
         await connector.uploadData(this);
       },
-      retryDelayMs: this.options.retryDelay,
-      crudUploadThrottleMs: this.options.crudUploadThrottleMs,
+      retryDelayMs: options?.retryDelayMs || this.options.retryDelay,
+      crudUploadThrottleMs: options?.crudUploadThrottleMs || this.options.crudUploadThrottleMs,
       identifier: this.database.name
     });
   }

--- a/packages/web/src/db/PowerSyncDatabase.ts
+++ b/packages/web/src/db/PowerSyncDatabase.ts
@@ -164,11 +164,20 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
     return getNavigatorLocks().request(`lock-${this.database.name}`, cb);
   }
 
-  protected generateSyncStreamImplementation(connector: PowerSyncBackendConnector): StreamingSyncImplementation {
+  protected generateSyncStreamImplementation(
+    connector: PowerSyncBackendConnector,
+    // This is used to pass in options on connection instead of only during db creation
+    options?: {
+      retryDelayMs?: number;
+      crudUploadThrottleMs?: number;
+    }
+  ): StreamingSyncImplementation {
     const remote = new WebRemote(connector);
 
     const syncOptions: WebStreamingSyncImplementationOptions = {
       ...(this.options as {}),
+      retryDelayMs: options?.retryDelayMs || this.options.retryDelay,
+      crudUploadThrottleMs: options?.crudUploadThrottleMs || this.options.crudUploadThrottleMs,
       flags: this.resolvedFlags,
       adapter: this.bucketStorageAdapter,
       remote,

--- a/packages/web/src/db/PowerSyncDatabase.ts
+++ b/packages/web/src/db/PowerSyncDatabase.ts
@@ -3,7 +3,7 @@ import {
   type PowerSyncBackendConnector,
   type PowerSyncCloseOptions,
   type PowerSyncConnectionOptions,
-  type PowerSyncConnectionOptionalOptions,
+  type AdditionalConnectionOptions,
   AbstractPowerSyncDatabase,
   DBAdapter,
   DEFAULT_POWERSYNC_CLOSE_OPTIONS,
@@ -168,7 +168,7 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
   protected generateSyncStreamImplementation(
     connector: PowerSyncBackendConnector,
     // This is used to pass in options on connection instead of only during db creation
-    options?: PowerSyncConnectionOptionalOptions
+    options?: AdditionalConnectionOptions
   ): StreamingSyncImplementation {
     const remote = new WebRemote(connector);
     // Use the options passed in during connect, or fallback to the options set during database creation

--- a/packages/web/src/db/PowerSyncDatabase.ts
+++ b/packages/web/src/db/PowerSyncDatabase.ts
@@ -167,7 +167,6 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
 
   protected generateSyncStreamImplementation(
     connector: PowerSyncBackendConnector,
-    // This is used to pass in options on connection instead of only during db creation
     options: Required<AdditionalConnectionOptions>
   ): StreamingSyncImplementation {
     const remote = new WebRemote(connector);

--- a/packages/web/src/db/PowerSyncDatabase.ts
+++ b/packages/web/src/db/PowerSyncDatabase.ts
@@ -173,11 +173,14 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
     }
   ): StreamingSyncImplementation {
     const remote = new WebRemote(connector);
+    // Use the options passed in during connect, or fallback to the options set during database creation
+    const retryDelayMs = options?.retryDelayMs || this.options.retryDelay;
+    const crudUploadThrottleMs = options?.crudUploadThrottleMs || this.options.crudUploadThrottleMs;
 
     const syncOptions: WebStreamingSyncImplementationOptions = {
       ...(this.options as {}),
-      retryDelayMs: options?.retryDelayMs || this.options.retryDelay,
-      crudUploadThrottleMs: options?.crudUploadThrottleMs || this.options.crudUploadThrottleMs,
+      retryDelayMs,
+      crudUploadThrottleMs,
       flags: this.resolvedFlags,
       adapter: this.bucketStorageAdapter,
       remote,

--- a/packages/web/src/db/PowerSyncDatabase.ts
+++ b/packages/web/src/db/PowerSyncDatabase.ts
@@ -168,17 +168,13 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
   protected generateSyncStreamImplementation(
     connector: PowerSyncBackendConnector,
     // This is used to pass in options on connection instead of only during db creation
-    options?: AdditionalConnectionOptions
+    options: Required<AdditionalConnectionOptions>
   ): StreamingSyncImplementation {
     const remote = new WebRemote(connector);
-    // Use the options passed in during connect, or fallback to the options set during database creation
-    const retryDelayMs = options?.retryDelayMs ?? this.options.retryDelayMs ?? this.options.retryDelay;
-    const crudUploadThrottleMs = options?.crudUploadThrottleMs ?? this.options.crudUploadThrottleMs;
-
     const syncOptions: WebStreamingSyncImplementationOptions = {
       ...(this.options as {}),
-      retryDelayMs,
-      crudUploadThrottleMs,
+      retryDelayMs: options.retryDelayMs,
+      crudUploadThrottleMs: options.crudUploadThrottleMs,
       flags: this.resolvedFlags,
       adapter: this.bucketStorageAdapter,
       remote,

--- a/packages/web/src/db/PowerSyncDatabase.ts
+++ b/packages/web/src/db/PowerSyncDatabase.ts
@@ -3,7 +3,7 @@ import {
   type PowerSyncBackendConnector,
   type PowerSyncCloseOptions,
   type PowerSyncConnectionOptions,
-  type AdditionalConnectionOptions,
+  type RequiredAdditionalConnectionOptions,
   AbstractPowerSyncDatabase,
   DBAdapter,
   DEFAULT_POWERSYNC_CLOSE_OPTIONS,
@@ -12,7 +12,7 @@ import {
   PowerSyncDatabaseOptionsWithOpenFactory,
   PowerSyncDatabaseOptionsWithSettings,
   SqliteBucketStorage,
-  StreamingSyncImplementation
+  StreamingSyncImplementation,
 } from '@powersync/common';
 import { Mutex } from 'async-mutex';
 import { WASQLiteOpenFactory } from './adapters/wa-sqlite/WASQLiteOpenFactory';
@@ -167,7 +167,7 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
 
   protected generateSyncStreamImplementation(
     connector: PowerSyncBackendConnector,
-    options: Required<AdditionalConnectionOptions>
+    options: RequiredAdditionalConnectionOptions
   ): StreamingSyncImplementation {
     const remote = new WebRemote(connector);
     const syncOptions: WebStreamingSyncImplementationOptions = {

--- a/packages/web/src/db/PowerSyncDatabase.ts
+++ b/packages/web/src/db/PowerSyncDatabase.ts
@@ -3,6 +3,7 @@ import {
   type PowerSyncBackendConnector,
   type PowerSyncCloseOptions,
   type PowerSyncConnectionOptions,
+  type PowerSyncConnectionOptionalOptions,
   AbstractPowerSyncDatabase,
   DBAdapter,
   DEFAULT_POWERSYNC_CLOSE_OPTIONS,
@@ -167,15 +168,12 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
   protected generateSyncStreamImplementation(
     connector: PowerSyncBackendConnector,
     // This is used to pass in options on connection instead of only during db creation
-    options?: {
-      retryDelayMs?: number;
-      crudUploadThrottleMs?: number;
-    }
+    options?: PowerSyncConnectionOptionalOptions
   ): StreamingSyncImplementation {
     const remote = new WebRemote(connector);
     // Use the options passed in during connect, or fallback to the options set during database creation
-    const retryDelayMs = options?.retryDelayMs || this.options.retryDelay;
-    const crudUploadThrottleMs = options?.crudUploadThrottleMs || this.options.crudUploadThrottleMs;
+    const retryDelayMs = options?.retryDelayMs ?? this.options.retryDelayMs;
+    const crudUploadThrottleMs = options?.crudUploadThrottleMs ?? this.options.crudUploadThrottleMs;
 
     const syncOptions: WebStreamingSyncImplementationOptions = {
       ...(this.options as {}),

--- a/packages/web/src/db/PowerSyncDatabase.ts
+++ b/packages/web/src/db/PowerSyncDatabase.ts
@@ -172,7 +172,7 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
   ): StreamingSyncImplementation {
     const remote = new WebRemote(connector);
     // Use the options passed in during connect, or fallback to the options set during database creation
-    const retryDelayMs = options?.retryDelayMs ?? this.options.retryDelayMs;
+    const retryDelayMs = options?.retryDelayMs ?? this.options.retryDelayMs ?? this.options.retryDelay;
     const crudUploadThrottleMs = options?.crudUploadThrottleMs ?? this.options.crudUploadThrottleMs;
 
     const syncOptions: WebStreamingSyncImplementationOptions = {

--- a/packages/web/tests/src/db/AbstractPowerSyncDatabase.test.ts
+++ b/packages/web/tests/src/db/AbstractPowerSyncDatabase.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AbstractPowerSyncDatabase, DEFAULT_RETRY_DELAY_MS, DEFAULT_CRUD_UPLOAD_THROTTLE_MS, BucketStorageAdapter, DBAdapter, PowerSyncBackendConnector, PowerSyncDatabaseOptionsWithSettings, RequiredAdditionalConnectionOptions, StreamingSyncImplementation } from '@powersync/common';
+import { testSchema } from '../../utils/testDb';
+
+class TestPowerSyncDatabase extends AbstractPowerSyncDatabase {
+  protected openDBAdapter(options: PowerSyncDatabaseOptionsWithSettings): DBAdapter {
+    return {} as any
+  }
+  protected generateSyncStreamImplementation(connector: PowerSyncBackendConnector, options: RequiredAdditionalConnectionOptions): StreamingSyncImplementation {
+    return undefined as any;
+  }
+  protected generateBucketStorageAdapter(): BucketStorageAdapter {
+    return {
+      init: vi.fn()
+    } as any
+  }
+  _initialize(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  get database() {
+    return {
+      get: vi.fn().mockResolvedValue({ version: '0.3.0'}),
+      execute: vi.fn(),
+      refreshSchema: vi.fn(),
+    } as any
+  }
+  // Expose protected method for testing
+  public testResolvedConnectionOptions(options?: any) {
+    return this.resolvedConnectionOptions(options);
+  }
+}
+
+describe('AbstractPowerSyncDatabase', () => {
+  describe('resolvedConnectionOptions', () => {
+    it('should use connect options when provided', () => {
+      const db = new TestPowerSyncDatabase({
+        schema: testSchema,
+        database: { dbFilename: 'test.db' }
+      });
+
+      const result = db.testResolvedConnectionOptions({
+        retryDelayMs: 1000,
+        crudUploadThrottleMs: 2000
+      });
+
+      expect(result).toEqual({
+        retryDelayMs: 1000,
+        crudUploadThrottleMs: 2000
+      });
+    });
+
+    it('should fallback to constructor options when connect options not provided', () => {
+      const db = new TestPowerSyncDatabase({
+        schema: testSchema,
+        database: { dbFilename: 'test.db' },
+        retryDelayMs: 3000,
+        crudUploadThrottleMs: 4000
+      });
+
+      const result = db.testResolvedConnectionOptions();
+
+      expect(result).toEqual({
+        retryDelayMs: 3000,
+        crudUploadThrottleMs: 4000
+      });
+    });
+
+    it('should convert retryDelay to retryDelayMs', () => {
+      const db = new TestPowerSyncDatabase({
+        schema: testSchema,
+        database: { dbFilename: 'test.db' },
+        retryDelay: 5000
+      });
+
+      const result = db.testResolvedConnectionOptions();
+
+      expect(result).toEqual({
+        retryDelayMs: 5000,
+        crudUploadThrottleMs: DEFAULT_CRUD_UPLOAD_THROTTLE_MS
+      });
+    });
+
+    it('should prioritize retryDelayMs over retryDelay in constructor options', () => {
+      const db = new TestPowerSyncDatabase({
+        schema: testSchema,
+        database: { dbFilename: 'test.db' },
+        retryDelay: 5000,
+        retryDelayMs: 6000
+      });
+
+      const result = db.testResolvedConnectionOptions();
+
+      expect(result).toEqual({
+        retryDelayMs: 6000,
+        crudUploadThrottleMs: DEFAULT_CRUD_UPLOAD_THROTTLE_MS
+      });
+    });
+
+    it('should prioritize connect options over constructor options', () => {
+      const db = new TestPowerSyncDatabase({
+        schema: testSchema,
+        database: { dbFilename: 'test.db' },
+        retryDelayMs: 5000,
+        crudUploadThrottleMs: 6000
+      });
+
+      const result = db.testResolvedConnectionOptions({
+        retryDelayMs: 7000,
+        crudUploadThrottleMs: 8000
+      });
+
+      expect(result).toEqual({
+        retryDelayMs: 7000,
+        crudUploadThrottleMs: 8000
+      });
+    });
+
+    it('should use default values when no options provided', () => {
+      const db = new TestPowerSyncDatabase({
+        schema: testSchema,
+        database: { dbFilename: 'test.db' }
+      });
+
+      const result = db.testResolvedConnectionOptions();
+
+      expect(result).toEqual({
+        retryDelayMs: DEFAULT_RETRY_DELAY_MS,
+        crudUploadThrottleMs: DEFAULT_CRUD_UPLOAD_THROTTLE_MS
+      });
+    });
+
+    it('should handle partial connect options', () => {
+      const db = new TestPowerSyncDatabase({
+        schema: testSchema,
+        database: { dbFilename: 'test.db' },
+        retryDelayMs: 5000,
+        crudUploadThrottleMs: 6000
+      });
+
+      const result = db.testResolvedConnectionOptions({
+        retryDelayMs: 7000
+      });
+
+      expect(result).toEqual({
+        retryDelayMs: 7000,
+        crudUploadThrottleMs: 6000
+      });
+    });
+  });
+});

--- a/packages/web/tests/src/db/PowersyncDatabase.test.ts
+++ b/packages/web/tests/src/db/PowersyncDatabase.test.ts
@@ -34,7 +34,7 @@ describe('PowerSyncDatabase - generateSyncStreamImplementation', () => {
       flags: {
         ssrMode: true,
       },
-      retryDelay: 1000,
+      retryDelayMs: 1000,
       crudUploadThrottleMs: 2000
     })
 
@@ -86,7 +86,7 @@ describe('PowerSyncDatabase - generateSyncStreamImplementation', () => {
         ssrMode: false,
         enableMultiTabs: false,
       },
-      retryDelay: 1000,
+      retryDelayMs: 1000,
       crudUploadThrottleMs: 2000
     })
 

--- a/packages/web/tests/src/db/PowersyncDatabase.test.ts
+++ b/packages/web/tests/src/db/PowersyncDatabase.test.ts
@@ -3,7 +3,6 @@ import { PowerSyncDatabase, SharedWebStreamingSyncImplementation, WebStreamingSy
 import { SSRStreamingSyncImplementation } from '../../../src/db/sync/SSRWebStreamingSyncImplementation'
 import { testSchema } from '../../utils/testDb'
 
-
 vi.mock('../../../src/db/sync/WebStreamingSyncImplementation')
 vi.mock('../../../src/db/sync/SharedWebStreamingSyncImplementation')
 vi.mock('../../../src/db/sync/SSRWebStreamingSyncImplementation')
@@ -38,7 +37,7 @@ describe('PowerSyncDatabase - generateSyncStreamImplementation', () => {
       crudUploadThrottleMs: 2000
     })
 
-    db['generateSyncStreamImplementation'](mockConnector)
+    db['generateSyncStreamImplementation'](mockConnector, { retryDelayMs: 1000, crudUploadThrottleMs: 2000 })
     expect(SSRStreamingSyncImplementation).toHaveBeenCalled()
 
     await setTimeout(() => window.removeEventListener('unhandledrejection', handler), 1)
@@ -50,7 +49,7 @@ describe('PowerSyncDatabase - generateSyncStreamImplementation', () => {
       database: { dbFilename: 'test.db' },
       flags: { enableMultiTabs: true }
     })
-    db['generateSyncStreamImplementation'](mockConnector)
+    db['generateSyncStreamImplementation'](mockConnector, { retryDelayMs: 1000, crudUploadThrottleMs: 2000 })
     expect(SharedWebStreamingSyncImplementation).toHaveBeenCalled()
   })
 
@@ -64,6 +63,7 @@ describe('PowerSyncDatabase - generateSyncStreamImplementation', () => {
         ssrMode: false,
         enableMultiTabs: false,
       },
+      retryDelayMs: 1000,
       crudUploadThrottleMs: 1000
     })
 
@@ -76,30 +76,8 @@ describe('PowerSyncDatabase - generateSyncStreamImplementation', () => {
     )
   })
 
-  it('handles partial option overrides', () => {
-    const db = new PowerSyncDatabase({
-      schema: testSchema,
-      database: {
-        dbFilename: 'test.db'
-      },
-      flags: {
-        ssrMode: false,
-        enableMultiTabs: false,
-      },
-      retryDelayMs: 1000,
-      crudUploadThrottleMs: 2000
-    })
-
-    db['generateSyncStreamImplementation'](mockConnector, { retryDelayMs: 50000 })
-    expect(WebStreamingSyncImplementation).toHaveBeenCalledWith(
-      expect.objectContaining({
-        retryDelayMs: 50000,
-      })
-    )
-  })
-
   // This test can be removed once retryDelay is removed and entirely replaced with retryDelayMs
-  it('works when using deprecated retryDelay instead of retryDelayMs', () => {
+  it('works when using deprecated retryDelay instead of retryDelayMs', async () => {
     const db = new PowerSyncDatabase({
       schema: testSchema,
       database: {
@@ -112,10 +90,10 @@ describe('PowerSyncDatabase - generateSyncStreamImplementation', () => {
       retryDelay: 11100,
     })
 
-    db['generateSyncStreamImplementation'](mockConnector)
+    db['generateSyncStreamImplementation'](mockConnector, { crudUploadThrottleMs: 2000, retryDelayMs: 50000 })
     expect(WebStreamingSyncImplementation).toHaveBeenCalledWith(
       expect.objectContaining({
-        retryDelayMs: 11100,
+        retryDelay: 11100,
       })
     )
   })

--- a/packages/web/tests/src/db/PowersyncDatabase.test.ts
+++ b/packages/web/tests/src/db/PowersyncDatabase.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { PowerSyncDatabase, SharedWebStreamingSyncImplementation, WebStreamingSyncImplementation } from '../../../src'
+import { SSRStreamingSyncImplementation } from '../../../src/db/sync/SSRWebStreamingSyncImplementation'
+import { testSchema } from '../../utils/testDb'
+
+
+vi.mock('../../../src/db/sync/WebStreamingSyncImplementation')
+vi.mock('../../../src/db/sync/SharedWebStreamingSyncImplementation')
+vi.mock('../../../src/db/sync/SSRWebStreamingSyncImplementation')
+
+describe('PowerSyncDatabase - generateSyncStreamImplementation', () => {
+  const mockConnector = {
+    uploadData: vi.fn(),
+    fetchCredentials: vi.fn()
+  }
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('uses SSRStreamingSyncImplementation when ssrMode is true', async () => {
+    // This is to prevent a false positive from the unhandled rejection
+    // of using SSR in this test.
+    const handler = (event: PromiseRejectionEvent) => {
+      event.preventDefault()
+    }
+    window.addEventListener('unhandledrejection', handler)
+
+    const db = new PowerSyncDatabase({
+      schema: testSchema,
+      database: {
+        dbFilename: 'test.db'
+      },
+      flags: {
+        ssrMode: true,
+      },
+      retryDelay: 1000,
+      crudUploadThrottleMs: 2000
+    })
+
+    db['generateSyncStreamImplementation'](mockConnector)
+    expect(SSRStreamingSyncImplementation).toHaveBeenCalled()
+
+    await setTimeout(() => window.removeEventListener('unhandledrejection', handler), 1)
+  })
+
+  it('uses SharedWebStreamingSyncImplementation when enableMultiTabs is true', () => {
+    const db = new PowerSyncDatabase({
+      schema: testSchema,
+      database: { dbFilename: 'test.db' },
+      flags: { enableMultiTabs: true }
+    })
+    db['generateSyncStreamImplementation'](mockConnector)
+    expect(SharedWebStreamingSyncImplementation).toHaveBeenCalled()
+  })
+
+  it('handles option overrides', () => {
+    const db = new PowerSyncDatabase({
+      schema: testSchema,
+      database: {
+        dbFilename: 'test.db'
+      },
+      flags: {
+        ssrMode: false,
+        enableMultiTabs: false,
+      },
+      crudUploadThrottleMs: 1000
+    })
+
+    db['generateSyncStreamImplementation'](mockConnector, { crudUploadThrottleMs: 20000, retryDelayMs: 50000 })
+    expect(WebStreamingSyncImplementation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        retryDelayMs: 50000,
+        crudUploadThrottleMs: 20000
+      })
+    )
+  })
+
+  it('handles partial option overrides', () => {
+    const db = new PowerSyncDatabase({
+      schema: testSchema,
+      database: {
+        dbFilename: 'test.db'
+      },
+      flags: {
+        ssrMode: false,
+        enableMultiTabs: false,
+      },
+      retryDelay: 1000,
+      crudUploadThrottleMs: 2000
+    })
+
+    db['generateSyncStreamImplementation'](mockConnector, { retryDelayMs: 50000 })
+    expect(WebStreamingSyncImplementation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        retryDelayMs: 50000,
+      })
+    )
+  })
+})

--- a/packages/web/tests/src/db/PowersyncDatabase.test.ts
+++ b/packages/web/tests/src/db/PowersyncDatabase.test.ts
@@ -97,4 +97,26 @@ describe('PowerSyncDatabase - generateSyncStreamImplementation', () => {
       })
     )
   })
+
+  // This test can be removed once retryDelay is removed and entirely replaced with retryDelayMs
+  it('works when using deprecated retryDelay instead of retryDelayMs', () => {
+    const db = new PowerSyncDatabase({
+      schema: testSchema,
+      database: {
+        dbFilename: 'test.db'
+      },
+      flags: {
+        ssrMode: false,
+        enableMultiTabs: false,
+      },
+      retryDelay: 11100,
+    })
+
+    db['generateSyncStreamImplementation'](mockConnector)
+    expect(WebStreamingSyncImplementation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        retryDelayMs: 11100,
+      })
+    )
+  })
 })


### PR DESCRIPTION
## Description
Add `retryDelayMs` and `crudUploadThrottleMs` to `connect` so that the values can be dynamically changed on reconnecting. Deprecate `retryDelay` option in favor of `retryDelayMs`.

## Testing
I ran the todolist react native demo and confirmed that the values used are from the connect method and added tests for web to confirm.