### PR TITLE
OPSLite: Silencing transactions that are reporting on failed rollbacks

### DIFF
--- a/.changeset/thin-panthers-decide.md
+++ b/.changeset/thin-panthers-decide.md
@@ -1,0 +1,5 @@
+---
+'@powersync/op-sqlite': patch
+---
+
+Silencing transactions that are reporting on failed rollback exceptions when they are safe to ignore.

--- a/packages/powersync-op-sqlite/src/db/OPSqliteAdapter.ts
+++ b/packages/powersync-op-sqlite/src/db/OPSqliteAdapter.ts
@@ -1,18 +1,5 @@
-import {
-  BaseObserver,
-  DBAdapter,
-  DBAdapterListener,
-  DBLockOptions,
-  QueryResult,
-  Transaction
-} from '@powersync/common';
-import {
-  ANDROID_DATABASE_PATH,
-  getDylibPath,
-  IOS_LIBRARY_PATH,
-  open,
-  type DB
-} from '@op-engineering/op-sqlite';
+import { BaseObserver, DBAdapter, DBAdapterListener, DBLockOptions, QueryResult, Transaction } from '@powersync/common';
+import { ANDROID_DATABASE_PATH, getDylibPath, IOS_LIBRARY_PATH, open, type DB } from '@op-engineering/op-sqlite';
 import Lock from 'async-lock';
 import { OPSQLiteConnection } from './OPSQLiteConnection';
 import { Platform } from 'react-native';
@@ -283,7 +270,12 @@ export class OPSQLiteDBAdapter extends BaseObserver<DBAdapterListener> implement
       await commit();
       return result;
     } catch (ex) {
-      await rollback();
+      try {
+        await rollback();
+      } catch (ex2) {
+        // In rare cases, a rollback may fail.
+        // Safe to ignore.
+      }
       throw ex;
     }
   }
@@ -292,7 +284,7 @@ export class OPSQLiteDBAdapter extends BaseObserver<DBAdapterListener> implement
     await this.initialized;
     await this.writeConnection!.refreshSchema();
 
-    if(this.readConnections) {
+    if (this.readConnections) {
       for (let readConnection of this.readConnections) {
         await readConnection.connection.refreshSchema();
       }


### PR DESCRIPTION
Users can easily trigger two rollback calls in transactions which causes an exception message users can't do anything about. This PR simply silences the exception when this happens as we do in [dart](https://github.com/powersync-ja/sqlite_async.dart/blob/4ba51e5a5bc4b6e47c4a21b658776fdce30a0548/packages/sqlite_async/lib/src/utils/shared_utils.dart#L33).

Reference PR from RNQS: https://github.com/powersync-ja/react-native-quick-sqlite/pull/36