### PR TITLE
docs: OPSQLite large datasets on android 12 (Temporary store memory option)

### DIFF
--- a/packages/powersync-op-sqlite/README.md
+++ b/packages/powersync-op-sqlite/README.md
@@ -104,6 +104,21 @@ const factory = new OPSqliteOpenFactory({
 });
 ```
 
+## Using the Memory Temporary Store
+
+For some targets like Android 12/API 31, syncing of large datasets may cause disk IO errors due to the default temporary store option (file) used.
+To resolve this you can use the `memory` option, by adding the following configuration option to your application's `package.json`
+
+```json
+{
+  // your normal package.json
+  // ...
+  "op-sqlite": {
+    "sqliteFlags": "-DSQLITE_TEMP_STORE=2"
+  }
+}
+```
+
 ## Native Projects
 
 This package uses native libraries. Create native Android and iOS projects (if not created already) by running:


### PR DESCRIPTION
For large datasets on Android 12, the default temp store (file) may cause disk IO errors, in the past we resolved this for RNQS by setting a build flag to use the memory option.

This PR adds a readme entry on how a user can configure their package.json to set the option for OPSQLite, ideally there is a way for us to define this as part of the code generation.

Reference PR from RNQS: https://github.com/powersync-ja/react-native-quick-sqlite/pull/28