### PR TITLE
docs: Updated github action versions

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -54,7 +54,7 @@ jobs:
         run: pnpm build:packages
       - name: Build Docs
         run: pnpm docs:build
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs/build
   deploy:
@@ -66,4 +66,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The doc deploy action has started failing due to a deprecated action no longer working - the two actions I have bumped wrap that action.
I have updated to the versions recommended in the upload-pages-artifact v3 release here:  https://github.com/actions/upload-pages-artifact/releases

Example build failure: https://github.com/powersync-ja/powersync-js/actions/runs/13054794562

Writeup of deprecation: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/