### PR TITLE
Cache size & temp storage

### DIFF
--- a/.changeset/lovely-impalas-do.md
+++ b/.changeset/lovely-impalas-do.md
@@ -1,0 +1,5 @@
+---
+'@powersync/web': minor
+---
+
+Add cacheSizeKb option, defaulting to 50MB.

--- a/.changeset/slow-spiders-smash.md
+++ b/.changeset/slow-spiders-smash.md
@@ -1,0 +1,5 @@
+---
+'@powersync/diagnostics-app': minor
+---
+
+Switch diagnostics app to OPFS.

--- a/.changeset/spotty-students-serve.md
+++ b/.changeset/spotty-students-serve.md
@@ -1,0 +1,5 @@
+---
+'@powersync/op-sqlite': minor
+---
+
+Default to using memory for temp store, and 50MB cache size.

--- a/packages/powersync-op-sqlite/README.md
+++ b/packages/powersync-op-sqlite/README.md
@@ -74,9 +74,7 @@ To load additional SQLite extensions include the `extensions` option in `sqliteO
 
 ```js
 sqliteOptions: {
-  extensions: [
-      { path: libPath, entryPoint: 'sqlite3_powersync_init' }
-  ]
+  extensions: [{ path: libPath, entryPoint: 'sqlite3_powersync_init' }];
 }
 ```
 
@@ -87,9 +85,9 @@ Example usage:
 ```ts
 import { getDylibPath } from '@op-engineering/op-sqlite';
 
-let libPath: string
+let libPath: string;
 if (Platform.OS === 'ios') {
-  libPath = getDylibPath('co.powersync.sqlitecore', 'powersync-sqlite-core')
+  libPath = getDylibPath('co.powersync.sqlitecore', 'powersync-sqlite-core');
 } else {
   libPath = 'libpowersync';
 }
@@ -97,26 +95,9 @@ if (Platform.OS === 'ios') {
 const factory = new OPSqliteOpenFactory({
   dbFilename: 'sqlite.db',
   sqliteOptions: {
-    extensions: [
-        { path: libPath, entryPoint: 'sqlite3_powersync_init' }
-    ]
+    extensions: [{ path: libPath, entryPoint: 'sqlite3_powersync_init' }]
   }
 });
-```
-
-## Using the Memory Temporary Store
-
-For some targets like Android 12/API 31, syncing of large datasets may cause disk IO errors due to the default temporary store option (file) used.
-To resolve this you can use the `memory` option, by adding the following configuration option to your application's `package.json`
-
-```json
-{
-  // your normal package.json
-  // ...
-  "op-sqlite": {
-    "sqliteFlags": "-DSQLITE_TEMP_STORE=2"
-  }
-}
 ```
 
 ## Native Projects

--- a/packages/powersync-op-sqlite/src/db/OPSqliteAdapter.ts
+++ b/packages/powersync-op-sqlite/src/db/OPSqliteAdapter.ts
@@ -44,19 +44,28 @@ export class OPSQLiteDBAdapter extends BaseObserver<DBAdapterListener> implement
   }
 
   protected async init() {
-    const { lockTimeoutMs, journalMode, journalSizeLimit, synchronous } = this.options.sqliteOptions!;
+    const { lockTimeoutMs, journalMode, journalSizeLimit, synchronous, cacheSizeKb, temporaryStorage } =
+      this.options.sqliteOptions!;
     const dbFilename = this.options.name;
 
     this.writeConnection = await this.openConnection(dbFilename);
 
-    const statements: string[] = [
+    const baseStatements = [
       `PRAGMA busy_timeout = ${lockTimeoutMs}`,
+      `PRAGMA cache_size = -${cacheSizeKb}`,
+      `PRAGMA temp_store = ${temporaryStorage}`
+    ];
+
+    const writeConnectionStatements = [
+      ...baseStatements,
       `PRAGMA journal_mode = ${journalMode}`,
       `PRAGMA journal_size_limit = ${journalSizeLimit}`,
       `PRAGMA synchronous = ${synchronous}`
     ];
 
-    for (const statement of statements) {
+    const readConnectionStatements = [...baseStatements, 'PRAGMA query_only = true'];
+
+    for (const statement of writeConnectionStatements) {
       for (let tries = 0; tries < 30; tries++) {
         try {
           await this.writeConnection!.execute(statement);
@@ -79,7 +88,9 @@ export class OPSQLiteDBAdapter extends BaseObserver<DBAdapterListener> implement
     this.readConnections = [];
     for (let i = 0; i < READ_CONNECTIONS; i++) {
       const conn = await this.openConnection(dbFilename);
-      await conn.execute('PRAGMA query_only = true');
+      for (let statement of readConnectionStatements) {
+        await conn.execute(statement);
+      }
       this.readConnections.push({ busy: false, connection: conn });
     }
   }

--- a/packages/powersync-op-sqlite/src/db/SqliteOptions.ts
+++ b/packages/powersync-op-sqlite/src/db/SqliteOptions.ts
@@ -31,6 +31,21 @@ export interface SqliteOptions {
   encryptionKey?: string | null;
 
   /**
+   * Where to store SQLite temporary files. Defaults to 'MEMORY'.
+   * Setting this to `FILESYSTEM` can cause issues with larger queries or datasets.
+   *
+   * For details, see: https://www.sqlite.org/pragma.html#pragma_temp_store
+   */
+  temporaryStorage?: TemporaryStorageOption;
+
+  /**
+   * Maximum SQLite cache size. Defaults to 50MB.
+   *
+   * For details, see: https://www.sqlite.org/pragma.html#pragma_cache_size
+   */
+  cacheSizeKb?: number;
+
+  /**
    * Load extensions using the path and entryPoint.
    * More info can be found here https://op-engineering.github.io/op-sqlite/docs/api#loading-extensions.
    */
@@ -38,6 +53,11 @@ export interface SqliteOptions {
     path: string;
     entryPoint?: string;
   }>;
+}
+
+export enum TemporaryStorageOption {
+  MEMORY = 'memory',
+  FILESYSTEM = 'file'
 }
 
 // SQLite journal mode. Set on the primary connection.
@@ -65,6 +85,8 @@ export const DEFAULT_SQLITE_OPTIONS: Required<SqliteOptions> = {
   journalMode: SqliteJournalMode.wal,
   synchronous: SqliteSynchronous.normal,
   journalSizeLimit: 6 * 1024 * 1024,
+  cacheSizeKb: 50 * 1024,
+  temporaryStorage: TemporaryStorageOption.MEMORY,
   lockTimeoutMs: 30000,
   encryptionKey: null,
   extensions: []

--- a/packages/web/src/db/adapters/wa-sqlite/WASQLiteConnection.ts
+++ b/packages/web/src/db/adapters/wa-sqlite/WASQLiteConnection.ts
@@ -235,6 +235,7 @@ export class WASqliteConnection
     await this.openDB();
     this.registerBroadcastListeners();
     await this.executeSingleStatement(`PRAGMA temp_store = ${this.options.temporaryStorage};`);
+    await this.executeSingleStatement(`PRAGMA cache_size = -${this.options.cacheSizeKb};`);
     await this.executeEncryptionPragma();
 
     this.sqliteAPI.update_hook(this.dbP, (updateType: number, dbName: string | null, tableName: string | null) => {

--- a/packages/web/src/db/adapters/wa-sqlite/WASQLiteOpenFactory.ts
+++ b/packages/web/src/db/adapters/wa-sqlite/WASQLiteOpenFactory.ts
@@ -4,7 +4,12 @@ import { openWorkerDatabasePort, resolveWorkerDatabasePortFactory } from '../../
 import { AbstractWebSQLOpenFactory } from '../AbstractWebSQLOpenFactory';
 import { AsyncDatabaseConnection, OpenAsyncDatabaseConnection } from '../AsyncDatabaseConnection';
 import { LockedAsyncDatabaseAdapter } from '../LockedAsyncDatabaseAdapter';
-import { ResolvedWebSQLOpenOptions, TemporaryStorageOption, WebSQLOpenFactoryOptions } from '../web-sql-flags';
+import {
+  DEFAULT_CACHE_SIZE_KB,
+  ResolvedWebSQLOpenOptions,
+  TemporaryStorageOption,
+  WebSQLOpenFactoryOptions
+} from '../web-sql-flags';
 import { WorkerWrappedAsyncDatabaseConnection } from '../WorkerWrappedAsyncDatabaseConnection';
 import { WASqliteConnection, WASQLiteVFS } from './WASQLiteConnection';
 
@@ -44,6 +49,7 @@ export class WASQLiteOpenFactory extends AbstractWebSQLOpenFactory {
     const {
       vfs = WASQLiteVFS.IDBBatchAtomicVFS,
       temporaryStorage = TemporaryStorageOption.MEMORY,
+      cacheSizeKb = DEFAULT_CACHE_SIZE_KB,
       encryptionKey
     } = this.waOptions;
 
@@ -60,6 +66,7 @@ export class WASQLiteOpenFactory extends AbstractWebSQLOpenFactory {
               optionsDbWorker({
                 ...this.options,
                 temporaryStorage,
+                cacheSizeKb,
                 flags: this.resolvedFlags,
                 encryptionKey
               })
@@ -74,6 +81,7 @@ export class WASQLiteOpenFactory extends AbstractWebSQLOpenFactory {
           dbFilename: this.options.dbFilename,
           vfs,
           temporaryStorage,
+          cacheSizeKb,
           flags: this.resolvedFlags,
           encryptionKey: encryptionKey
         }),
@@ -94,6 +102,7 @@ export class WASQLiteOpenFactory extends AbstractWebSQLOpenFactory {
         debugMode: this.options.debugMode,
         vfs,
         temporaryStorage,
+        cacheSizeKb,
         flags: this.resolvedFlags,
         encryptionKey: encryptionKey
       });

--- a/packages/web/src/db/adapters/web-sql-flags.ts
+++ b/packages/web/src/db/adapters/web-sql-flags.ts
@@ -47,6 +47,8 @@ export interface ResolvedWebSQLOpenOptions extends SQLOpenOptions {
    */
   temporaryStorage: TemporaryStorageOption;
 
+  cacheSizeKb: number;
+
   /**
    * Encryption key for the database.
    * If set, the database will be encrypted using ChaCha20.
@@ -58,6 +60,8 @@ export enum TemporaryStorageOption {
   MEMORY = 'memory',
   FILESYSTEM = 'file'
 }
+
+export const DEFAULT_CACHE_SIZE_KB = 100 * 1024;
 
 /**
  * Options for opening a Web SQL connection
@@ -74,11 +78,21 @@ export interface WebSQLOpenFactoryOptions extends SQLOpenOptions {
   worker?: string | URL | ((options: ResolvedWebSQLOpenOptions) => Worker | SharedWorker);
 
   logger?: ILogger;
+
   /**
    * Where to store SQLite temporary files. Defaults to 'MEMORY'.
    * Setting this to `FILESYSTEM` can cause issues with larger queries or datasets.
+   *
+   * For details, see: https://www.sqlite.org/pragma.html#pragma_temp_store
    */
   temporaryStorage?: TemporaryStorageOption;
+
+  /**
+   * Maximum SQLite cache size. Defaults to 50MB.
+   *
+   * For details, see: https://www.sqlite.org/pragma.html#pragma_cache_size
+   */
+  cacheSizeKb?: number;
 
   /**
    * Encryption key for the database.

--- a/packages/web/src/db/adapters/web-sql-flags.ts
+++ b/packages/web/src/db/adapters/web-sql-flags.ts
@@ -61,7 +61,7 @@ export enum TemporaryStorageOption {
   FILESYSTEM = 'file'
 }
 
-export const DEFAULT_CACHE_SIZE_KB = 100 * 1024;
+export const DEFAULT_CACHE_SIZE_KB = 50 * 1024;
 
 /**
  * Options for opening a Web SQL connection

--- a/packages/web/src/db/sync/SharedWebStreamingSyncImplementation.ts
+++ b/packages/web/src/db/sync/SharedWebStreamingSyncImplementation.ts
@@ -6,7 +6,7 @@ import {
   SharedSyncClientEvent,
   SharedSyncImplementation
 } from '../../worker/sync/SharedSyncImplementation';
-import { resolveWebSQLFlags, TemporaryStorageOption } from '../adapters/web-sql-flags';
+import { DEFAULT_CACHE_SIZE_KB, resolveWebSQLFlags, TemporaryStorageOption } from '../adapters/web-sql-flags';
 import { WebDBAdapter } from '../adapters/WebDBAdapter';
 import {
   WebStreamingSyncImplementation,
@@ -106,10 +106,10 @@ export class SharedWebStreamingSyncImplementation extends WebStreamingSyncImplem
      * This worker will manage all syncing operations remotely.
      */
     const resolvedWorkerOptions = {
-      ...options,
       dbFilename: this.options.identifier!,
-      // TODO
       temporaryStorage: TemporaryStorageOption.MEMORY,
+      cacheSizeKb: DEFAULT_CACHE_SIZE_KB,
+      ...options,
       flags: resolveWebSQLFlags(options.flags)
     };
 

--- a/tools/diagnostics-app/src/library/powersync/ConnectionManager.ts
+++ b/tools/diagnostics-app/src/library/powersync/ConnectionManager.ts
@@ -4,7 +4,10 @@ import {
   PowerSyncDatabase,
   WebRemote,
   WebStreamingSyncImplementation,
-  WebStreamingSyncImplementationOptions
+  WebStreamingSyncImplementationOptions,
+  WASQLiteOpenFactory,
+  TemporaryStorageOption,
+  WASQLiteVFS
 } from '@powersync/web';
 import Logger from 'js-logger';
 import { DynamicSchemaManager } from './DynamicSchemaManager';
@@ -25,12 +28,16 @@ export const getParams = () => {
 
 export const schemaManager = new DynamicSchemaManager();
 
+const openFactory = new WASQLiteOpenFactory({
+  dbFilename: 'diagnostics.db',
+  debugMode: true,
+  cacheSizeKb: 500 * 1024,
+  temporaryStorage: TemporaryStorageOption.MEMORY,
+  vfs: WASQLiteVFS.OPFSCoopSyncVFS
+});
+
 export const db = new PowerSyncDatabase({
-  database: {
-    dbFilename: 'example.db',
-    debugMode: true,
-    cacheSizeKb: 500000
-  },
+  database: openFactory,
   schema: schemaManager.buildSchema()
 });
 

--- a/tools/diagnostics-app/src/library/powersync/ConnectionManager.ts
+++ b/tools/diagnostics-app/src/library/powersync/ConnectionManager.ts
@@ -28,11 +28,11 @@ export const schemaManager = new DynamicSchemaManager();
 export const db = new PowerSyncDatabase({
   database: {
     dbFilename: 'example.db',
-    debugMode: true
+    debugMode: true,
+    cacheSizeKb: 500000
   },
   schema: schemaManager.buildSchema()
 });
-db.execute('PRAGMA cache_size=-500000');
 
 export const connector = new TokenConnector();
 


### PR DESCRIPTION
Add `cacheSizeKb` option for web and op-sqlite, defaulting to a 50MB max cache size (versus SQLite default of 2MB). This makes a big impact on IndexedDB - see https://github.com/powersync-ja/powersync-sqlite-core/pull/56#issuecomment-2642302992.

Also add both `temporaryStorage` and `cacheSizeKb` options for op-sqlite, now also defaulting op-sqlite to `PRAGMA temp_store = memory` (same as web), and a 50MB cache size. This removes the need for changing compile settings for op-sqlite for Android.

These are more effort to add for RNQS, so I haven't added it there yet (need to modify react-native-quick-sqlite itself).