### PR TITLE
feat: Add FetchStrategy option to connect() for WebSockets

### DIFF
--- a/.changeset/angry-pumpkins-double.md
+++ b/.changeset/angry-pumpkins-double.md
@@ -1,0 +1,6 @@
+---
+'@powersync/react-native': minor
+'@powersync/common': minor
+---
+
+Introduced `fetchStrategy` option to connect, allowing you to choose either `buffered` or `sequential` for the Websocket connect option. Internally the functionality of `buffered` was used by default, but now it can be switched to the sequential mode. This changes the WebSocket sync queue to only process one sync event at a time, improving known keep-alive issues for lower-end hardware with minimal impact on sync performance.

--- a/.changeset/shiny-boxes-prove.md
+++ b/.changeset/shiny-boxes-prove.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Changed WebSocket sync queue by reducing pending events from 10 to 1, improving known keepalive issues with minimal impact on sync performance.

--- a/.changeset/shiny-boxes-prove.md
+++ b/.changeset/shiny-boxes-prove.md
@@ -1,5 +1,0 @@
----
-'@powersync/common': patch
----
-
-Changed WebSocket sync queue by reducing pending events from 10 to 1, improving known keepalive issues with minimal impact on sync performance.

--- a/packages/common/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/common/src/client/sync/stream/AbstractRemote.ts
@@ -21,13 +21,13 @@ export type RemoteConnector = {
 
 // Refresh at least 30 sec before it expires
 const REFRESH_CREDENTIALS_SAFETY_PERIOD_MS = 30_000;
-const SYNC_QUEUE_REQUEST_N = 10;
+const SYNC_QUEUE_REQUEST_N = 1;
 const SYNC_QUEUE_REQUEST_LOW_WATER = 5;
 
 // Keep alive message is sent every period
-const KEEP_ALIVE_MS = 20_000;
+const KEEP_ALIVE_MS = 60_000;
 // The ACK must be received in this period
-const KEEP_ALIVE_LIFETIME_MS = 30_000;
+const KEEP_ALIVE_LIFETIME_MS = 90_000;
 
 export const DEFAULT_REMOTE_LOGGER = Logger.get('PowerSyncRemote');
 

--- a/packages/react-native/src/sync/stream/ReactNativeRemote.ts
+++ b/packages/react-native/src/sync/stream/ReactNativeRemote.ts
@@ -9,6 +9,7 @@ import {
   FetchImplementation,
   FetchImplementationProvider,
   RemoteConnector,
+  SocketSyncStreamOptions,
   StreamingSyncLine,
   SyncStreamOptions
 } from '@powersync/common';
@@ -56,7 +57,7 @@ export class ReactNativeRemote extends AbstractRemote {
     return BSON;
   }
 
-  async socketStream(options: SyncStreamOptions): Promise<DataStream<StreamingSyncLine>> {
+  async socketStream(options: SocketSyncStreamOptions): Promise<DataStream<StreamingSyncLine>> {
     return super.socketStream(options);
   }
 


### PR DESCRIPTION
This allows the fetch strategy to be configured, with the actual functionality addition being the `sequential` option.

When specifying `sequential`:
Instead of queueing up multiple sync events (10 originally) before applying them, which would lead to less round-trips - we are configuring the queue size to 1, meaning each event will get processed individually before asking for the next.
This results in less overhead processing of the netword events (pending items) and should free up the web socket for better keep alive acknowledgements.

Currently this resolves a known issue on slower devices with large sync datasets.