### PR TITLE
fix(react-query): ensure useSuspenseQuery data is nonNullable

### DIFF
--- a/packages/tanstack-react-query/src/hooks/useQuery.ts
+++ b/packages/tanstack-react-query/src/hooks/useQuery.ts
@@ -32,7 +32,7 @@ export function useQuery<TData = unknown, TError = Tanstack.DefaultError>(
 export function useSuspenseQuery<TData = unknown, TError = Tanstack.DefaultError>(
   options: UseBaseQueryOptions<Tanstack.UseSuspenseQueryOptions<TData, TError>> & { query?: undefined },
   queryClient?: Tanstack.QueryClient
-): Tanstack.UseSuspenseQueryResult<TData, TError>;
+): Tanstack.UseSuspenseQueryResult<NonNullable<TData>, TError>;
 
 // Overload when 'query' is present
 export function useSuspenseQuery<TData = unknown, TError = Tanstack.DefaultError>(
@@ -40,7 +40,7 @@ export function useSuspenseQuery<TData = unknown, TError = Tanstack.DefaultError
     query: string | CompilableQuery<TData>;
   },
   queryClient?: Tanstack.QueryClient
-): Tanstack.UseSuspenseQueryResult<TData[], TError>;
+): Tanstack.UseSuspenseQueryResult<NonNullable<TData>[], TError>;
 
 export function useSuspenseQuery<TData = unknown, TError = Tanstack.DefaultError>(
   options: UseBaseQueryOptions<Tanstack.UseSuspenseQueryOptions<TData, TError>>,


### PR DESCRIPTION
This fixes #495

## Description
When providing a `queryFn` that returns potentially undefined data, the TypeScript definitions for `useSuspenseQuery` show the `data` property as potentially **undefined**. 

Since `useSuspenseQuery`, like React Query's own implementation, guarantees that data will be always available by throwing an error in case it is not, the set of types for `data` should not include **null** or **undefined**, regardless of the `queryFn`'s return value type definition. 

This PR updates the TypeScript definitions for `useSuspenseQuery` to correctly reflect that the returned data is always defined. 

## Changes
- Updated return type of `useSuspenseQuery` to use `NonNullable<TData>`
