### PR TITLE
Support bucket priorities

### DIFF
--- a/.changeset/friendly-chairs-camp.md
+++ b/.changeset/friendly-chairs-camp.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': minor
+---
+
+Support bucket priorities

--- a/packages/common/src/client/sync/bucket/BucketStorageAdapter.ts
+++ b/packages/common/src/client/sync/bucket/BucketStorageAdapter.ts
@@ -66,7 +66,10 @@ export interface BucketStorageAdapter extends BaseObserver<BucketStorageListener
 
   getBucketStates(): Promise<BucketState[]>;
 
-  syncLocalDatabase(checkpoint: Checkpoint, priority?: number): Promise<{ checkpointValid: boolean; ready: boolean; failures?: any[] }>;
+  syncLocalDatabase(
+    checkpoint: Checkpoint,
+    priority?: number
+  ): Promise<{ checkpointValid: boolean; ready: boolean; failures?: any[] }>;
 
   nextCrudItem(): Promise<CrudEntry | undefined>;
   hasCrud(): Promise<boolean>;

--- a/packages/common/src/client/sync/bucket/BucketStorageAdapter.ts
+++ b/packages/common/src/client/sync/bucket/BucketStorageAdapter.ts
@@ -3,6 +3,11 @@ import { CrudBatch } from './CrudBatch.js';
 import { CrudEntry, OpId } from './CrudEntry.js';
 import { SyncDataBatch } from './SyncDataBatch.js';
 
+export interface BucketDescription {
+  name: string;
+  priority: number;
+}
+
 export interface Checkpoint {
   last_op_id: OpId;
   buckets: BucketChecksum[];
@@ -27,6 +32,7 @@ export interface SyncLocalDatabaseResult {
 
 export interface BucketChecksum {
   bucket: string;
+  priority: number;
   /**
    * 32-bit unsigned hash.
    */
@@ -60,7 +66,7 @@ export interface BucketStorageAdapter extends BaseObserver<BucketStorageListener
 
   getBucketStates(): Promise<BucketState[]>;
 
-  syncLocalDatabase(checkpoint: Checkpoint): Promise<{ checkpointValid: boolean; ready: boolean; failures?: any[] }>;
+  syncLocalDatabase(checkpoint: Checkpoint, priority?: number): Promise<{ checkpointValid: boolean; ready: boolean; failures?: any[] }>;
 
   nextCrudItem(): Promise<CrudEntry | undefined>;
   hasCrud(): Promise<boolean>;

--- a/packages/common/src/client/sync/bucket/SqliteBucketStorage.ts
+++ b/packages/common/src/client/sync/bucket/SqliteBucketStorage.ts
@@ -186,20 +186,22 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
         }
       }
 
-      arg = JSON.stringify({priority, buckets: affectedBuckets});
+      arg = JSON.stringify({ priority, buckets: affectedBuckets });
     }
 
     return this.writeTransaction(async (tx) => {
       const { insertId: result } = await tx.execute('INSERT INTO powersync_operations(op, data) VALUES(?, ?)', [
         'sync_local',
-        arg,
+        arg
       ]);
       return result == 1;
     });
   }
 
   async validateChecksums(checkpoint: Checkpoint, priority: number | undefined): Promise<SyncLocalDatabaseResult> {
-    const rs = await this.db.execute('SELECT powersync_validate_checkpoint(?) as result', [JSON.stringify({...checkpoint, priority})]);
+    const rs = await this.db.execute('SELECT powersync_validate_checkpoint(?) as result', [
+      JSON.stringify({ ...checkpoint, priority })
+    ]);
 
     const resultItem = rs.rows?.item(0);
     this.logger.debug('validateChecksums result item', resultItem);

--- a/packages/common/src/client/sync/stream/streaming-sync-types.ts
+++ b/packages/common/src/client/sync/stream/streaming-sync-types.ts
@@ -116,6 +116,13 @@ export interface StreamingSyncCheckpointComplete {
   };
 }
 
+export interface StreamingSyncCheckpointPartiallyComplete {
+  partial_checkpoint_complete: {
+    priority: number;
+    last_op_id: OpId;
+  };
+}
+
 export interface StreamingSyncKeepalive {
   /** If specified, token expires in this many seconds. */
   token_expires_in: number;
@@ -126,6 +133,7 @@ export type StreamingSyncLine =
   | StreamingSyncCheckpoint
   | StreamingSyncCheckpointDiff
   | StreamingSyncCheckpointComplete
+  | StreamingSyncCheckpointPartiallyComplete
   | StreamingSyncKeepalive;
 
 export interface BucketRequest {
@@ -151,6 +159,10 @@ export function isStreamingSyncCheckpoint(line: StreamingSyncLine): line is Stre
 
 export function isStreamingSyncCheckpointComplete(line: StreamingSyncLine): line is StreamingSyncCheckpointComplete {
   return (line as StreamingSyncCheckpointComplete).checkpoint_complete != null;
+}
+
+export function isStreamingSyncCheckpointPartiallyComplete(line: StreamingSyncLine): line is StreamingSyncCheckpointPartiallyComplete {
+  return (line as StreamingSyncCheckpointPartiallyComplete).partial_checkpoint_complete != null;
 }
 
 export function isStreamingSyncCheckpointDiff(line: StreamingSyncLine): line is StreamingSyncCheckpointDiff {

--- a/packages/common/src/client/sync/stream/streaming-sync-types.ts
+++ b/packages/common/src/client/sync/stream/streaming-sync-types.ts
@@ -161,7 +161,9 @@ export function isStreamingSyncCheckpointComplete(line: StreamingSyncLine): line
   return (line as StreamingSyncCheckpointComplete).checkpoint_complete != null;
 }
 
-export function isStreamingSyncCheckpointPartiallyComplete(line: StreamingSyncLine): line is StreamingSyncCheckpointPartiallyComplete {
+export function isStreamingSyncCheckpointPartiallyComplete(
+  line: StreamingSyncLine
+): line is StreamingSyncCheckpointPartiallyComplete {
   return (line as StreamingSyncCheckpointPartiallyComplete).partial_checkpoint_complete != null;
 }
 

--- a/packages/common/src/db/DBAdapter.ts
+++ b/packages/common/src/db/DBAdapter.ts
@@ -103,7 +103,7 @@ export interface DBAdapter extends BaseObserverInterface<DBAdapterListener>, DBG
   writeTransaction: <T>(fn: (tx: Transaction) => Promise<T>, options?: DBLockOptions) => Promise<T>;
   /**
    * This method refreshes the schema information across all connections. This is for advanced use cases, and should generally not be needed.
-   */ 
+   */
   refreshSchema: () => Promise<void>;
 }
 

--- a/packages/common/src/db/crud/SyncStatus.ts
+++ b/packages/common/src/db/crud/SyncStatus.ts
@@ -5,9 +5,9 @@ export type SyncDataFlowStatus = Partial<{
 
 export interface SyncPriorityStatus {
   priority: number;
-  lastSyncedAt?: Date,
-  hasSynced?: boolean,
-};
+  lastSyncedAt?: Date;
+  hasSynced?: boolean;
+}
 
 export type SyncStatusOptions = {
   connected?: boolean;
@@ -15,7 +15,7 @@ export type SyncStatusOptions = {
   dataFlow?: SyncDataFlowStatus;
   lastSyncedAt?: Date;
   hasSynced?: boolean;
-  statusInPriority?: SyncPriorityStatus[],
+  statusInPriority?: SyncPriorityStatus[];
 };
 
 export class SyncStatus {
@@ -77,7 +77,7 @@ export class SyncStatus {
   /**
    * Reports a pair of {@link SyncStatus#hasSynced} and {@link SyncStatus#lastSyncedAt} fields that apply
    * to a specific bucket priority instead of the entire sync operation.
-   * 
+   *
    * When buckets with different priorities are declared, PowerSync may choose to synchronize higher-priority
    * buckets first. When a consistent view over all buckets for all priorities up until the given priority is
    * reached, PowerSync makes data from those buckets available before lower-priority buckets have finished
@@ -86,7 +86,7 @@ export class SyncStatus {
    * be consistent with that checkpoint. For this reason, this method may also return the status for lower priorities.
    * In a state where the PowerSync just finished synchronizing buckets in priority level 3, calling this method
    * with a priority of 1 may return information for priority level 3.
-   * 
+   *
    * @param priority The bucket priority for which the status should be reported.
    */
   statusForPriority(priority: number): SyncPriorityStatus {
@@ -102,7 +102,7 @@ export class SyncStatus {
     return {
       priority,
       lastSyncedAt: this.lastSyncedAt,
-      hasSynced: this.hasSynced,
+      hasSynced: this.hasSynced
     };
   }
 
@@ -122,7 +122,7 @@ export class SyncStatus {
       dataFlow: this.dataFlowStatus,
       lastSyncedAt: this.lastSyncedAt,
       hasSynced: this.hasSynced,
-      statusInPriority: this.options.statusInPriority,
+      statusInPriority: this.statusInPriority
     };
   }
 

--- a/packages/common/src/db/crud/SyncStatus.ts
+++ b/packages/common/src/db/crud/SyncStatus.ts
@@ -3,12 +3,19 @@ export type SyncDataFlowStatus = Partial<{
   uploading: boolean;
 }>;
 
+export interface SyncPriorityStatus {
+  priority: number;
+  lastSyncedAt?: Date,
+  hasSynced?: boolean,
+};
+
 export type SyncStatusOptions = {
   connected?: boolean;
   connecting?: boolean;
   dataFlow?: SyncDataFlowStatus;
   lastSyncedAt?: Date;
   hasSynced?: boolean;
+  statusInPriority?: SyncPriorityStatus[],
 };
 
 export class SyncStatus {
@@ -60,6 +67,45 @@ export class SyncStatus {
     );
   }
 
+  /**
+   * Partial sync status for involved bucket priorities.
+   */
+  get statusInPriority() {
+    return (this.options.statusInPriority ?? []).toSorted(SyncStatus.comparePriorities);
+  }
+
+  /**
+   * Reports a pair of {@link SyncStatus#hasSynced} and {@link SyncStatus#lastSyncedAt} fields that apply
+   * to a specific bucket priority instead of the entire sync operation.
+   * 
+   * When buckets with different priorities are declared, PowerSync may choose to synchronize higher-priority
+   * buckets first. When a consistent view over all buckets for all priorities up until the given priority is
+   * reached, PowerSync makes data from those buckets available before lower-priority buckets have finished
+   * synchronizing.
+   * When PowerSync makes data for a given priority available, all buckets in higher-priorities are guaranteed to
+   * be consistent with that checkpoint. For this reason, this method may also return the status for lower priorities.
+   * In a state where the PowerSync just finished synchronizing buckets in priority level 3, calling this method
+   * with a priority of 1 may return information for priority level 3.
+   * 
+   * @param priority The bucket priority for which the status should be reported.
+   */
+  statusForPriority(priority: number): SyncPriorityStatus {
+    // statusInPriority is sorted by ascending priorities (so higher numbers to lower numbers).
+    for (const known of this.statusInPriority) {
+      // We look for the first entry that doesn't have a higher priority.
+      if (known.priority >= priority) {
+        return known;
+      }
+    }
+
+    // If we have a complete sync, that necessarily includes all priorities.
+    return {
+      priority,
+      lastSyncedAt: this.lastSyncedAt,
+      hasSynced: this.hasSynced,
+    };
+  }
+
   isEqual(status: SyncStatus) {
     return JSON.stringify(this.options) == JSON.stringify(status.options);
   }
@@ -75,7 +121,12 @@ export class SyncStatus {
       connecting: this.connecting,
       dataFlow: this.dataFlowStatus,
       lastSyncedAt: this.lastSyncedAt,
-      hasSynced: this.hasSynced
+      hasSynced: this.hasSynced,
+      statusInPriority: this.options.statusInPriority,
     };
+  }
+
+  private static comparePriorities(a: SyncPriorityStatus, b: SyncPriorityStatus) {
+    return b.priority - a.priority; // Reverse because higher priorities have lower numbers
   }
 }

--- a/packages/common/tests/db/schema/Schema.test.ts
+++ b/packages/common/tests/db/schema/Schema.test.ts
@@ -35,7 +35,7 @@ describe('Schema', () => {
       }),
       posts: new Table({
         title: column.text,
-        content: column.text,
+        content: column.text
       })
     };
     const schema = new Schema(schemaDefinition);
@@ -62,7 +62,7 @@ describe('Schema', () => {
 
     const invalidSchema = new Schema({
       invalidTable: new Table({
-        'invalid name': column.text,
+        'invalid name': column.text
       })
     });
 
@@ -77,7 +77,7 @@ describe('Schema', () => {
       }),
       posts: new Table({
         title: column.text,
-        content: column.text,
+        content: column.text
       })
     });
 

--- a/packages/web/src/db/sync/SSRWebStreamingSyncImplementation.ts
+++ b/packages/web/src/db/sync/SSRWebStreamingSyncImplementation.ts
@@ -52,7 +52,14 @@ export class SSRStreamingSyncImplementation extends BaseObserver implements Stre
    * This will never resolve in SSR Mode.
    */
   async waitForStatus(status: SyncStatusOptions) {
-    return new Promise<void>((r) => {});
+    return this.waitUntilStatusMatches(() => false);
+  }
+
+  /**
+   * This will never resolve in SSR Mode.
+   */
+  waitUntilStatusMatches(_predicate: (status: SyncStatus) => boolean): Promise<void> {
+    return new Promise<void>(() => {});
   }
 
   /**

--- a/packages/web/src/worker/sync/SharedSyncImplementation.ts
+++ b/packages/web/src/worker/sync/SharedSyncImplementation.ts
@@ -128,6 +128,11 @@ export class SharedSyncImplementation
     return this.syncStreamClient!.waitForStatus(status);
   }
 
+  async waitUntilStatusMatches(predicate: (status: SyncStatus) => boolean): Promise<void> {
+    await this.waitForReady();
+    return this.syncStreamClient!.waitUntilStatusMatches(predicate);
+  }
+
   get lastSyncedAt(): Date | undefined {
     return this.syncStreamClient?.lastSyncedAt;
   }

--- a/packages/web/tests/bucket_storage.test.ts
+++ b/packages/web/tests/bucket_storage.test.ts
@@ -119,7 +119,7 @@ describe('Bucket Storage', () => {
 
     await syncLocalChecked({
       last_op_id: '3',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
 
     await expectAsset1_3();
@@ -136,8 +136,8 @@ describe('Bucket Storage', () => {
     await syncLocalChecked({
       last_op_id: '3',
       buckets: [
-        { bucket: 'bucket1', checksum: 3 },
-        { bucket: 'bucket2', checksum: 3 }
+        { bucket: 'bucket1', checksum: 3, priority: 3 },
+        { bucket: 'bucket2', checksum: 3, priority: 3 }
       ]
     });
     await expectAsset1_3();
@@ -158,8 +158,8 @@ describe('Bucket Storage', () => {
     await syncLocalChecked({
       last_op_id: '3',
       buckets: [
-        { bucket: 'bucket1', checksum: 3 },
-        { bucket: 'bucket2', checksum: 1 }
+        { bucket: 'bucket1', checksum: 3, priority: 3 },
+        { bucket: 'bucket2', checksum: 1, priority: 3 }
       ]
     });
     await expectAsset1_3();
@@ -177,8 +177,8 @@ describe('Bucket Storage', () => {
     await syncLocalChecked({
       last_op_id: '4',
       buckets: [
-        { bucket: 'bucket1', checksum: 3 },
-        { bucket: 'bucket2', checksum: 7 }
+        { bucket: 'bucket1', checksum: 3, priority: 3 },
+        { bucket: 'bucket2', checksum: 7, priority: 3 }
       ]
     });
     await expectAsset1_3();
@@ -196,8 +196,8 @@ describe('Bucket Storage', () => {
     await syncLocalChecked({
       last_op_id: '5',
       buckets: [
-        { bucket: 'bucket1', checksum: 8 },
-        { bucket: 'bucket2', checksum: 7 }
+        { bucket: 'bucket1', checksum: 8, priority: 3 },
+        { bucket: 'bucket2', checksum: 7, priority: 3 }
       ]
     });
 
@@ -232,7 +232,7 @@ describe('Bucket Storage', () => {
 
     await syncLocalChecked({
       last_op_id: '4',
-      buckets: [{ bucket: 'bucket1', checksum: 8 }]
+      buckets: [{ bucket: 'bucket1', checksum: 8, priority: 3 }]
     });
 
     expect(await db.getAll("SELECT id, description, make FROM assets WHERE id = 'O1'")).deep.equals([
@@ -243,7 +243,7 @@ describe('Bucket Storage', () => {
 
     await syncLocalChecked({
       last_op_id: '5',
-      buckets: [{ bucket: 'bucket1', checksum: 13 }]
+      buckets: [{ bucket: 'bucket1', checksum: 13, priority: 3 }]
     });
 
     await expectAsset1_3();
@@ -258,8 +258,8 @@ describe('Bucket Storage', () => {
     const result = await bucketStorage.syncLocalDatabase({
       last_op_id: '3',
       buckets: [
-        { bucket: 'bucket1', checksum: 10 },
-        { bucket: 'bucket2', checksum: 1 }
+        { bucket: 'bucket1', checksum: 10, priority: 3 },
+        { bucket: 'bucket2', checksum: 1, priority: 3 }
       ]
     });
 
@@ -285,7 +285,7 @@ describe('Bucket Storage', () => {
 
     await syncLocalChecked({
       last_op_id: '3',
-      buckets: [{ bucket: 'bucket1', checksum: 3 }]
+      buckets: [{ bucket: 'bucket1', checksum: 3, priority: 3 }]
     });
 
     // Bucket is deleted, but object is still present in other buckets.
@@ -319,7 +319,7 @@ describe('Bucket Storage', () => {
     // Check that the data is there
     await syncLocalChecked({
       last_op_id: '3',
-      buckets: [{ bucket: 'bucket1', checksum: 4 }]
+      buckets: [{ bucket: 'bucket1', checksum: 4, priority: 3 }]
     });
     await expectAsset1_3();
 
@@ -350,7 +350,7 @@ describe('Bucket Storage', () => {
 
     await syncLocalChecked({
       last_op_id: '3',
-      buckets: [{ bucket: 'bucket1', checksum: 4 }]
+      buckets: [{ bucket: 'bucket1', checksum: 4, priority: 3 }]
     });
 
     await expectAsset1_3();
@@ -362,7 +362,7 @@ describe('Bucket Storage', () => {
 
     await syncLocalChecked({
       last_op_id: '1',
-      buckets: [{ bucket: 'bucket1', checksum: 1 }]
+      buckets: [{ bucket: 'bucket1', checksum: 1, priority: 3 }]
     });
 
     // CLEAR, then save new data
@@ -393,7 +393,7 @@ describe('Bucket Storage', () => {
     await syncLocalChecked({
       last_op_id: '3',
       // 2 + 3. 1 is replaced with 2.
-      buckets: [{ bucket: 'bucket1', checksum: 5 }]
+      buckets: [{ bucket: 'bucket1', checksum: 5, priority: 3 }]
     });
 
     await expectNoAsset1();
@@ -425,7 +425,7 @@ describe('Bucket Storage', () => {
 
     await syncLocalChecked({
       last_op_id: '4',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
 
     await expect(powersync.getAll('SELECT * FROM assets')).rejects.toThrow('no such table');
@@ -469,7 +469,7 @@ describe('Bucket Storage', () => {
 
     await syncLocalChecked({
       last_op_id: '3',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
 
     await expectAsset1_3(powersync);
@@ -510,7 +510,7 @@ describe('Bucket Storage', () => {
     await syncLocalChecked({
       last_op_id: '4',
       write_checkpoint: '4',
-      buckets: [{ bucket: 'bucket1', checksum: 7 }]
+      buckets: [{ bucket: 'bucket1', checksum: 7, priority: 3 }]
     });
 
     await bucketStorage.forceCompact();
@@ -518,7 +518,7 @@ describe('Bucket Storage', () => {
     await syncLocalChecked({
       last_op_id: '4',
       write_checkpoint: '4',
-      buckets: [{ bucket: 'bucket1', checksum: 7 }]
+      buckets: [{ bucket: 'bucket1', checksum: 7, priority: 3 }]
     });
 
     const stats = await db.getAll(
@@ -534,7 +534,7 @@ describe('Bucket Storage', () => {
 
     await syncLocalChecked({
       last_op_id: '3',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
 
     // Local save
@@ -545,7 +545,7 @@ describe('Bucket Storage', () => {
     const result = await bucketStorage.syncLocalDatabase({
       last_op_id: '3',
       write_checkpoint: '3',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
 
     expect(result).deep.equals({ ready: false, checkpointValid: true });
@@ -560,7 +560,7 @@ describe('Bucket Storage', () => {
     const result3 = await bucketStorage.syncLocalDatabase({
       last_op_id: '3',
       write_checkpoint: '3',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
     expect(result3).deep.equals({ ready: false, checkpointValid: true });
 
@@ -574,7 +574,7 @@ describe('Bucket Storage', () => {
     await syncLocalChecked({
       last_op_id: '5',
       write_checkpoint: '5',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
 
     // Since the object was not in the sync response, it is deleted.
@@ -589,7 +589,7 @@ describe('Bucket Storage', () => {
     await syncLocalChecked({
       last_op_id: '3',
       write_checkpoint: '3',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
 
     // Local save
@@ -604,7 +604,7 @@ describe('Bucket Storage', () => {
     const result3 = await bucketStorage.syncLocalDatabase({
       last_op_id: '3',
       write_checkpoint: '3',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
     expect(result3).deep.equals({ ready: false, checkpointValid: true });
 
@@ -616,7 +616,7 @@ describe('Bucket Storage', () => {
     const result4 = await bucketStorage.syncLocalDatabase({
       last_op_id: '5',
       write_checkpoint: '5',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
     expect(result4).deep.equals({ ready: false, checkpointValid: true });
   });
@@ -629,7 +629,7 @@ describe('Bucket Storage', () => {
     await syncLocalChecked({
       last_op_id: '3',
       write_checkpoint: '3',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
 
     // Local save
@@ -648,7 +648,7 @@ describe('Bucket Storage', () => {
     const result4 = await bucketStorage.syncLocalDatabase({
       last_op_id: '5',
       write_checkpoint: '5',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
     expect(result4).deep.equals({ ready: false, checkpointValid: true });
   });
@@ -661,7 +661,7 @@ describe('Bucket Storage', () => {
     await syncLocalChecked({
       last_op_id: '3',
       write_checkpoint: '3',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
 
     // Local save
@@ -694,7 +694,7 @@ describe('Bucket Storage', () => {
     await syncLocalChecked({
       last_op_id: '5',
       write_checkpoint: '5',
-      buckets: [{ bucket: 'bucket1', checksum: 11 }]
+      buckets: [{ bucket: 'bucket1', checksum: 11, priority: 3 }]
     });
 
     expect(await db.getAll("SELECT description FROM assets WHERE id = 'O3'")).deep.equals([
@@ -710,7 +710,7 @@ describe('Bucket Storage', () => {
     await syncLocalChecked({
       last_op_id: '3',
       write_checkpoint: '3',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
 
     // Local insert, later rejected by server
@@ -728,7 +728,7 @@ describe('Bucket Storage', () => {
     await syncLocalChecked({
       last_op_id: '3',
       write_checkpoint: '4',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
 
     expect(await db.getAll("SELECT description FROM assets WHERE id = 'O3'")).empty;
@@ -742,7 +742,7 @@ describe('Bucket Storage', () => {
     await syncLocalChecked({
       last_op_id: '3',
       write_checkpoint: '3',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
 
     // Local delete, later rejected by server
@@ -760,7 +760,7 @@ describe('Bucket Storage', () => {
     await syncLocalChecked({
       last_op_id: '3',
       write_checkpoint: '4',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
 
     expect(await db.getAll("SELECT description FROM assets WHERE id = 'O2'")).deep.equals([{ description: 'bar' }]);
@@ -774,7 +774,7 @@ describe('Bucket Storage', () => {
     await syncLocalChecked({
       last_op_id: '3',
       write_checkpoint: '3',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
 
     // Local update, later rejected by server
@@ -792,7 +792,7 @@ describe('Bucket Storage', () => {
     await syncLocalChecked({
       last_op_id: '3',
       write_checkpoint: '4',
-      buckets: [{ bucket: 'bucket1', checksum: 6 }]
+      buckets: [{ bucket: 'bucket1', checksum: 6, priority: 3 }]
     });
 
     expect(await db.getAll("SELECT description FROM assets WHERE id = 'O2'")).deep.equals([{ description: 'bar' }]);

--- a/packages/web/tests/utils/MockStreamOpenFactory.ts
+++ b/packages/web/tests/utils/MockStreamOpenFactory.ts
@@ -33,7 +33,7 @@ export class TestConnector implements PowerSyncBackendConnector {
 }
 
 export class MockRemote extends AbstractRemote {
-  streamController: ReadableStreamDefaultController | null;
+  streamController: ReadableStreamDefaultController<StreamingSyncLine> | null;
 
   constructor(
     connector: RemoteConnector,
@@ -118,6 +118,10 @@ export class MockRemote extends AbstractRemote {
     });
 
     return stream;
+  }
+
+  enqueueLine(line: StreamingSyncLine) {
+    this.streamController?.enqueue(line);
   }
 }
 


### PR DESCRIPTION
Support bucket priorities by recognizing partial checkpoint complete messages and forwarding their status to the core extension.

This requires rolling version 0.3.10 of the core extension into this repository first.