### PR TITLE
Opfs uploads

### DIFF
--- a/.changeset/forty-moose-yell.md
+++ b/.changeset/forty-moose-yell.md
@@ -1,0 +1,5 @@
+---
+'@powersync/web': patch
+---
+
+Fixed bug where using OPFS and reconnecting would cause upload triggers to fail.

--- a/packages/web/src/worker/sync/SharedSyncImplementation.ts
+++ b/packages/web/src/worker/sync/SharedSyncImplementation.ts
@@ -71,10 +71,7 @@ export type WrappedSyncPort = {
 /**
  * @internal
  */
-export type RemoteOperationAbortController = {
-  controller: AbortController;
-  activePort: WrappedSyncPort;
-};
+export type RemoteOperationAbortController = { controller: AbortController; activePort: WrappedSyncPort };
 
 /**
  * @internal
@@ -180,6 +177,9 @@ export class SharedSyncImplementation
     await this.waitForReady();
     // This effectively queues connect and disconnect calls. Ensuring multiple tabs' requests are synchronized
     return getNavigatorLocks().request('shared-sync-connect', async () => {
+      if (!this.dbAdapter) {
+        await this.openInternalDB();
+      }
       this.syncStreamClient = this.generateStreamingImplementation();
       this.lastConnectOptions = options;
       this.syncStreamClient.registerListener({
@@ -206,10 +206,7 @@ export class SharedSyncImplementation
    * Adds a new client tab's message port to the list of connected ports
    */
   addPort(port: MessagePort) {
-    const portProvider = {
-      port,
-      clientProvider: Comlink.wrap<AbstractSharedSyncClientProvider>(port)
-    };
+    const portProvider = { port, clientProvider: Comlink.wrap<AbstractSharedSyncClientProvider>(port) };
     this.ports.push(portProvider);
 
     // Give the newly connected client the latest status
@@ -231,12 +228,7 @@ export class SharedSyncImplementation
     }
 
     const trackedPort = this.ports[index];
-    if (trackedPort.db) {
-      trackedPort.db.close();
-    }
-
-    // Release proxy
-    trackedPort.clientProvider[Comlink.releaseProxy]();
+    // Remove from the list of active ports
     this.ports.splice(index, 1);
 
     /**
@@ -249,12 +241,25 @@ export class SharedSyncImplementation
       }
     });
 
-    if (this.dbAdapter == trackedPort.db && this.syncStreamClient) {
-      await this.disconnect();
-      // Ask for a new DB worker port handler
-      await this.openInternalDB();
-      await this.connect(this.lastConnectOptions);
+    const shouldReconnect = !!this.syncStreamClient;
+    if (this.dbAdapter && this.dbAdapter == trackedPort.db) {
+      if (shouldReconnect) {
+        await this.disconnect();
+      }
+
+      // Clearing the adapter will result in a new one being opened in connect
+      this.dbAdapter = null;
+
+      if (shouldReconnect) {
+        await this.connect(this.lastConnectOptions);
+      }
     }
+
+    if (trackedPort.db) {
+      trackedPort.db.close();
+    }
+    // Release proxy
+    trackedPort.clientProvider[Comlink.releaseProxy]();
   }
 
   triggerCrudUpload() {
@@ -288,10 +293,7 @@ export class SharedSyncImplementation
           const lastPort = this.ports[this.ports.length - 1];
           return new Promise(async (resolve, reject) => {
             const abortController = new AbortController();
-            this.fetchCredentialsController = {
-              controller: abortController,
-              activePort: lastPort
-            };
+            this.fetchCredentialsController = { controller: abortController, activePort: lastPort };
 
             abortController.signal.onabort = reject;
             try {
@@ -310,10 +312,7 @@ export class SharedSyncImplementation
 
         return new Promise(async (resolve, reject) => {
           const abortController = new AbortController();
-          this.uploadDataController = {
-            controller: abortController,
-            activePort: lastPort
-          };
+          this.uploadDataController = { controller: abortController, activePort: lastPort };
 
           // Resolving will make it retry
           abortController.signal.onabort = () => resolve();
@@ -334,6 +333,10 @@ export class SharedSyncImplementation
 
   protected async openInternalDB() {
     const lastClient = this.ports[this.ports.length - 1];
+    if (!lastClient) {
+      // Should not really happen in practice
+      throw new Error(`Could not open DB connection since no client is connected.`);
+    }
     const workerPort = await lastClient.clientProvider.getDBWorkerPort();
     const remote = Comlink.wrap<OpenAsyncDatabaseConnection>(workerPort);
     const identifier = this.syncParams!.dbParams.dbFilename;
@@ -341,11 +344,7 @@ export class SharedSyncImplementation
     const locked = new LockedAsyncDatabaseAdapter({
       name: identifier,
       openConnection: async () => {
-        return new WorkerWrappedAsyncDatabaseConnection({
-          remote,
-          baseConnection: db,
-          identifier
-        });
+        return new WorkerWrappedAsyncDatabaseConnection({ remote, baseConnection: db, identifier });
       },
       logger: this.logger
     });


### PR DESCRIPTION
# Overview

A bug was identified when using OPFS as the SQLite VFS. When reconnecting with different client parameters, the PowerSync client failed to trigger CRUD uploads, preventing data from being uploaded. This issue occurred only when multiple tab support was enabled (the default).

The root cause was the shared sync worker using a stale database connection after a reconnect. The sync manager's logic for obtaining a database connection has been updated to ensure a valid connection is always used when a client disconnects or reconnects.

Relevant unit tests were updated to include OPFS.

## TODOs
- [ ] Investigate weird formatting changes
