### PR TITLE
chore: Removed last executeAsync usages in group-chat demo project.

### DIFF
--- a/demos/react-native-supabase-group-chat/src/app/(app)/(chats)/g/create.tsx
+++ b/demos/react-native-supabase-group-chat/src/app/(app)/(chats)/g/create.tsx
@@ -26,14 +26,14 @@ export default function CreateGroup() {
 
     await powerSync.writeTransaction(async (tx) => {
       try {
-        await tx.executeAsync('INSERT INTO groups (id, owner_id, name, created_at) VALUES (?, ?, ?, datetime())', [
+        await tx.execute('INSERT INTO groups (id, owner_id, name, created_at) VALUES (?, ?, ?, datetime())', [
           groupId,
           user?.id,
           name
         ]);
         for (const profileId of selectedContacts) {
           const membershipId = uuid();
-          await tx.executeAsync(
+          await tx.execute(
             'INSERT INTO memberships (id, group_id, profile_id, created_at) VALUES (?, ?, ?, datetime())',
             [membershipId, groupId, profileId]
           );

--- a/demos/react-native-supabase-group-chat/src/app/(app)/contacts/index.tsx
+++ b/demos/react-native-supabase-group-chat/src/app/(app)/contacts/index.tsx
@@ -41,21 +41,6 @@ export default function ContactsIndex() {
       ownerId,
       profileId
     ]);
-
-    /* await powerSync.writeTransaction(async (tx) => {
-      try {
-        tx.executeAsync(
-          "INSERT INTO profiles (id, name, handle, demo) VALUES (?, ?, ?, ?)",
-          [profileId, name, handle, true],
-        );
-        tx.executeAsync(
-          "INSERT INTO contacts (id, owner_id, profile_id) VALUES (?, ?, ?)",
-          [contactId, ownerId, profileId],
-        );
-      } catch (error) {
-        console.error("Error", error);
-      }
-    }); */
   }
 
   async function handleAddContact(profileId: string, name: string, handle: string) {


### PR DESCRIPTION
A user reported the use of the removed/deprecated `executeAsync` function in a demo which has now be replaced by `execute`. Minor cleanup.

Original issue: https://github.com/powersync-ja/powersync-js/issues/509