### PR TITLE
Rename `priorityStatuses` -> `priorityStatusEntries`

### DIFF
--- a/packages/common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/common/src/client/AbstractPowerSyncDatabase.ts
@@ -352,7 +352,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
       'SELECT priority, last_synced_at FROM ps_sync_state ORDER BY priority DESC'
     );
     let lastCompleteSync: Date | undefined;
-    const priorityStatuses: SyncPriorityStatus[] = [];
+    const priorityStatusEntries: SyncPriorityStatus[] = [];
 
     for (const { priority, last_synced_at } of result) {
       const parsedDate = new Date(last_synced_at + 'Z');
@@ -361,7 +361,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
         // This lowest-possible priority represents a complete sync.
         lastCompleteSync = parsedDate;
       } else {
-        priorityStatuses.push({ priority, hasSynced: true, lastSyncedAt: parsedDate });
+        priorityStatusEntries.push({ priority, hasSynced: true, lastSyncedAt: parsedDate });
       }
     }
 
@@ -369,7 +369,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
     const updatedStatus = new SyncStatus({
       ...this.currentStatus.toJSON(),
       hasSynced,
-      priorityStatuses,
+      priorityStatusEntries,
       lastSyncedAt: lastCompleteSync
     });
 

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -610,7 +610,7 @@ The next upload iteration will be delayed.`);
               this.logger.debug('partial checkpoint validation succeeded');
 
               // All states with a higher priority can be deleted since this partial sync includes them.
-              const priorityStates = this.syncStatus.priorityStatuses.filter((s) => s.priority <= priority);
+              const priorityStates = this.syncStatus.priorityStatusEntries.filter((s) => s.priority <= priority);
               priorityStates.push({
                 priority,
                 lastSyncedAt: new Date(),
@@ -619,7 +619,7 @@ The next upload iteration will be delayed.`);
 
               this.updateSyncStatus({
                 connected: true,
-                priorityStatuses: priorityStates
+                priorityStatusEntries: priorityStates
               });
             }
           } else if (isStreamingSyncCheckpointDiff(line)) {
@@ -688,7 +688,7 @@ The next upload iteration will be delayed.`);
               this.updateSyncStatus({
                 connected: true,
                 lastSyncedAt: new Date(),
-                priorityStatuses: []
+                priorityStatusEntries: []
               });
             } else if (validatedCheckpoint === targetCheckpoint) {
               const result = await this.options.adapter.syncLocalDatabase(targetCheckpoint!);
@@ -705,7 +705,7 @@ The next upload iteration will be delayed.`);
                 this.updateSyncStatus({
                   connected: true,
                   lastSyncedAt: new Date(),
-                  priorityStatuses: [],
+                  priorityStatusEntries: [],
                   dataFlow: {
                     downloading: false
                   }
@@ -730,7 +730,7 @@ The next upload iteration will be delayed.`);
         ...this.syncStatus.dataFlowStatus,
         ...options.dataFlow
       },
-      priorityStatuses: options.priorityStatuses ?? this.syncStatus.priorityStatuses
+      priorityStatusEntries: options.priorityStatusEntries ?? this.syncStatus.priorityStatusEntries
     });
 
     if (!this.syncStatus.isEqual(updatedStatus)) {

--- a/packages/common/src/db/crud/SyncStatus.ts
+++ b/packages/common/src/db/crud/SyncStatus.ts
@@ -15,7 +15,7 @@ export type SyncStatusOptions = {
   dataFlow?: SyncDataFlowStatus;
   lastSyncedAt?: Date;
   hasSynced?: boolean;
-  priorityStatuses?: SyncPriorityStatus[];
+  priorityStatusEntries?: SyncPriorityStatus[];
 };
 
 export class SyncStatus {
@@ -70,8 +70,8 @@ export class SyncStatus {
   /**
    * Partial sync status for involved bucket priorities.
    */
-  get priorityStatuses() {
-    return (this.options.priorityStatuses ?? []).toSorted(SyncStatus.comparePriorities);
+  get priorityStatusEntries() {
+    return (this.options.priorityStatusEntries ?? []).toSorted(SyncStatus.comparePriorities);
   }
 
   /**
@@ -90,8 +90,8 @@ export class SyncStatus {
    * @param priority The bucket priority for which the status should be reported.
    */
   statusForPriority(priority: number): SyncPriorityStatus {
-    // priorityStatuses are sorted by ascending priorities (so higher numbers to lower numbers).
-    for (const known of this.priorityStatuses) {
+    // priorityStatusEntries are sorted by ascending priorities (so higher numbers to lower numbers).
+    for (const known of this.priorityStatusEntries) {
       // We look for the first entry that doesn't have a higher priority.
       if (known.priority >= priority) {
         return known;
@@ -122,7 +122,7 @@ export class SyncStatus {
       dataFlow: this.dataFlowStatus,
       lastSyncedAt: this.lastSyncedAt,
       hasSynced: this.hasSynced,
-      priorityStatuses: this.priorityStatuses
+      priorityStatusEntries: this.priorityStatusEntries
     };
   }
 

--- a/packages/web/tests/stream.test.ts
+++ b/packages/web/tests/stream.test.ts
@@ -249,7 +249,7 @@ describe(
         });
         await another.init();
 
-        expect(another.currentStatus.priorityStatuses).toHaveLength(1);
+        expect(another.currentStatus.priorityStatusEntries).toHaveLength(1);
         expect(another.currentStatus.statusForPriority(0).hasSynced).toBeTruthy();
         await another.waitForFirstSync({ priority: 0 });
       });


### PR DESCRIPTION
This makes the API changes for bucket priorities consistent across the three SDKs that implement them:

1. List of entries for each priority status: `priorityStatusEntries` on `SyncStatus`.
2. Resolving the state for a priority: `statusForPriority` on `SyncStatus`.
3. Waiting for a sync to complete: Named `priority` argument on `PowerSyncDatabase.waitForFirstSync`.
