### PR TITLE
Raise minimum version for core extension

### DIFF
--- a/.changeset/mighty-guests-lick.md
+++ b/.changeset/mighty-guests-lick.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Raise minimum version of core extension to 0.3.11

--- a/packages/common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/common/src/client/AbstractPowerSyncDatabase.ts
@@ -337,13 +337,13 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
         .map((n) => parseInt(n));
     } catch (e) {
       throw new Error(
-        `Unsupported powersync extension version. Need >=0.2.0 <1.0.0, got: ${this.sdkVersion}. Details: ${e.message}`
+        `Unsupported powersync extension version. Need >=0.3.11 <1.0.0, got: ${this.sdkVersion}. Details: ${e.message}`
       );
     }
 
-    // Validate >=0.2.0 <1.0.0
-    if (versionInts[0] != 0 || versionInts[1] < 2 || versionInts[2] < 0) {
-      throw new Error(`Unsupported powersync extension version. Need >=0.2.0 <1.0.0, got: ${this.sdkVersion}`);
+    // Validate >=0.3.11 <1.0.0
+    if (versionInts[0] != 0 || versionInts[1] < 3 || (versionInts[1] == 3 && versionInts[2] < 11)) {
+      throw new Error(`Unsupported powersync extension version. Need >=0.3.11 <1.0.0, got: ${this.sdkVersion}`);
     }
   }
 

--- a/packages/web/tests/src/db/AbstractPowerSyncDatabase.test.ts
+++ b/packages/web/tests/src/db/AbstractPowerSyncDatabase.test.ts
@@ -33,7 +33,7 @@ class TestPowerSyncDatabase extends AbstractPowerSyncDatabase {
 
   get database() {
     return {
-      get: vi.fn().mockResolvedValue({ version: '0.3.0' }),
+      get: vi.fn().mockResolvedValue({ version: '0.3.11' }),
       getAll: vi.fn().mockResolvedValue([]),
       execute: vi.fn(),
       refreshSchema: vi.fn()


### PR DESCRIPTION
Because we're now reading from the `ps_sync_state` to restore the `lastSyncedAt` information, we need version 0.3.11 of the core extensions or newer. This adopts the version check accordingly.