### PR TITLE
Fix useQuery race condition for initial query.

### DIFF
--- a/.changeset/slimy-glasses-jog.md
+++ b/.changeset/slimy-glasses-jog.md
@@ -1,0 +1,6 @@
+---
+'@powersync/react': patch
+'@powersync/react-native': patch
+---
+
+Fixed an issue with `useQuery` where initial query/parameter changes could cause a race condition if the first query took long.


### PR DESCRIPTION
Using the following snippet (originally reported [here](https://github.com/powersync-ja/powersync-js/issues/517)) that applies a filter in a useEffect to a query to make the result set smaller:
 
```
function GetUsers() {
  const [userFilter, setUserFilter] = useState<string>()
  let query = db.selectFrom("User").selectAll()

  if (userFilter) {
    query = query.where("id", "=", userFilter)
  }

  const { data } = useQuery(query)
  console.log("GetUsers result", userFilter, data.length)

  useEffect(() => {
    setUserFilter("500")
  }, [])

  return <Text>Data length: {data.length}</Text>
}
```

The first query that was fired without the filter from the `if` finishes last meaning query order and result order ends up not being the same. Giving the following output:
 ```
 GetUsers result 500 0
 GetUsers result 500 0
 GetUsers result 500 1
 GetUsers result 500 10000 <-- XXX
``` 
Where the user would expect `1` since it would be the result for the last query fired.

This code change aborts the initial query if a new one was fired, so we now get the following output: 
```
GetUsers result 500 0
GetUsers result 500 0
GetUsers result 500 1
```

Changeset has been tested on the reported issue.