### PR TITLE
Add changeset for attachment readme update

### DIFF
--- a/.changeset/modern-lobsters-sell.md
+++ b/.changeset/modern-lobsters-sell.md
@@ -1,0 +1,5 @@
+---
+'@powersync/attachments': patch
+---
+
+Fix README link for StorageAdapter source file (https://github.com/powersync-ja/powersync-js/blob/main/packages/attachments/src/StorageAdapter.ts)


### PR DESCRIPTION
The original [PR](https://github.com/powersync-ja/powersync-js/pull/451) did not contain a changeset so the updated README did not reflect on npm.