### PR TITLE
Add alpha release hints to node package

### DIFF
--- a/.changeset/tame-boats-hammer.md
+++ b/.changeset/tame-boats-hammer.md
@@ -1,0 +1,5 @@
+---
+'@powersync/node': patch
+---
+
+Update readme to reflect alpha status.

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -11,6 +11,10 @@ Using this package is not necessary for PowerSync on servers, see [our documenta
 
 This package has an API similar to the PowerSync web SDK, for which a summary of features is available [here](https://docs.powersync.com/client-sdk-references/js-web).
 
+## Alpha Release
+
+The `@powersync/node` package is currently in an Alpha release.
+
 # Installation
 
 ## Install Package


### PR DESCRIPTION
Add a section to the readme explaining that the package is in an Alpha release at the moment.