### PR TITLE
Use consistent package descriptions for SDK packages

### DIFF
--- a/.changeset/grumpy-panthers-own.md
+++ b/.changeset/grumpy-panthers-own.md
@@ -1,0 +1,7 @@
+---
+'@powersync/react-native': patch
+'@powersync/node': patch
+'@powersync/web': patch
+---
+
+Update package description

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -5,7 +5,7 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
-  "description": "PowerSync - sync Postgres with SQLite in your Node.js app for offline-first and real-time data",
+  "description": "PowerSync Node.js SDK. Sync Postgres, MongoDB or MySQL with SQLite in your Node.js app",
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -5,7 +5,7 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
-  "description": "PowerSync - sync Postgres with SQLite in your React Native app for offline-first and real-time data",
+  "description": "PowerSync React Native SDK. Sync Postgres, MongoDB or MySQL with SQLite in your React Native app",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./lib/index.d.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@powersync/web",
   "version": "1.15.0",
-  "description": "A Web SDK for JourneyApps PowerSync",
+  "description": "PowerSync web SDK. Sync Postgres, MongoDB or MySQL with SQLite in your web app",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
   "bin": {


### PR DESCRIPTION
Following the suggestion from @kobiebotha, this standardizes the package description for SDK entrypoint packages to "PowerSync ${Framework} SDK. Sync Postgres, MongoDB or MySQL with SQLite in your ${Framework} app".