### PR TITLE
feat: Added attachmentTableName option

### DIFF
--- a/.changeset/slimy-mice-invite.md
+++ b/.changeset/slimy-mice-invite.md
@@ -1,0 +1,5 @@
+---
+'@powersync/attachments': minor
+---
+
+Added `attachmentTableName` option to attachment queue which allows you to specify the table name it should work with.

--- a/packages/attachments/src/AbstractAttachmentQueue.ts
+++ b/packages/attachments/src/AbstractAttachmentQueue.ts
@@ -14,9 +14,14 @@ export interface AttachmentQueueOptions {
    */
   cacheLimit?: number;
   /**
-   * The name of the directory where attachments are stored on the device, not the full path
+   * The name of the directory where attachments are stored on the device, not the full path. Defaults to `attachments`.
    */
   attachmentDirectoryName?: string;
+
+  /**
+   * The name of the table where attachments are stored, defaults to `attachments` table.
+   */
+  attachmentTableName?: string;
   /**
    * Whether to mark the initial watched attachment IDs to be synced
    */
@@ -36,7 +41,8 @@ export interface AttachmentQueueOptions {
 }
 
 export const DEFAULT_ATTACHMENT_QUEUE_OPTIONS: Partial<AttachmentQueueOptions> = {
-  attachmentDirectoryName: 'attachments',
+  attachmentDirectoryName: ATTACHMENT_TABLE,
+  attachmentTableName: ATTACHMENT_TABLE,
   syncInterval: 30_000,
   cacheLimit: 100,
   performInitialSync: true,
@@ -90,7 +96,7 @@ export abstract class AbstractAttachmentQueue<T extends AttachmentQueueOptions =
   }
 
   get table() {
-    return ATTACHMENT_TABLE;
+    return this.options.attachmentTableName!;
   }
 
   async init() {


### PR DESCRIPTION
The attachment queue always pointed to the hardcoded `attachments` table. This allows the developer to override the target table. 

Alternative approach to https://github.com/powersync-ja/powersync-js/pull/523, which was originally reported in https://github.com/powersync-ja/powersync-js/issues/522.

Update: Verified working on the reporter's side.