### PR TITLE
fix: Web encryption crashing on init.

### DIFF
--- a/.changeset/new-doors-unite.md
+++ b/.changeset/new-doors-unite.md
@@ -1,0 +1,5 @@
+---
+'@powersync/web': patch
+---
+
+Ensuring encryption pragma executes before setting cache size, fixes issue where encryption would throw an error during initialization.

--- a/packages/web/src/db/adapters/wa-sqlite/WASQLiteConnection.ts
+++ b/packages/web/src/db/adapters/wa-sqlite/WASQLiteConnection.ts
@@ -235,8 +235,8 @@ export class WASqliteConnection
     await this.openDB();
     this.registerBroadcastListeners();
     await this.executeSingleStatement(`PRAGMA temp_store = ${this.options.temporaryStorage};`);
-    await this.executeSingleStatement(`PRAGMA cache_size = -${this.options.cacheSizeKb};`);
     await this.executeEncryptionPragma();
+    await this.executeSingleStatement(`PRAGMA cache_size = -${this.options.cacheSizeKb};`);
 
     this.sqliteAPI.update_hook(this.dbP, (updateType: number, dbName: string | null, tableName: string | null) => {
       if (!tableName) {

--- a/packages/web/tests/encryption.test.ts
+++ b/packages/web/tests/encryption.test.ts
@@ -1,0 +1,64 @@
+import {
+  PowerSyncDatabase,
+  WASQLiteOpenFactory,
+  WASQLiteVFS,
+  WebPowerSyncDatabaseOptionsWithOpenFactory,
+  WebPowerSyncDatabaseOptionsWithSettings
+} from '@powersync/web';
+import { v4 as uuid } from 'uuid';
+import { describe, expect, it } from 'vitest';
+import { testSchema } from './utils/testDb';
+
+describe('Encryption Tests', { sequential: true }, () => {
+  it('IDBBatchAtomicVFS encryption', async () => {
+    await testEncryption({
+      schema: testSchema,
+      database: { dbFilename: 'iddb-file.db' },
+      encryptionKey: 'iddb-key'
+    });
+  });
+
+  it('OPFSCoopSyncVFS encryption', async () => {
+    await testEncryption({
+      schema: testSchema,
+      database: new WASQLiteOpenFactory({
+        dbFilename: 'opfs-file.db',
+        vfs: WASQLiteVFS.OPFSCoopSyncVFS,
+        encryptionKey: 'opfs-key'
+      })
+    });
+  });
+
+  it('AccessHandlePoolVFS encryption', async () => {
+    await testEncryption({
+      schema: testSchema,
+      database: new WASQLiteOpenFactory({
+        dbFilename: 'ahp-file.db',
+        vfs: WASQLiteVFS.AccessHandlePoolVFS,
+        encryptionKey: 'ahp-key'
+      })
+    });
+  });
+});
+
+/**
+ * The open/close and open again flow is an easy way to verify that encryption is working.
+ */
+const testEncryption = async (
+  options: WebPowerSyncDatabaseOptionsWithSettings | WebPowerSyncDatabaseOptionsWithOpenFactory
+) => {
+  let powersync = new PowerSyncDatabase(options as any);
+
+  await powersync.init();
+  await powersync.close();
+
+  powersync = new PowerSyncDatabase(options as any);
+
+  await powersync.init();
+  await powersync.execute('INSERT INTO assets(id, make, customer_id) VALUES (uuid(), ?, ?)', ['test', uuid()]);
+  const results = await powersync.getAll('SELECT * FROM assets');
+  expect(results.length).toBe(1);
+
+  await powersync.disconnectAndClear();
+  await powersync.close();
+};


### PR DESCRIPTION
Got the following error when building an encryption demo:
![image](https://github.com/user-attachments/assets/bdcff281-29b3-413d-8d22-6a13c6c4c160)

It seems that executing the cache_size pragma before the encryption pragma causes this issue. Simply reordered, and verified this fix via unit tests.