### PR TITLE
Navigator locks are now aquired with a random/unique key.

### DIFF
--- a/.changeset/khaki-pears-add.md
+++ b/.changeset/khaki-pears-add.md
@@ -1,0 +1,8 @@
+---
+'@powersync/web': minor
+---
+
+Navigator locks are now aquired with a random/unique key.
+
+This resolves an issue related to sequential `connect()` calls breaking all syncing and never reaching a `connected` state.
+Two typical scenarios that can cause this is switching client parameters and React's `StrictMode` which does multiple calls of hooks like `useEffect`.

--- a/packages/web/src/db/adapters/WorkerWrappedAsyncDatabaseConnection.ts
+++ b/packages/web/src/db/adapters/WorkerWrappedAsyncDatabaseConnection.ts
@@ -58,7 +58,7 @@ export class WorkerWrappedAsyncDatabaseConnection<Config extends ResolvedWebSQLO
     await new Promise<void>((resolve, reject) =>
       navigator.locks
         .request(
-          `shared-connection-${this.options.identifier}`,
+          `shared-connection-${this.options.identifier}-${Date.now()}-${Math.round(Math.random() * 10000)}`,
           {
             signal: this.lockAbortController.signal
           },


### PR DESCRIPTION
This PR resolves an issue related to sequential `connect()` calls breaking all syncing and never reaching a `connected` state.
Two typical scenarios that can cause this is switching client parameters and React's `StrictMode` which does multiple calls of hooks like `useEffect`.

This PR ensures that locks used for internal connection sharing are unique.

Alternative to https://github.com/powersync-ja/powersync-js/pull/545

Thanks @simolus3 for suggesting this approach.