### PR TITLE
Bumping tanstack peer dependency to ^5.70.0

### DIFF
--- a/.changeset/fast-cobras-repeat.md
+++ b/.changeset/fast-cobras-repeat.md
@@ -1,0 +1,5 @@
+---
+'@powersync/tanstack-react-query': patch
+---
+
+Bumping tanstack query peer dependency to `^5.70.0`.

--- a/packages/tanstack-react-query/package.json
+++ b/packages/tanstack-react-query/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@powersync/common": "workspace:*",
     "@powersync/react": "workspace:*",
-    "@tanstack/react-query": "^5.55.4"
+    "@tanstack/react-query": "^5.70.0"
   },
   "devDependencies": {
     "@testing-library/react": "^15.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,16 +246,16 @@ importers:
     dependencies:
       '@capacitor/android':
         specifier: ^6.0.0
-        version: 6.1.2(@capacitor/core@7.1.0)
+        version: 6.1.2(@capacitor/core@7.2.0)
       '@capacitor/core':
         specifier: latest
-        version: 7.1.0
+        version: 7.2.0
       '@capacitor/ios':
         specifier: ^6.0.0
-        version: 6.1.2(@capacitor/core@7.1.0)
+        version: 6.1.2(@capacitor/core@7.2.0)
       '@capacitor/splash-screen':
         specifier: latest
-        version: 7.0.0(@capacitor/core@7.1.0)
+        version: 7.0.0(@capacitor/core@7.2.0)
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
         version: 1.2.1
@@ -401,7 +401,7 @@ importers:
         version: 10.4.20(postcss@8.5.3)
       babel-loader:
         specifier: ^9.1.3
-        version: 9.2.1(@babel/core@7.25.7)(webpack@5.98.0(@swc/core@1.6.13(@swc/helpers@0.5.5)))
+        version: 9.2.1(@babel/core@7.25.7)(webpack@5.95.0(@swc/core@1.6.13(@swc/helpers@0.5.5)))
       electron:
         specifier: 30.0.2
         version: 30.0.2
@@ -1970,8 +1970,8 @@ importers:
         specifier: workspace:*
         version: link:../react
       '@tanstack/react-query':
-        specifier: ^5.55.4
-        version: 5.59.14(react@18.2.0)
+        specifier: ^5.70.0
+        version: 5.71.1(react@18.2.0)
     devDependencies:
       '@testing-library/react':
         specifier: ^15.0.2
@@ -3829,8 +3829,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@capacitor/core@7.1.0':
-    resolution: {integrity: sha512-I0a4C8gux5sx+HDamJjCiWHEWRdJU3hejwURFOSwJjUmAMkfkrm4hOsI0dgd+S0eCkKKKYKz9WNm7DAIvhm2zw==}
+  '@capacitor/core@7.2.0':
+    resolution: {integrity: sha512-2zCnA6RJeZ9ec4470o8QMZEQTWpekw9FNoqm5TLc10jeCrhvHVI8MPgxdZVc3mOdFlyieYu4AS1fNxSqbS57Pw==}
 
   '@capacitor/ios@6.1.2':
     resolution: {integrity: sha512-HaeW68KisBd/7TmavzPDlL2bpoDK5AjR2ZYrqU4TlGwM88GtQfvduBCAlSCj20X0w/4+rWMkseD9dAAkacjiyQ==}
@@ -8712,11 +8712,11 @@ packages:
     peerDependencies:
       react: '*'
 
-  '@tanstack/query-core@5.59.13':
-    resolution: {integrity: sha512-Oou0bBu/P8+oYjXsJQ11j+gcpLAMpqW42UlokQYEz4dE7+hOtVO9rVuolJKgEccqzvyFzqX4/zZWY+R/v1wVsQ==}
+  '@tanstack/query-core@5.71.1':
+    resolution: {integrity: sha512-4+ZswCHOfJX+ikhXNoocamTUmJcHtB+Ljjz/oJkC7/eKB5IrzEwR4vEwZUENiPi+wISucJHR5TUbuuJ26w3kdQ==}
 
-  '@tanstack/react-query@5.59.14':
-    resolution: {integrity: sha512-2cM4x3Ka4Thl7/wnjf++EMGA2Is/RgPynn83D4kfGiJOGSjb5T2D3EEOlC8Nt6U2htLS3imOXjOSMEjC3K7JNg==}
+  '@tanstack/react-query@5.71.1':
+    resolution: {integrity: sha512-6BTkaSIGT58MroI4kIGXNdx/NhirXPU+75AJObLq+WBa39WmoxhzSk0YX+hqWJ/bvqZJFxslbEU4qIHaRZq+8Q==}
     peerDependencies:
       react: ^18 || ^19
 
@@ -24162,9 +24162,9 @@ snapshots:
       '@types/tough-cookie': 4.0.5
       tough-cookie: 4.1.4
 
-  '@capacitor/android@6.1.2(@capacitor/core@7.1.0)':
+  '@capacitor/android@6.1.2(@capacitor/core@7.2.0)':
     dependencies:
-      '@capacitor/core': 7.1.0
+      '@capacitor/core': 7.2.0
 
   '@capacitor/cli@6.1.2':
     dependencies:
@@ -24189,17 +24189,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@capacitor/core@7.1.0':
+  '@capacitor/core@7.2.0':
     dependencies:
       tslib: 2.7.0
 
-  '@capacitor/ios@6.1.2(@capacitor/core@7.1.0)':
+  '@capacitor/ios@6.1.2(@capacitor/core@7.2.0)':
     dependencies:
-      '@capacitor/core': 7.1.0
+      '@capacitor/core': 7.2.0
 
-  '@capacitor/splash-screen@7.0.0(@capacitor/core@7.1.0)':
+  '@capacitor/splash-screen@7.0.0(@capacitor/core@7.2.0)':
     dependencies:
-      '@capacitor/core': 7.1.0
+      '@capacitor/core': 7.2.0
 
   '@changesets/apply-release-plan@7.0.5':
     dependencies:
@@ -32490,11 +32490,11 @@ snapshots:
       '@tamagui/use-force-update': 1.79.6(react@18.3.1)
       react: 18.3.1
 
-  '@tanstack/query-core@5.59.13': {}
+  '@tanstack/query-core@5.71.1': {}
 
-  '@tanstack/react-query@5.59.14(react@18.2.0)':
+  '@tanstack/react-query@5.71.1(react@18.2.0)':
     dependencies:
-      '@tanstack/query-core': 5.59.13
+      '@tanstack/query-core': 5.71.1
       react: 18.2.0
 
   '@testing-library/dom@10.4.0':
@@ -34459,12 +34459,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.2.1(@babel/core@7.25.7)(webpack@5.98.0(@swc/core@1.6.13(@swc/helpers@0.5.5))):
+  babel-loader@9.2.1(@babel/core@7.25.7)(webpack@5.95.0(@swc/core@1.6.13(@swc/helpers@0.5.5))):
     dependencies:
       '@babel/core': 7.25.7
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.98.0(@swc/core@1.6.13(@swc/helpers@0.5.5))
+      webpack: 5.95.0(@swc/core@1.6.13(@swc/helpers@0.5.5))
 
   babel-loader@9.2.1(@babel/core@7.26.10)(webpack@5.95.0(@swc/core@1.10.1(@swc/helpers@0.5.5))):
     dependencies:


### PR DESCRIPTION
Simple peer dependency bump.
Resolves https://github.com/powersync-ja/powersync-js/issues/491