### PR TITLE
Fix checkpoints during uploads not being applied

### DIFF
--- a/packages/common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/common/src/client/AbstractPowerSyncDatabase.ts
@@ -15,7 +15,7 @@ import { Schema } from '../db/schema/Schema.js';
 import { BaseObserver } from '../utils/BaseObserver.js';
 import { ControlledExecutor } from '../utils/ControlledExecutor.js';
 import { mutexRunExclusive } from '../utils/mutex.js';
-import { throttleTrailing } from '../utils/throttle.js';
+import { throttleTrailing } from '../utils/async.js';
 import { SQLOpenFactory, SQLOpenOptions, isDBAdapter, isSQLOpenFactory, isSQLOpenOptions } from './SQLOpenFactory.js';
 import { PowerSyncBackendConnector } from './connection/PowerSyncBackendConnector.js';
 import { runOnSchemaChange } from './runOnSchemaChange.js';

--- a/packages/common/src/utils/async.ts
+++ b/packages/common/src/utils/async.ts
@@ -48,3 +48,13 @@ export function throttleLeadingTrailing(func: () => void, wait: number) {
     }
   };
 }
+
+export function onAbortPromise(signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve();
+    } else {
+      signal.onabort = () => resolve();
+    }
+  })
+}

--- a/packages/web/tests/utils/MockStreamOpenFactory.ts
+++ b/packages/web/tests/utils/MockStreamOpenFactory.ts
@@ -18,6 +18,7 @@ import {
   WebPowerSyncOpenFactoryOptions,
   WebStreamingSyncImplementation
 } from '@powersync/web';
+import { MockedFunction, vi } from 'vitest';
 
 export class TestConnector implements PowerSyncBackendConnector {
   async fetchCredentials(): Promise<PowerSyncCredentials> {
@@ -35,12 +36,21 @@ export class TestConnector implements PowerSyncBackendConnector {
 export class MockRemote extends AbstractRemote {
   streamController: ReadableStreamDefaultController<StreamingSyncLine> | null;
   errorOnStreamStart = false;
+  generateCheckpoint: MockedFunction<() => any>;
+
   constructor(
     connector: RemoteConnector,
     protected onStreamRequested: () => void
   ) {
     super(connector);
     this.streamController = null;
+    this.generateCheckpoint = vi.fn(() => {
+      return {
+        data: {
+          write_checkpoint: '1000',
+        }
+      };
+    });
   }
 
   async getBSON(): Promise<BSONImplementation> {
@@ -53,11 +63,7 @@ export class MockRemote extends AbstractRemote {
   async get(path: string, headers?: Record<string, string> | undefined): Promise<any> {
     // mock a response for write checkpoint API
     if (path.includes('checkpoint')) {
-      return {
-        data: {
-          write_checkpoint: '1000'
-        }
-      };
+      return this.generateCheckpoint();
     }
     throw new Error('Not implemented');
   }


### PR DESCRIPTION
Under our consistency guarantee, we can't make data from new checkpoints visible if there are local changes that haven't been uploaded yet. Our current implementation for this case (recognizable by `ready = false`) was to simply do nothing. That's not unreasonable: After all, the pending local changes are supposed to be uploaded eventually, which should trigger new checkpoint messages that we'd then apply.

However, there is a potential race condition when a pending upload is currently in progress. While the connector is uploading changes (and before finishing), some data may already be uploaded to the database, triggering the sync service to send new checkpoints. These checkpoints would be entirely ignored, because we're already uploading data and there is no subsequent upload to trigger another one.

To fix that issue, this PR improves the checkpoint handling logic. If we get a checkpoint complete message that didn't apply because of local data or a `write_checkpoint` mismatch, _and_ we're currently in the process of uploading changes or waiting for a `write-checkpoint2.json` request, then await that before trying the same checkpoint again. Either,

- the same checkpoint message applies now (in case it was emitted before the connector completes or the `write-checkpoint2.json` returns). Or,
- we can expect another checkpoint to come up soon (since we've waited for the response and the old one didn't work). Doing nothing is the correct behavior here.