### PR TITLE
chore: Resolving `node_modules` via require.resolve for `copy-assets`

### DIFF
--- a/.changeset/good-ghosts-rush.md
+++ b/.changeset/good-ghosts-rush.md
@@ -2,4 +2,4 @@
 '@powersync/web': minor
 ---
 
-Added input flag option to copy assets command, allows you to specify a path to the node_modules directory - useful in cases like a monorepo.
+Determining `node_modules` location via `require.resolve` for the `copy-assets` command. Fixes use cases where `node_modules` location might differ such as in a monorepo.

--- a/.changeset/good-ghosts-rush.md
+++ b/.changeset/good-ghosts-rush.md
@@ -1,0 +1,5 @@
+---
+'@powersync/web': minor
+---
+
+Added input flag option to copy assets command, allows you to specify a path to the node_modules directory - useful in cases like a monorepo.

--- a/packages/web/bin/powersync.js
+++ b/packages/web/bin/powersync.js
@@ -11,14 +11,17 @@ program.name('powersync-web').description('CLI for PowerSync Web SDK utilities')
 program
   .command('copy-assets')
   .description('Copy assets to the specified output directory')
+  .option('-i, --input <directory>', 'node modules dependency directory', 'node_modules')
   .option('-o, --output <directory>', 'output directory for assets', 'public')
   .action(async (options) => {
+    const inputDir = options.input;
     const outputDir = options.output;
 
+    console.log(`Input directory: ${inputDir}`);
     console.log(`Target directory: ${outputDir}`);
 
     const cwd = process.cwd();
-    const source = path.join(cwd, 'node_modules', '@powersync', 'web', 'dist');
+    const source = path.join(cwd, inputDir, '@powersync', 'web', 'dist');
     const destination = path.join(cwd, outputDir, '@powersync');
 
     await fsPromise.rm(destination, { recursive: true, force: true }); // Clear old assets

--- a/packages/web/bin/powersync.js
+++ b/packages/web/bin/powersync.js
@@ -11,17 +11,16 @@ program.name('powersync-web').description('CLI for PowerSync Web SDK utilities')
 program
   .command('copy-assets')
   .description('Copy assets to the specified output directory')
-  .option('-i, --input <directory>', 'node modules dependency directory', 'node_modules')
   .option('-o, --output <directory>', 'output directory for assets', 'public')
   .action(async (options) => {
-    const inputDir = options.input;
+    const resolvedPath = require.resolve('@powersync/web/umd');
     const outputDir = options.output;
 
-    console.log(`Input directory: ${inputDir}`);
+    console.log(`Resolved input path: ${resolvedPath}`);
     console.log(`Target directory: ${outputDir}`);
 
     const cwd = process.cwd();
-    const source = path.join(cwd, inputDir, '@powersync', 'web', 'dist');
+    const source = path.join(path.dirname(resolvedPath));
     const destination = path.join(cwd, outputDir, '@powersync');
 
     await fsPromise.rm(destination, { recursive: true, force: true }); // Clear old assets


### PR DESCRIPTION
Aims to resolve https://github.com/powersync-ja/powersync-js/issues/540.
In monorepos the node_modules directory is not always at `cwd`.