### PR TITLE
Fix node electron example when packaged

### DIFF
--- a/demos/example-electron-node/config.ts
+++ b/demos/example-electron-node/config.ts
@@ -85,7 +85,7 @@ const mainConfig: Configuration = {
     new CopyPlugin({
       patterns: [{
         from: path.resolve(require.resolve('@powersync/node/package.json'), `../lib/${extensionPath}`),
-        to: extensionPath,
+        to: path.join('powersync', extensionPath),
       }],
     }),
     new DefinePluginImpl({
@@ -95,7 +95,8 @@ const mainConfig: Configuration = {
   ],
   resolve: {
     extensions: ['.js', '.ts', '.jsx', '.tsx', '.css', '.json']
-  }
+  },
+  target: "electron-main",
 };
 
 const rendererConfig: Configuration = {
@@ -116,7 +117,9 @@ const rendererConfig: Configuration = {
 
 const config: ForgeConfig = {
   packagerConfig: {
-    asar: true
+    asar: {
+      unpack: '**/{.**,**}/**/powersync/*'
+    },
   },
   rebuildConfig: {
     force: true,

--- a/demos/example-electron-node/src/main/index.ts
+++ b/demos/example-electron-node/src/main/index.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { Worker } from 'node:worker_threads';
 
 import { PowerSyncDatabase, SyncStreamConnectionMethod } from '@powersync/node';
@@ -19,10 +20,22 @@ if (require('electron-squirrel-startup')) {
   app.quit();
 }
 
+const userDataDirectory = app.getPath('userData');
+try {
+  if (!fs.existsSync(userDataDirectory)) {
+    fs.mkdirSync(userDataDirectory);
+  }
+} catch (e) {
+  console.error('Could not create database directory', e);
+}
+
+console.log('Storing data in ', userDataDirectory);
+
 const database = new PowerSyncDatabase({
   schema: AppSchema,
   database: {
     dbFilename: 'test.db',
+    dbLocation: userDataDirectory,
     openWorker(_, options) {
       return new Worker(new URL('./worker.ts', import.meta.url), options);
     }

--- a/demos/example-electron-node/src/main/worker.ts
+++ b/demos/example-electron-node/src/main/worker.ts
@@ -18,7 +18,14 @@ function resolvePowerSyncCoreExtension() {
 
   // This example uses copy-webpack-plugin to copy the prebuilt library over. This ensures that it is
   // available in packaged release builds.
-  return path.resolve(__dirname, extensionPath);
+  let libraryPath = path.resolve(__dirname, 'powersync', extensionPath);
+
+  if (__dirname.indexOf('app.asar') != -1) {
+    // Our build configuration ensures the extension is always available outside of the archive too.
+    libraryPath = libraryPath.replace('app.asar', 'app.asar.unpacked');
+  }
+
+  return libraryPath;
 }
 
 startPowerSyncWorker({ extensionPath: resolvePowerSyncCoreExtension });


### PR DESCRIPTION
The example in `demos/example-electron-node` has two problems that only occur when running the packaged builds (the generated app after running `pnpm package`):

1. It opens databases in the current working directory. On macOS, that appears to be the read-only `.app` file of the app itself by default, where we can't open databases. This changes the example to use a directory in `app.getPath('userData')` instead.
2. All assets get put into an archive (`app.asar`) by default. Electron patches some Node APIs to be aware of this (so e.g. calling `process.dlopen` would automatically extract the relevant library), but SQLite obviously can't be aware of that when we're loading the extension. So:
  - I've changed the copy step responsible for copying the native PowerSync loadable core extension into a `powersync/` directory.
  - Then, asar is configured to create an uncompressed copy of the extension.
  - Finally, in `worker.ts`, we check whether `__dirname` points to the archive, and, if so, use the extracted directory instead.