### PR TITLE
Schema options

### DIFF
--- a/.changeset/giant-ladybugs-dress.md
+++ b/.changeset/giant-ladybugs-dress.md
@@ -2,7 +2,7 @@
 '@powersync/common': minor
 ---
 
-- Add `trackOld` option on `Table` which sets `CrudEntry.oldData` to previous values on updates.
+- Add `trackPreviousValues` option on `Table` which sets `CrudEntry.previousValues` to previous values on updates.
 - Add `trackMetadata` option on `Table` which adds a `_metadata` column that can be used for updates.
   The configured metadata is available through `CrudEntry.metadata`.
 - Add `ignoreEmptyUpdates` option which skips creating CRUD entries for updates that don't change any values.

--- a/.changeset/giant-ladybugs-dress.md
+++ b/.changeset/giant-ladybugs-dress.md
@@ -2,7 +2,7 @@
 '@powersync/common': minor
 ---
 
-- Add `includeOld` option on `Table` which sets `CrudEntry.oldData` to previous values on updates.
-- Add `includeMetadata` option on `Table` which adds a `_metadata` column that can be used for updates.
+- Add `trackOld` option on `Table` which sets `CrudEntry.oldData` to previous values on updates.
+- Add `trackMetadata` option on `Table` which adds a `_metadata` column that can be used for updates.
   The configured metadata is available through `CrudEntry.metadata`.
-- Add `ignoreEmptyUpdate` option which skips creating CRUD entries for updates that don't change any values.
+- Add `ignoreEmptyUpdates` option which skips creating CRUD entries for updates that don't change any values.

--- a/.changeset/giant-ladybugs-dress.md
+++ b/.changeset/giant-ladybugs-dress.md
@@ -1,0 +1,8 @@
+---
+'@powersync/common': minor
+---
+
+- Add `includeOld` option on `Table` which sets `CrudEntry.oldData` to previous values on updates.
+- Add `includeMetadata` option on `Table` which adds a `_metadata` column that can be used for updates.
+  The configured metadata is available through `CrudEntry.metadata`.
+- Add `ignoreEmptyUpdate` option which skips creating CRUD entries for updates that don't change any values.

--- a/packages/common/src/client/sync/bucket/CrudEntry.ts
+++ b/packages/common/src/client/sync/bucket/CrudEntry.ts
@@ -66,10 +66,10 @@ export class CrudEntry {
   opData?: Record<string, any>;
 
   /**
-   * For tables where the `trackOld` option has been enabled, this tracks previous values for
+   * For tables where the `trackPreviousValues` option has been enabled, this tracks previous values for
    * `UPDATE` and `DELETE` statements.
    */
-  oldData?: Record<string, any>;
+  previousValues?: Record<string, any>;
 
   /**
    * Table that contained the change.
@@ -109,7 +109,7 @@ export class CrudEntry {
     id: string,
     transactionId?: number,
     opData?: Record<string, any>,
-    oldData?: Record<string, any>,
+    previousValues?: Record<string, any>,
     metadata?: string
   ) {
     this.clientId = clientId;
@@ -118,7 +118,7 @@ export class CrudEntry {
     this.opData = opData;
     this.table = table;
     this.transactionId = transactionId;
-    this.oldData = oldData;
+    this.previousValues = previousValues;
     this.metadata = metadata;
   }
 

--- a/packages/common/src/client/sync/bucket/CrudEntry.ts
+++ b/packages/common/src/client/sync/bucket/CrudEntry.ts
@@ -25,9 +25,11 @@ export type CrudEntryJSON = {
 
 type CrudEntryDataJSON = {
   data: Record<string, any>;
+  old?: Record<string, any>;
   op: UpdateType;
   type: string;
   id: string;
+  metadata?: string;
 };
 
 /**
@@ -62,6 +64,13 @@ export class CrudEntry {
    * Data associated with the change.
    */
   opData?: Record<string, any>;
+
+  /**
+   * For tables where the `includeOld` option has been enabled, this tracks previous values for
+   * `UPDATE` and `DELETE` statements.
+   */
+  oldData?: Record<string, any>;
+
   /**
    * Table that contained the change.
    */
@@ -71,9 +80,26 @@ export class CrudEntry {
    */
   transactionId?: number;
 
+  /**
+   * Client-side metadata attached with this write.
+   *
+   * This field is only available when the `includeMetadata` option was set to `true` when creating a table
+   * and the insert or update statement set the `_metadata` column.
+   */
+  metadata?: string;
+
   static fromRow(dbRow: CrudEntryJSON) {
     const data: CrudEntryDataJSON = JSON.parse(dbRow.data);
-    return new CrudEntry(parseInt(dbRow.id), data.op, data.type, data.id, dbRow.tx_id, data.data);
+    return new CrudEntry(
+      parseInt(dbRow.id),
+      data.op,
+      data.type,
+      data.id,
+      dbRow.tx_id,
+      data.data,
+      data.old,
+      data.metadata
+    );
   }
 
   constructor(
@@ -82,7 +108,9 @@ export class CrudEntry {
     table: string,
     id: string,
     transactionId?: number,
-    opData?: Record<string, any>
+    opData?: Record<string, any>,
+    oldData?: Record<string, any>,
+    metadata?: string
   ) {
     this.clientId = clientId;
     this.id = id;
@@ -90,6 +118,8 @@ export class CrudEntry {
     this.opData = opData;
     this.table = table;
     this.transactionId = transactionId;
+    this.oldData = oldData;
+    this.metadata = metadata;
   }
 
   /**

--- a/packages/common/src/client/sync/bucket/CrudEntry.ts
+++ b/packages/common/src/client/sync/bucket/CrudEntry.ts
@@ -66,7 +66,7 @@ export class CrudEntry {
   opData?: Record<string, any>;
 
   /**
-   * For tables where the `includeOld` option has been enabled, this tracks previous values for
+   * For tables where the `trackOld` option has been enabled, this tracks previous values for
    * `UPDATE` and `DELETE` statements.
    */
   oldData?: Record<string, any>;
@@ -83,7 +83,7 @@ export class CrudEntry {
   /**
    * Client-side metadata attached with this write.
    *
-   * This field is only available when the `includeMetadata` option was set to `true` when creating a table
+   * This field is only available when the `trackMetadata` option was set to `true` when creating a table
    * and the insert or update statement set the `_metadata` column.
    */
   metadata?: string;

--- a/packages/common/src/db/schema/Schema.ts
+++ b/packages/common/src/db/schema/Schema.ts
@@ -53,15 +53,7 @@ export class Schema<S extends SchemaType = SchemaType> {
 
   private convertToClassicTables(props: S) {
     return Object.entries(props).map(([name, table]) => {
-      const convertedTable = new Table({
-        name,
-        columns: table.columns,
-        indexes: table.indexes,
-        localOnly: table.localOnly,
-        insertOnly: table.insertOnly,
-        viewName: table.viewNameOverride || name
-      });
-      return convertedTable;
+      return table.copyWithName(name);
     });
   }
 }

--- a/packages/common/src/db/schema/Table.ts
+++ b/packages/common/src/db/schema/Table.ts
@@ -46,7 +46,7 @@ export const DEFAULT_TABLE_OPTIONS = {
   localOnly: false,
   includeOld: false,
   includeMetadata: false,
-  ignoreEmptyUpdate: false,
+  ignoreEmptyUpdate: false
 };
 
 export const InvalidSQLCharacters = /["'%,.#\s[\]]/;
@@ -141,6 +141,13 @@ export class Table<Columns extends ColumnsType = ColumnsType> {
     } else {
       this.initTableV2(optionsOrColumns, v2Options);
     }
+  }
+
+  copyWithName(name: string): Table {
+    return new Table({
+      ...this.options,
+      name
+    });
   }
 
   private isTableV1(arg: TableOptions | Columns): arg is TableOptions {

--- a/packages/common/src/db/schema/Table.ts
+++ b/packages/common/src/db/schema/Table.ts
@@ -14,17 +14,17 @@ interface SharedTableOptions {
   localOnly?: boolean;
   insertOnly?: boolean;
   viewName?: string;
-  trackOld?: boolean | TrackOldOptions;
+  trackPrevious?: boolean | TrackPreviousOptions;
   trackMetadata?: boolean;
   ignoreEmptyUpdates?: boolean;
 }
 
-/** Whether to include old columns when PowerSync tracks local changes.
+/** Whether to include previous column values when PowerSync tracks local changes.
  *
- * Including old columns may be helpful for some backend connector implementations, which is
+ * Including old values may be helpful for some backend connector implementations, which is
  * why it can be enabled on per-table or per-columm basis.
  */
-export interface TrackOldOptions {
+export interface TrackPreviousOptions {
   /** When defined, a list of column names for which old values should be tracked. */
   columns?: string[];
   /** When enabled, only include values that have actually been changed by an update. */
@@ -56,7 +56,7 @@ export const DEFAULT_TABLE_OPTIONS = {
   indexes: [],
   insertOnly: false,
   localOnly: false,
-  trackOld: false,
+  trackPrevious: false,
   trackMetadata: false,
   ignoreEmptyUpdates: false
 };
@@ -200,7 +200,7 @@ export class Table<Columns extends ColumnsType = ColumnsType> {
       viewName: options?.viewName,
       insertOnly: options?.insertOnly,
       localOnly: options?.localOnly,
-      trackOld: options?.trackOld,
+      trackPrevious: options?.trackPrevious,
       trackMetadata: options?.trackMetadata,
       ignoreEmptyUpdates: options?.ignoreEmptyUpdates
     };
@@ -212,7 +212,7 @@ export class Table<Columns extends ColumnsType = ColumnsType> {
   private applyDefaultOptions() {
     this.options.insertOnly ??= DEFAULT_TABLE_OPTIONS.insertOnly;
     this.options.localOnly ??= DEFAULT_TABLE_OPTIONS.localOnly;
-    this.options.trackOld ??= DEFAULT_TABLE_OPTIONS.trackOld;
+    this.options.trackPrevious ??= DEFAULT_TABLE_OPTIONS.trackPrevious;
     this.options.trackMetadata ??= DEFAULT_TABLE_OPTIONS.trackMetadata;
     this.options.ignoreEmptyUpdates ??= DEFAULT_TABLE_OPTIONS.ignoreEmptyUpdates;
   }
@@ -255,8 +255,8 @@ export class Table<Columns extends ColumnsType = ColumnsType> {
     return this.options.insertOnly!;
   }
 
-  get trackOld() {
-    return this.options.trackOld!;
+  get trackPrevious() {
+    return this.options.trackPrevious!;
   }
 
   get trackMetadata() {
@@ -301,7 +301,7 @@ export class Table<Columns extends ColumnsType = ColumnsType> {
     if (this.trackMetadata && this.localOnly) {
       throw new Error(`Can't include metadata for local-only tables.`);
     }
-    if (this.trackOld != false && this.localOnly) {
+    if (this.trackPrevious != false && this.localOnly) {
       throw new Error(`Can't include old values for local-only tables.`);
     }
 
@@ -341,15 +341,15 @@ export class Table<Columns extends ColumnsType = ColumnsType> {
   }
 
   toJSON() {
-    const trackOld = this.trackOld;
+    const trackPrevious = this.trackPrevious;
 
     return {
       name: this.name,
       view_name: this.viewName,
       local_only: this.localOnly,
       insert_only: this.insertOnly,
-      include_old: trackOld && ((trackOld as any).columns ?? true),
-      include_old_only_when_changed: typeof trackOld == 'object' && trackOld.onlyWhenChanged == true,
+      include_old: trackPrevious && ((trackPrevious as any).columns ?? true),
+      include_old_only_when_changed: typeof trackPrevious == 'object' && trackPrevious.onlyWhenChanged == true,
       include_metadata: this.trackMetadata,
       ignore_empty_update: this.ignoreEmptyUpdates,
       columns: this.columns.map((c) => c.toJSON()),

--- a/packages/common/src/db/schema/Table.ts
+++ b/packages/common/src/db/schema/Table.ts
@@ -14,9 +14,9 @@ interface SharedTableOptions {
   localOnly?: boolean;
   insertOnly?: boolean;
   viewName?: string;
-  includeOld?: boolean | IncludeOldOptions;
-  includeMetadata?: boolean;
-  ignoreEmptyUpdate?: boolean;
+  trackOld?: boolean | TrackOldOptions;
+  trackMetadata?: boolean;
+  ignoreEmptyUpdates?: boolean;
 }
 
 /** Whether to include old columns when PowerSync tracks local changes.
@@ -24,7 +24,7 @@ interface SharedTableOptions {
  * Including old columns may be helpful for some backend connector implementations, which is
  * why it can be enabled on per-table or per-columm basis.
  */
-export interface IncludeOldOptions {
+export interface TrackOldOptions {
   /** When defined, a list of column names for which old values should be tracked. */
   columns?: string[];
   /** When enabled, only include values that have actually been changed by an update. */
@@ -56,9 +56,9 @@ export const DEFAULT_TABLE_OPTIONS = {
   indexes: [],
   insertOnly: false,
   localOnly: false,
-  includeOld: false,
-  includeMetadata: false,
-  ignoreEmptyUpdate: false
+  trackOld: false,
+  trackMetadata: false,
+  ignoreEmptyUpdates: false
 };
 
 export const InvalidSQLCharacters = /["'%,.#\s[\]]/;
@@ -200,9 +200,9 @@ export class Table<Columns extends ColumnsType = ColumnsType> {
       viewName: options?.viewName,
       insertOnly: options?.insertOnly,
       localOnly: options?.localOnly,
-      includeOld: options?.includeOld,
-      includeMetadata: options?.includeMetadata,
-      ignoreEmptyUpdate: options?.ignoreEmptyUpdate
+      trackOld: options?.trackOld,
+      trackMetadata: options?.trackMetadata,
+      ignoreEmptyUpdates: options?.ignoreEmptyUpdates
     };
     this.applyDefaultOptions();
 
@@ -212,9 +212,9 @@ export class Table<Columns extends ColumnsType = ColumnsType> {
   private applyDefaultOptions() {
     this.options.insertOnly ??= DEFAULT_TABLE_OPTIONS.insertOnly;
     this.options.localOnly ??= DEFAULT_TABLE_OPTIONS.localOnly;
-    this.options.includeOld ??= DEFAULT_TABLE_OPTIONS.includeOld;
-    this.options.includeMetadata ??= DEFAULT_TABLE_OPTIONS.includeMetadata;
-    this.options.ignoreEmptyUpdate ??= DEFAULT_TABLE_OPTIONS.ignoreEmptyUpdate;
+    this.options.trackOld ??= DEFAULT_TABLE_OPTIONS.trackOld;
+    this.options.trackMetadata ??= DEFAULT_TABLE_OPTIONS.trackMetadata;
+    this.options.ignoreEmptyUpdates ??= DEFAULT_TABLE_OPTIONS.ignoreEmptyUpdates;
   }
 
   get name() {
@@ -255,16 +255,16 @@ export class Table<Columns extends ColumnsType = ColumnsType> {
     return this.options.insertOnly!;
   }
 
-  get includeOld() {
-    return this.options.includeOld!;
+  get trackOld() {
+    return this.options.trackOld!;
   }
 
-  get includeMetadata() {
-    return this.options.includeMetadata!;
+  get trackMetadata() {
+    return this.options.trackMetadata!;
   }
 
-  get ignoreEmptyUpdate() {
-    return this.options.ignoreEmptyUpdate!;
+  get ignoreEmptyUpdates() {
+    return this.options.ignoreEmptyUpdates!;
   }
 
   get internalName() {
@@ -298,10 +298,10 @@ export class Table<Columns extends ColumnsType = ColumnsType> {
       throw new Error(`Table has too many columns. The maximum number of columns is ${MAX_AMOUNT_OF_COLUMNS}.`);
     }
 
-    if (this.includeMetadata && this.localOnly) {
+    if (this.trackMetadata && this.localOnly) {
       throw new Error(`Can't include metadata for local-only tables.`);
     }
-    if (this.includeOld != false && this.localOnly) {
+    if (this.trackOld != false && this.localOnly) {
       throw new Error(`Can't include old values for local-only tables.`);
     }
 
@@ -341,17 +341,17 @@ export class Table<Columns extends ColumnsType = ColumnsType> {
   }
 
   toJSON() {
-    const includeOld = this.includeOld;
+    const trackOld = this.trackOld;
 
     return {
       name: this.name,
       view_name: this.viewName,
       local_only: this.localOnly,
       insert_only: this.insertOnly,
-      include_old: includeOld && ((includeOld as any).columns ?? true),
-      include_old_only_when_changed: typeof includeOld == 'object' && includeOld.onlyWhenChanged == true,
-      include_metadata: this.includeMetadata,
-      ignore_empty_update: this.ignoreEmptyUpdate,
+      include_old: trackOld && ((trackOld as any).columns ?? true),
+      include_old_only_when_changed: typeof trackOld == 'object' && trackOld.onlyWhenChanged == true,
+      include_metadata: this.trackMetadata,
+      ignore_empty_update: this.ignoreEmptyUpdates,
       columns: this.columns.map((c) => c.toJSON()),
       indexes: this.indexes.map((e) => e.toJSON(this))
     };

--- a/packages/common/tests/db/schema/Schema.test.ts
+++ b/packages/common/tests/db/schema/Schema.test.ts
@@ -90,6 +90,10 @@ describe('Schema', () => {
           view_name: 'users',
           local_only: false,
           insert_only: false,
+          ignore_empty_update: false,
+          include_metadata: false,
+          include_old: false,
+          include_old_only_when_changed: false,
           columns: [
             { name: 'name', type: 'TEXT' },
             { name: 'age', type: 'INTEGER' }
@@ -101,6 +105,10 @@ describe('Schema', () => {
           view_name: 'posts',
           local_only: false,
           insert_only: false,
+          ignore_empty_update: false,
+          include_metadata: false,
+          include_old: false,
+          include_old_only_when_changed: false,
           columns: [
             { name: 'title', type: 'TEXT' },
             { name: 'content', type: 'TEXT' }

--- a/packages/common/tests/db/schema/Table.test.ts
+++ b/packages/common/tests/db/schema/Table.test.ts
@@ -138,10 +138,10 @@ describe('Table', () => {
     expect(createTable({}).toJSON().include_metadata).toBe(false);
     expect(createTable({ trackMetadata: true }).toJSON().include_metadata).toBe(true);
 
-    expect(createTable({ trackOld: true }).toJSON().include_old).toBe(true);
-    expect(createTable({ trackOld: true }).toJSON().include_old_only_when_changed).toBe(false);
+    expect(createTable({ trackPrevious: true }).toJSON().include_old).toBe(true);
+    expect(createTable({ trackPrevious: true }).toJSON().include_old_only_when_changed).toBe(false);
 
-    const complexIncldueOld = createTable({ trackOld: {
+    const complexIncldueOld = createTable({ trackPrevious: {
       columns: ['foo', 'bar'],
       onlyWhenChanged: true,
     } });
@@ -216,7 +216,7 @@ describe('Table', () => {
           {
             name: column.text
           },
-          { localOnly: true, trackOld: true }
+          { localOnly: true, trackPrevious: true }
         ).validate()
       ).toThrowError("Can't include old values for local-only tables.");
 
@@ -225,7 +225,7 @@ describe('Table', () => {
           {
             name: column.text
           },
-          { localOnly: true, trackOld: { onlyWhenChanged: false } }
+          { localOnly: true, trackPrevious: { onlyWhenChanged: false } }
         ).validate()
       ).toThrowError("Can't include old values for local-only tables.");
     });

--- a/packages/common/tests/db/schema/Table.test.ts
+++ b/packages/common/tests/db/schema/Table.test.ts
@@ -132,18 +132,18 @@ describe('Table', () => {
 
   it('should handle options', () => {
     function createTable(options: TableV2Options) {
-      return new Table({name: column.text}, options);
+      return new Table({ name: column.text }, options);
     }
 
     expect(createTable({}).toJSON().include_metadata).toBe(false);
-    expect(createTable({includeMetadata: true}).toJSON().include_metadata).toBe(true);
+    expect(createTable({ includeMetadata: true }).toJSON().include_metadata).toBe(true);
 
-    expect(createTable({includeOld: true}).toJSON().include_old).toBe(true);
-    expect(createTable({includeOld: true}).toJSON().include_old_only_when_changed).toBe(false);
-    expect(createTable({includeOld: 'when-changed'}).toJSON().include_old).toBe(true);
-    expect(createTable({includeOld: 'when-changed'}).toJSON().include_old_only_when_changed).toBe(true);
+    expect(createTable({ includeOld: true }).toJSON().include_old).toBe(true);
+    expect(createTable({ includeOld: true }).toJSON().include_old_only_when_changed).toBe(false);
+    expect(createTable({ includeOld: 'when-changed' }).toJSON().include_old).toBe(true);
+    expect(createTable({ includeOld: 'when-changed' }).toJSON().include_old_only_when_changed).toBe(true);
 
-    expect(createTable({ignoreEmptyUpdate: true}).toJSON().ignore_empty_update).toBe(true);
+    expect(createTable({ ignoreEmptyUpdate: true }).toJSON().ignore_empty_update).toBe(true);
   });
 
   describe('validate', () => {
@@ -196,23 +196,32 @@ describe('Table', () => {
 
     it('should throw an error for local-only tables with metadata', () => {
       expect(() =>
-        new Table({
-          name: column.text,
-        }, { localOnly: true, includeMetadata: true }).validate()
+        new Table(
+          {
+            name: column.text
+          },
+          { localOnly: true, includeMetadata: true }
+        ).validate()
       ).toThrowError("Can't include metadata for local-only tables.");
     });
 
     it('should throw an error for local-only tables tracking old values', () => {
       expect(() =>
-        new Table({
-          name: column.text,
-        }, { localOnly: true, includeOld: true }).validate()
+        new Table(
+          {
+            name: column.text
+          },
+          { localOnly: true, includeOld: true }
+        ).validate()
       ).toThrowError("Can't include old values for local-only tables.");
 
       expect(() =>
-        new Table({
-          name: column.text,
-        }, { localOnly: true, includeOld: 'when-changed' }).validate()
+        new Table(
+          {
+            name: column.text
+          },
+          { localOnly: true, includeOld: 'when-changed' }
+        ).validate()
       ).toThrowError("Can't include old values for local-only tables.");
     });
   });

--- a/packages/common/tests/db/schema/Table.test.ts
+++ b/packages/common/tests/db/schema/Table.test.ts
@@ -136,19 +136,19 @@ describe('Table', () => {
     }
 
     expect(createTable({}).toJSON().include_metadata).toBe(false);
-    expect(createTable({ includeMetadata: true }).toJSON().include_metadata).toBe(true);
+    expect(createTable({ trackMetadata: true }).toJSON().include_metadata).toBe(true);
 
-    expect(createTable({ includeOld: true }).toJSON().include_old).toBe(true);
-    expect(createTable({ includeOld: true }).toJSON().include_old_only_when_changed).toBe(false);
+    expect(createTable({ trackOld: true }).toJSON().include_old).toBe(true);
+    expect(createTable({ trackOld: true }).toJSON().include_old_only_when_changed).toBe(false);
 
-    const complexIncldueOld = createTable({ includeOld: {
+    const complexIncldueOld = createTable({ trackOld: {
       columns: ['foo', 'bar'],
       onlyWhenChanged: true,
     } });
     expect(complexIncldueOld.toJSON().include_old).toStrictEqual(['foo', 'bar']);
     expect(complexIncldueOld.toJSON().include_old_only_when_changed).toBe(true);
 
-    expect(createTable({ ignoreEmptyUpdate: true }).toJSON().ignore_empty_update).toBe(true);
+    expect(createTable({ ignoreEmptyUpdates: true }).toJSON().ignore_empty_update).toBe(true);
   });
 
   describe('validate', () => {
@@ -205,7 +205,7 @@ describe('Table', () => {
           {
             name: column.text
           },
-          { localOnly: true, includeMetadata: true }
+          { localOnly: true, trackMetadata: true }
         ).validate()
       ).toThrowError("Can't include metadata for local-only tables.");
     });
@@ -216,7 +216,7 @@ describe('Table', () => {
           {
             name: column.text
           },
-          { localOnly: true, includeOld: true }
+          { localOnly: true, trackOld: true }
         ).validate()
       ).toThrowError("Can't include old values for local-only tables.");
 
@@ -225,7 +225,7 @@ describe('Table', () => {
           {
             name: column.text
           },
-          { localOnly: true, includeOld: { onlyWhenChanged: false } }
+          { localOnly: true, trackOld: { onlyWhenChanged: false } }
         ).validate()
       ).toThrowError("Can't include old values for local-only tables.");
     });

--- a/packages/common/tests/db/schema/Table.test.ts
+++ b/packages/common/tests/db/schema/Table.test.ts
@@ -140,8 +140,13 @@ describe('Table', () => {
 
     expect(createTable({ includeOld: true }).toJSON().include_old).toBe(true);
     expect(createTable({ includeOld: true }).toJSON().include_old_only_when_changed).toBe(false);
-    expect(createTable({ includeOld: 'when-changed' }).toJSON().include_old).toBe(true);
-    expect(createTable({ includeOld: 'when-changed' }).toJSON().include_old_only_when_changed).toBe(true);
+
+    const complexIncldueOld = createTable({ includeOld: {
+      columns: ['foo', 'bar'],
+      onlyWhenChanged: true,
+    } });
+    expect(complexIncldueOld.toJSON().include_old).toStrictEqual(['foo', 'bar']);
+    expect(complexIncldueOld.toJSON().include_old_only_when_changed).toBe(true);
 
     expect(createTable({ ignoreEmptyUpdate: true }).toJSON().ignore_empty_update).toBe(true);
   });
@@ -220,7 +225,7 @@ describe('Table', () => {
           {
             name: column.text
           },
-          { localOnly: true, includeOld: 'when-changed' }
+          { localOnly: true, includeOld: { onlyWhenChanged: false } }
         ).validate()
       ).toThrowError("Can't include old values for local-only tables.");
     });

--- a/packages/common/tests/db/schema/TableV2.test.ts
+++ b/packages/common/tests/db/schema/TableV2.test.ts
@@ -79,6 +79,10 @@ describe('TableV2', () => {
       view_name: 'customView',
       local_only: false,
       insert_only: false,
+      ignore_empty_update: false,
+      include_metadata: false,
+      include_old: false,
+      include_old_only_when_changed: false,
       columns: [
         { name: 'name', type: 'TEXT' },
         { name: 'age', type: 'INTEGER' }

--- a/packages/node/tests/crud.test.ts
+++ b/packages/node/tests/crud.test.ts
@@ -26,7 +26,7 @@ databaseTest('include old values', async ({ database }) => {
       {
         name: column.text
       },
-      { trackOld: true }
+      { trackPrevious: true }
     )
   });
   await database.updateSchema(schema);
@@ -35,7 +35,7 @@ databaseTest('include old values', async ({ database }) => {
   await database.execute('UPDATE lists SET name = ?', ['new name']);
  
   const batch = await database.getNextCrudTransaction();
-  expect(batch?.crud[0].oldData).toStrictEqual({name: 'entry'});
+  expect(batch?.crud[0].previousValues).toStrictEqual({name: 'entry'});
 });
 
 databaseTest('include old values with column filter', async ({ database }) => {
@@ -46,7 +46,7 @@ databaseTest('include old values with column filter', async ({ database }) => {
         name: column.text,
         content: column.text
       },
-      { trackOld: { columns: ['name'] } }
+      { trackPrevious: { columns: ['name'] } }
     )
   });
   await database.updateSchema(schema);
@@ -55,7 +55,7 @@ databaseTest('include old values with column filter', async ({ database }) => {
   await database.execute('UPDATE lists SET name = ?, content = ?', ['new name', 'new content']);
  
   const batch = await database.getNextCrudTransaction();
-  expect(batch?.crud[0].oldData).toStrictEqual({name: 'name'});
+  expect(batch?.crud[0].previousValues).toStrictEqual({name: 'name'});
 });
 
 databaseTest('include old values when changed', async ({ database }) => {
@@ -66,7 +66,7 @@ databaseTest('include old values when changed', async ({ database }) => {
         name: column.text,
         content: column.text
       },
-      { trackOld: { onlyWhenChanged: true } }
+      { trackPrevious: { onlyWhenChanged: true } }
     )
   });
   await database.updateSchema(schema);
@@ -75,7 +75,7 @@ databaseTest('include old values when changed', async ({ database }) => {
   await database.execute('UPDATE lists SET name = ?', ['new name']);
  
   const batch = await database.getNextCrudTransaction();
-  expect(batch?.crud[0].oldData).toStrictEqual({name: 'name'});
+  expect(batch?.crud[0].previousValues).toStrictEqual({name: 'name'});
 });
 
 databaseTest('ignore empty update', async ({ database }) => {

--- a/packages/node/tests/crud.test.ts
+++ b/packages/node/tests/crud.test.ts
@@ -9,7 +9,7 @@ databaseTest('include metadata', async ({ database }) => {
       {
         name: column.text
       },
-      { includeMetadata: true }
+      { trackMetadata: true }
     )
   });
   await database.updateSchema(schema);
@@ -26,7 +26,7 @@ databaseTest('include old values', async ({ database }) => {
       {
         name: column.text
       },
-      { includeOld: true }
+      { trackOld: true }
     )
   });
   await database.updateSchema(schema);
@@ -46,7 +46,7 @@ databaseTest('include old values with column filter', async ({ database }) => {
         name: column.text,
         content: column.text
       },
-      { includeOld: { columns: ['name'] } }
+      { trackOld: { columns: ['name'] } }
     )
   });
   await database.updateSchema(schema);
@@ -66,7 +66,7 @@ databaseTest('include old values when changed', async ({ database }) => {
         name: column.text,
         content: column.text
       },
-      { includeOld: { onlyWhenChanged: true } }
+      { trackOld: { onlyWhenChanged: true } }
     )
   });
   await database.updateSchema(schema);
@@ -85,7 +85,7 @@ databaseTest('ignore empty update', async ({ database }) => {
       {
         name: column.text
       },
-      { ignoreEmptyUpdate: true }
+      { ignoreEmptyUpdates: true }
     )
   });
   await database.updateSchema(schema);

--- a/packages/node/tests/crud.test.ts
+++ b/packages/node/tests/crud.test.ts
@@ -1,0 +1,78 @@
+import { expect } from 'vitest';
+import { column, Schema, Table } from '@powersync/common';
+import { databaseTest } from './utils';
+
+databaseTest('include metadata', async ({ database }) => {
+  await database.init();
+  const schema = new Schema({
+    lists: new Table(
+      {
+        name: column.text
+      },
+      { includeMetadata: true }
+    )
+  });
+  await database.updateSchema(schema);
+  await database.execute('INSERT INTO lists (id, name, _metadata) VALUES (uuid(), ?, ?);', ['entry', 'so meta']);
+ 
+  const batch = await database.getNextCrudTransaction();
+  expect(batch?.crud[0].metadata).toBe('so meta');
+});
+
+databaseTest('include old values', async ({ database }) => {
+  await database.init();
+  const schema = new Schema({
+    lists: new Table(
+      {
+        name: column.text
+      },
+      { includeOld: true }
+    )
+  });
+  await database.updateSchema(schema);
+  await database.execute('INSERT INTO lists (id, name) VALUES (uuid(), ?);', ['entry']);
+  await database.execute('DELETE FROM ps_crud;');
+  await database.execute('UPDATE lists SET name = ?', ['new name']);
+ 
+  const batch = await database.getNextCrudTransaction();
+  expect(batch?.crud[0].oldData).toStrictEqual({name: 'entry'});
+});
+
+databaseTest('include old values when changed', async ({ database }) => {
+  await database.init();
+  const schema = new Schema({
+    lists: new Table(
+      {
+        name: column.text,
+        content: column.text
+      },
+      { includeOld: 'when-changed' }
+    )
+  });
+  await database.updateSchema(schema);
+  await database.execute('INSERT INTO lists (id, name, content) VALUES (uuid(), ?, ?);', ['name', 'content']);
+  await database.execute('DELETE FROM ps_crud;');
+  await database.execute('UPDATE lists SET name = ?', ['new name']);
+ 
+  const batch = await database.getNextCrudTransaction();
+  expect(batch?.crud[0].oldData).toStrictEqual({name: 'name'});
+});
+
+databaseTest('ignore empty update', async ({ database }) => {
+  await database.init();
+  const schema = new Schema({
+    lists: new Table(
+      {
+        name: column.text
+      },
+      { ignoreEmptyUpdate: true }
+    )
+  });
+  await database.updateSchema(schema);
+  await database.execute('INSERT INTO lists (id, name) VALUES (uuid(), ?);', ['name']);
+  await database.execute('DELETE FROM ps_crud;');
+  await database.execute('UPDATE lists SET name = ?', ['name']);
+ 
+  const batch = await database.getNextCrudTransaction();
+  expect(batch).toBeNull();
+});


### PR DESCRIPTION
This exposes the new table options introduced in version 0.3.13 of the core extension, namely:

- `include_old` (either a boolean or an array of column names): Adds an `old` entry to the `ps_crud.data` JSON object that includes old values for updates.
 - `include_old_only_when_changed`: Skip unchanged values from updates.
- `include_metadata`: Adds a `_metadata` column that can be written to for updates. It's reported through `CrudEntry.metadata` afterwards.
- `ignore_empty_update`: Don't create `ps_crud` entries for `UPDATE` statements that didn't change any values. 

Most of this feature is tested in the core extension, this adds a few simple tests ensuring we forward options correctly.