### PR TITLE
Bump WA-SQLite dependency to resolve OPFS issue

### DIFF
--- a/.changeset/shiny-carpets-mix.md
+++ b/.changeset/shiny-carpets-mix.md
@@ -1,0 +1,5 @@
+---
+'@powersync/web': patch
+---
+
+Fix an infinite loop when multiple tabs using `WASQLiteVFS.OPFSCoopSyncVFS` are using the database concurrently.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -60,7 +60,7 @@
   "author": "JOURNEYAPPS",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@journeyapps/wa-sqlite": "^1.2.3",
+    "@journeyapps/wa-sqlite": "^1.2.4",
     "@powersync/common": "workspace:^1.28.0"
   },
   "dependencies": {
@@ -71,7 +71,7 @@
     "commander": "^12.1.0"
   },
   "devDependencies": {
-    "@journeyapps/wa-sqlite": "^1.2.3",
+    "@journeyapps/wa-sqlite": "^1.2.4",
     "@types/uuid": "^9.0.6",
     "crypto-browserify": "^3.12.0",
     "p-defer": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
         version: 19.2.4(@angular/core@19.2.4(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.3
+        version: 1.2.4
       '@powersync/web':
         specifier: workspace:*
         version: link:../../packages/web
@@ -255,7 +255,7 @@ importers:
         version: 7.0.1(@capacitor/core@7.2.0)
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.3
+        version: 1.2.4
       '@powersync/react':
         specifier: workspace:*
         version: link:../../packages/react
@@ -310,7 +310,7 @@ importers:
         version: 11.13.0(@emotion/react@11.13.3(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.3
+        version: 1.2.4
       '@mui/icons-material':
         specifier: ^5.15.16
         version: 5.16.7(@mui/material@5.16.7(@emotion/react@11.13.3(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
@@ -498,7 +498,7 @@ importers:
         version: 5.1.0
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.3
+        version: 1.2.4
       '@lexical/react':
         specifier: ^0.15.0
         version: 0.15.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(yjs@13.6.19)
@@ -650,7 +650,7 @@ importers:
     dependencies:
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.3
+        version: 1.2.4
       '@powersync/react':
         specifier: workspace:*
         version: link:../../packages/react
@@ -1080,7 +1080,7 @@ importers:
         version: 2.4.3(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.8.2))(@types/react@18.3.18)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.3
+        version: 1.2.4
       '@powersync/attachments':
         specifier: workspace:*
         version: link:../../packages/attachments
@@ -1234,7 +1234,7 @@ importers:
         version: 11.11.5(@emotion/react@11.11.4(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.3
+        version: 1.2.4
       '@mui/icons-material':
         specifier: ^5.15.12
         version: 5.16.7(@mui/material@5.16.7(@emotion/react@11.11.4(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
@@ -1319,7 +1319,7 @@ importers:
         version: 11.11.5(@emotion/react@11.11.4(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.3
+        version: 1.2.4
       '@mui/icons-material':
         specifier: ^5.15.12
         version: 5.16.7(@mui/material@5.16.7(@emotion/react@11.11.4(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
@@ -1468,7 +1468,7 @@ importers:
     dependencies:
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.3
+        version: 1.2.4
       '@mui/material':
         specifier: ^5.15.12
         version: 5.16.7(@emotion/react@11.13.3(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1712,7 +1712,7 @@ importers:
     devDependencies:
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.3
+        version: 1.2.4
       '@powersync/web':
         specifier: workspace:*
         version: link:../web
@@ -1743,7 +1743,7 @@ importers:
     devDependencies:
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.3
+        version: 1.2.4
       '@powersync/web':
         specifier: workspace:*
         version: link:../web
@@ -1999,8 +1999,8 @@ importers:
         version: 12.1.0
     devDependencies:
       '@journeyapps/wa-sqlite':
-        specifier: ^1.2.3
-        version: 1.2.3
+        specifier: ^1.2.4
+        version: 1.2.4
       '@types/uuid':
         specifier: ^9.0.6
         version: 9.0.8
@@ -2048,7 +2048,7 @@ importers:
     dependencies:
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.3
+        version: 1.2.4
       '@mui/material':
         specifier: ^5.15.12
         version: 5.16.7(@emotion/react@11.13.3(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5109,8 +5109,8 @@ packages:
       react: '*'
       react-native: '*'
 
-  '@journeyapps/wa-sqlite@1.2.3':
-    resolution: {integrity: sha512-+VJf64cdQzMd0rbN5pLDwUzhTLVD7qpihiE5fLP/aiS18phJJBSNUpJ8awLKTjWxTkkW1OEOzRUgANIeDPp4hw==}
+  '@journeyapps/wa-sqlite@1.2.4':
+    resolution: {integrity: sha512-pr8fksYO7lX27XoRH6CC1Qh1YvzoKxi4AzQFJuNNPhXEwahOvgM/Ln7P6dLH7uHRSKqyQ1fyHqHrDMsXzCPI9g==}
 
   '@jridgewell/gen-mapping@0.3.5':
     resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
@@ -24736,7 +24736,7 @@ snapshots:
       react: 18.3.1
       react-native: 0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.8.2))(@types/react@18.3.18)(encoding@0.1.13)(react@18.3.1)
 
-  '@journeyapps/wa-sqlite@1.2.3': {}
+  '@journeyapps/wa-sqlite@1.2.4': {}
 
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:


### PR DESCRIPTION
This updates `@journeyapps/wa-sqlite` to version `1.2.4`, which fixes an issue we've seen when multiple tabs using `OPFSCoopSyncVFS` are initializing the database in quick succession.

Since we have a `^` dependency this is not technically necessary, but it's still nice to be explicit about it so that we can point at a minimum version of `@powersync/web` that we expect to work.