### PR TITLE
Fix missing filter when setting `last_op`

### DIFF
--- a/.changeset/polite-news-sneeze.md
+++ b/.changeset/polite-news-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Fix applying bucket state around partial syncs.

--- a/packages/common/src/client/sync/bucket/SqliteBucketStorage.ts
+++ b/packages/common/src/client/sync/bucket/SqliteBucketStorage.ts
@@ -154,9 +154,9 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
       return { ready: false, checkpointValid: false, checkpointFailures: r.checkpointFailures };
     }
 
-    const buckets = checkpoint.buckets;
+    let buckets = checkpoint.buckets;
     if (priority !== undefined) {
-      buckets.filter((b) => hasMatchingPriority(priority, b));
+      buckets = buckets.filter((b) => hasMatchingPriority(priority, b));
     }
     const bucketNames = buckets.map((b) => b.bucket);
     await this.writeTransaction(async (tx) => {


### PR DESCRIPTION
After we receive a (partial) checkpoint complete and have validated checksums, we set `last_op` to the `last_op_id` of the checkpoint for involved buckets.

Due to an ignored filter in `syncLocalDatabase`, we were raising `last_op` even for buckets with lower priorities when receiving a partial completion for a higher priority. Having a wrong value in `last_op_id` is a problem when the sync stream gets reset without completing a full checkpoint afterwards, because we use that value to create the next request when reconnecting.