### PR TITLE
[Diagnostics App] Fix partial checkpoints (bucket priorities)

### DIFF
--- a/.changeset/cuddly-news-carry.md
+++ b/.changeset/cuddly-news-carry.md
@@ -1,0 +1,5 @@
+---
+'@powersync/diagnostics-app': patch
+---
+
+Fix handling of partial checkpoints

--- a/tools/diagnostics-app/src/library/powersync/RecordingStorageAdapter.ts
+++ b/tools/diagnostics-app/src/library/powersync/RecordingStorageAdapter.ts
@@ -41,8 +41,9 @@ export class RecordingStorageAdapter extends SqliteBucketStorage {
     });
   }
 
-  async syncLocalDatabase(checkpoint: Checkpoint) {
-    const r = await super.syncLocalDatabase(checkpoint);
+  async syncLocalDatabase(checkpoint: Checkpoint, priority?: number) {
+    const r = await super.syncLocalDatabase(checkpoint, priority);
+
     // Refresh schema asynchronously, to allow us to better measure
     // performance of initial sync.
     setTimeout(() => {


### PR DESCRIPTION
The diagnostics app overrides SqliteBucketStorage to track some metadata. This was not updated when we implemented bucket priorities, resulting in checksum failures in the diagnostics app when bucket priorities are used.

The symptoms would be repeated logs like below, and never completing the sync.

```
[PowerSyncStream] Partial checkpoint complete 1
[SqliteBucketStorage] validateChecksums priority, checkpoint, result item undefined, {...}
[SqliteBucketStorage] Checksums failed for ...
[SqliteBucketStorage] done deleting bucket
```

This issue was specific to the diagnostics app, and did not affect any other SDK clients.

The deployed diagnostics app version was a little outdated, and not affected by this issue.