### PR TITLE
poc: Expo Fetch

### DIFF
--- a/.changeset/many-fishes-camp.md
+++ b/.changeset/many-fishes-camp.md
@@ -1,0 +1,5 @@
+---
+'@powersync/react-native': minor
+---
+
+Added ability to use Expo's fetch API if available.

--- a/packages/react-native/src/sync/stream/ReactNativeRemote.ts
+++ b/packages/react-native/src/sync/stream/ReactNativeRemote.ts
@@ -27,7 +27,24 @@ export const STREAMING_POST_TIMEOUT_MS = 30_000;
  * a polyfill.
  */
 class ReactNativeFetchProvider extends FetchImplementationProvider {
+  constructor(public logger: ILogger = DEFAULT_REMOTE_LOGGER) {
+    super();
+  }
+
   getFetch(): FetchImplementation {
+    /**
+     * From Expo 52, Expo provides a fetch implementation which supports HTTP streams.
+     * https://docs.expo.dev/versions/latest/sdk/expo/#expofetch-api
+     */
+    try {
+      const f = require('expo/fetch').fetch;
+      if (f) {
+        this.logger.debug('Using Expo fetch implementation');
+        return f;
+      }
+    } catch (e) {
+      // If expo is not installed, fallback
+    }
     return fetch.bind(globalThis);
   }
 }
@@ -40,7 +57,7 @@ export class ReactNativeRemote extends AbstractRemote {
   ) {
     super(connector, logger, {
       ...(options ?? {}),
-      fetchImplementation: options?.fetchImplementation ?? new ReactNativeFetchProvider()
+      fetchImplementation: options?.fetchImplementation ?? new ReactNativeFetchProvider(logger)
     });
   }
 


### PR DESCRIPTION
# Overview

We currently use `react-native-fetch-api` in the React Native SDK to perform `fetch` operations. This is required since the standard React Native `fetch` implementation does not support HTTP text streaming. 

Some users recently reported errors of the form 
```
[PowerSyncStream] Caught exception when uploading. Upload will retry after a delay. Exception: require(_dependencyMap[11], "rea(...)/BlobManager").createFromOptions is not a function (it is undefined)
```
Which most likely is caused by `react-native-fetch-api`.

Expo 52 introduced their own [implementation](https://docs.expo.dev/versions/latest/sdk/expo/#expofetch-api) for `fetch` which supports HTTP streaming. 

This PR attempts to require and use Expo's fetch implementation (if available) - we default to `react-native-fetch-api` if Expo >= 52 is not installed.