### PR TITLE
[Feature] getNextCrudTransactionBatch

### DIFF
--- a/.changeset/new-days-fry.md
+++ b/.changeset/new-days-fry.md
@@ -1,0 +1,8 @@
+---
+'@powersync/common': minor
+'@powersync/web': minor
+'@powersync/node': minor
+'@powersync/react-native': minor
+---
+
+Added `getNextCrudTransactionBatch` method which allows batch uploads for multiple transactions


### PR DESCRIPTION
# Overview

Some users have requested the ability to batch upload multiple transactions using the uploadData handler. However, the existing getNextCrudBatch and getNextCrudTransaction methods make this process somewhat cumbersome.

getNextCrudBatch does not group items by transaction, and completing the batch removes all of its CRUD items from the queue. This makes it difficult for developers to fetch and complete a batch corresponding to multiple related transactions.

getNextCrudTransaction returns only the CRUD entries for a single transaction. Developers are effectively forced to upload transactions one at a time, as repeated calls will continue to return the first pending transaction until it has been completed.

This PR introduces a new method, getNextCrudTransactionBatch (name subject to change), which returns a CrudBatch containing items from multiple CRUD transactions. This allows for more efficient and flexible batch uploads.

 