### PR TITLE
fix: Broadcast logger not being being passed to WebRemote

### DIFF
--- a/.changeset/honest-melons-laugh.md
+++ b/.changeset/honest-melons-laugh.md
@@ -1,0 +1,5 @@
+---
+'@powersync/web': patch
+---
+
+Fixed issue where broadcast logger wasn't being passed to WebRemote, causing worker remote logs not to be broadcasted to the tab's logs.

--- a/packages/web/src/worker/sync/SharedSyncImplementation.ts
+++ b/packages/web/src/worker/sync/SharedSyncImplementation.ts
@@ -306,28 +306,31 @@ export class SharedSyncImplementation
     // Create a new StreamingSyncImplementation for each connect call. This is usually done is all SDKs.
     return new WebStreamingSyncImplementation({
       adapter: new SqliteBucketStorage(this.dbAdapter!, new Mutex(), this.logger),
-      remote: new WebRemote({
-        fetchCredentials: async () => {
-          const lastPort = this.ports[this.ports.length - 1];
-          return new Promise(async (resolve, reject) => {
-            const abortController = new AbortController();
-            this.fetchCredentialsController = {
-              controller: abortController,
-              activePort: lastPort
-            };
+      remote: new WebRemote(
+        {
+          fetchCredentials: async () => {
+            const lastPort = this.ports[this.ports.length - 1];
+            return new Promise(async (resolve, reject) => {
+              const abortController = new AbortController();
+              this.fetchCredentialsController = {
+                controller: abortController,
+                activePort: lastPort
+              };
 
-            abortController.signal.onabort = reject;
-            try {
-              this.logger.log('calling the last port client provider for credentials');
-              resolve(await lastPort.clientProvider.fetchCredentials());
-            } catch (ex) {
-              reject(ex);
-            } finally {
-              this.fetchCredentialsController = undefined;
-            }
-          });
-        }
-      }),
+              abortController.signal.onabort = reject;
+              try {
+                this.logger.log('calling the last port client provider for credentials');
+                resolve(await lastPort.clientProvider.fetchCredentials());
+              } catch (ex) {
+                reject(ex);
+              } finally {
+                this.fetchCredentialsController = undefined;
+              }
+            });
+          }
+        },
+        this.logger
+      ),
       uploadCrud: async () => {
         const lastPort = this.ports[this.ports.length - 1];
 


### PR DESCRIPTION
This was causing worker remote logs not to be broadcasted to the individual tabs' logs. Missing parameter on construction of the WebRemote in SharedSyncImplementation - `this.logger` will be set to `this.broadcastLogger` when the `broadcastLogs` flag is true (defaults to true).

After this change you can see the remote logs:
| log call | Log in tab's console |
|--------|--------|
| ![Screenshot 2025-05-15 at 10 18 17](https://github.com/user-attachments/assets/d9aca1c6-1c02-4f87-bcb1-1a9ec7245b1a) | ![Screenshot 2025-05-15 at 10 21 45](https://github.com/user-attachments/assets/2c7add01-a507-49fa-8061-ac051a4dee26) | 



