### PR TITLE
feat: Fetch credentials on token expiry/401

### DIFF
--- a/.changeset/cool-yaks-allow.md
+++ b/.changeset/cool-yaks-allow.md
@@ -1,0 +1,5 @@
+---
+'@powersync/web': minor
+---
+
+To support the upstream credentials management changes from `@powersync/common`, the sync worker now communicates credentials invalidation to tabs.

--- a/.changeset/shiny-rules-invent.md
+++ b/.changeset/shiny-rules-invent.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': minor
+---
+
+Improved credentials management and error handling. Credentials are invalidated when they expire or become invalid. The frequency of credential fetching has been reduced as a result of this work.

--- a/.changeset/shiny-rules-invent.md
+++ b/.changeset/shiny-rules-invent.md
@@ -2,4 +2,4 @@
 '@powersync/common': minor
 ---
 
-Improved credentials management and error handling. Credentials are invalidated when they expire or become invalid. The frequency of credential fetching has been reduced as a result of this work.
+Improved credentials management and error handling. Credentials are invalidated when they expire or become invalid based on responses from the PowerSync service. The frequency of credential fetching has been reduced as a result of this work.

--- a/packages/common/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/common/src/client/sync/stream/AbstractRemote.ts
@@ -396,9 +396,17 @@ export abstract class AbstractRemote {
         syncQueueRequestSize, // The initial N amount
         {
           onError: (e) => {
-            if (e.message.includes('Authorization failed') || e.message.includes('PSYNC_S21')) {
-              this.invalidateCredentials();
+            if (e.message.includes('PSYNC_')) {
+              if (e.message.includes('PSYNC_S21')) {
+                this.invalidateCredentials();
+              }
+            } else {
+              // Possible that connection is with an older service, always invalidate to be safe
+              if (e.message !== 'Closed. ') {
+                this.invalidateCredentials();
+              }
             }
+
             // Don't log closed as an error
             if (e.message !== 'Closed. ') {
               this.logger.error(e);

--- a/packages/common/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/common/src/client/sync/stream/AbstractRemote.ts
@@ -163,8 +163,6 @@ export abstract class AbstractRemote {
    *
    * This should always fetch a fresh set of credentials - don't use cached
    * values.
-   *
-   *
    */
   async fetchCredentials() {
     const credentials = await this.connector.fetchCredentials();
@@ -223,6 +221,10 @@ export abstract class AbstractRemote {
       body: JSON.stringify(data)
     });
 
+    if (res.status === 401) {
+      this.invalidateCredentials();
+    }
+
     if (!res.ok) {
       throw new Error(`Received ${res.status} - ${res.statusText} when posting to ${path}: ${await res.text()}}`);
     }
@@ -239,6 +241,10 @@ export abstract class AbstractRemote {
         ...request.headers
       }
     });
+
+    if (res.status === 401) {
+      this.invalidateCredentials();
+    }
 
     if (!res.ok) {
       throw new Error(`Received ${res.status} - ${res.statusText} when getting from ${path}: ${await res.text()}}`);
@@ -265,6 +271,10 @@ export abstract class AbstractRemote {
       this.logger.error(`Caught ex when POST streaming to ${path}`, ex);
       throw ex;
     });
+
+    if (res.status === 401) {
+      this.invalidateCredentials();
+    }
 
     if (!res.ok) {
       const text = await res.text();

--- a/packages/common/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/common/src/client/sync/stream/AbstractRemote.ts
@@ -21,8 +21,6 @@ export type RemoteConnector = {
 const POWERSYNC_TRAILING_SLASH_MATCH = /\/+$/;
 const POWERSYNC_JS_VERSION = PACKAGE.version;
 
-// Refresh at least 30 sec before it expires
-const REFRESH_CREDENTIALS_SAFETY_PERIOD_MS = 30_000;
 const SYNC_QUEUE_REQUEST_LOW_WATER = 5;
 
 // Keep alive message is sent every period

--- a/packages/common/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/common/src/client/sync/stream/AbstractRemote.ts
@@ -396,7 +396,7 @@ export abstract class AbstractRemote {
         syncQueueRequestSize, // The initial N amount
         {
           onError: (e) => {
-            if (e.message.includes('Authorization failed') || e.message.includes('401')) {
+            if (e.message.includes('Authorization failed')) {
               this.invalidateCredentials();
             }
             // Don't log closed as an error

--- a/packages/common/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/common/src/client/sync/stream/AbstractRemote.ts
@@ -396,7 +396,7 @@ export abstract class AbstractRemote {
         syncQueueRequestSize, // The initial N amount
         {
           onError: (e) => {
-            if (e.message.includes('Authorization failed')) {
+            if (e.message.includes('Authorization failed') || e.message.includes('PSYNC_S21')) {
               this.invalidateCredentials();
             }
             // Don't log closed as an error

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -691,6 +691,11 @@ The next upload iteration will be delayed.`);
                */
               await this.delayRetry();
               return;
+            } else if (remaining_seconds < 30) {
+              this.logger.debug('Token will expire soon; reconnect');
+              // Pre-emptively refresh the token
+              this.options.remote.invalidateCredentials();
+              return;
             }
             this.triggerCrudUpload();
           } else {

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -683,12 +683,13 @@ The next upload iteration will be delayed.`);
             if (remaining_seconds == 0) {
               // Connection would be closed automatically right after this
               this.logger.debug('Token expiring; reconnect');
-              /**
-               * For a rare case where the backend connector does not update the token
-               * (uses the same one), this should have some delay.
-               */
+              this.options.remote.invalidateCredentials();
+
               await this.delayRetry();
               return;
+            } else if (remaining_seconds < 30) {
+              // Pre-emptively refresh the token
+              await this.options.remote.prefetchCredentials();
             }
             this.triggerCrudUpload();
           } else {

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -687,9 +687,6 @@ The next upload iteration will be delayed.`);
 
               await this.delayRetry();
               return;
-            } else if (remaining_seconds < 30) {
-              // Pre-emptively refresh the token
-              await this.options.remote.prefetchCredentials();
             }
             this.triggerCrudUpload();
           } else {

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -685,6 +685,10 @@ The next upload iteration will be delayed.`);
               this.logger.debug('Token expiring; reconnect');
               this.options.remote.invalidateCredentials();
 
+              /**
+               * For a rare case where the backend connector does not update the token
+               * (uses the same one), this should have some delay.
+               */
               await this.delayRetry();
               return;
             }

--- a/packages/web/src/db/sync/SharedWebStreamingSyncImplementation.ts
+++ b/packages/web/src/db/sync/SharedWebStreamingSyncImplementation.ts
@@ -31,6 +31,10 @@ class SharedSyncClientProvider extends AbstractSharedSyncClientProvider {
     return Comlink.transfer(port, [port]);
   }
 
+  invalidateCredentials() {
+    this.options.remote.invalidateCredentials();
+  }
+
   async fetchCredentials(): Promise<PowerSyncCredentials | null> {
     const credentials = await this.options.remote.getCredentials();
     if (credentials == null) {

--- a/packages/web/src/worker/sync/AbstractSharedSyncClientProvider.ts
+++ b/packages/web/src/worker/sync/AbstractSharedSyncClientProvider.ts
@@ -5,6 +5,7 @@ import type { PowerSyncCredentials, SyncStatusOptions } from '@powersync/common'
  */
 export abstract class AbstractSharedSyncClientProvider {
   abstract fetchCredentials(): Promise<PowerSyncCredentials | null>;
+  abstract invalidateCredentials(): void;
   abstract uploadCrud(): Promise<void>;
   abstract statusChanged(status: SyncStatusOptions): void;
   abstract getDBWorkerPort(): Promise<MessagePort>;

--- a/packages/web/src/worker/sync/SharedSyncImplementation.ts
+++ b/packages/web/src/worker/sync/SharedSyncImplementation.ts
@@ -308,6 +308,15 @@ export class SharedSyncImplementation
       adapter: new SqliteBucketStorage(this.dbAdapter!, new Mutex(), this.logger),
       remote: new WebRemote(
         {
+          invalidateCredentials: async () => {
+            const lastPort = this.ports[this.ports.length - 1];
+            try {
+              this.logger.log('calling the last port client provider to invalidate credentials');
+              lastPort.clientProvider.invalidateCredentials();
+            } catch (ex) {
+              this.logger.error('error invalidating credentials', ex);
+            }
+          },
           fetchCredentials: async () => {
             const lastPort = this.ports[this.ports.length - 1];
             return new Promise(async (resolve, reject) => {


### PR DESCRIPTION
Improved credentials management and error handling. Credentials are invalidated when they expire or become invalid based on responses from the PowerSync service. The frequency of credential fetching has been reduced as a result of this work.

For web we need to communicate over the comlink from the worker to the main tab that invalidation needs to happen.

Follows a similar pattern applied to PowerSync Dart.

Alternative approach to https://github.com/powersync-ja/powersync-js/pull/528