### PR TITLE
Fix `dist/` missing for node releases

### DIFF
--- a/.changeset/odd-brooms-run.md
+++ b/.changeset/odd-brooms-run.md
@@ -1,0 +1,5 @@
+---
+'@powersync/node': patch
+---
+
+Fix CJS distributables not being published.

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "install": "node download_core.js",
     "build": "tsc -b && rollup --config",
-    "build:prod": "tsc -b --sourceMap false",
+    "build:prod": "build",
     "clean": "rm -rf lib dist tsconfig.tsbuildinfo dist",
     "watch": "tsc -b -w",
     "test": "vitest"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "install": "node download_core.js",
     "build": "tsc -b && rollup --config",
-    "build:prod": "build",
+    "build:prod": "tsc -b --sourceMap false && rollup --config",
     "clean": "rm -rf lib dist tsconfig.tsbuildinfo dist",
     "watch": "tsc -b -w",
     "test": "vitest"


### PR DESCRIPTION
To compile the Node SDK, we're using `rollup` to convert the ESM modules emitted by `tsc` into a CJS bundle for users who can't (or don't want to) import the package as an ESM module. These files are generated into a `dist/` directory by the `build` script in that package.

Unfortunately, the release logic doesn't call `build`, it runs `build:release` which didn't invoke `rollup`. This adds the missing invocation.