### PR TITLE
Diagnostics app reconnect

### DIFF
--- a/.changeset/silent-lions-cough.md
+++ b/.changeset/silent-lions-cough.md
@@ -1,0 +1,5 @@
+---
+'@powersync/diagnostics-app': patch
+---
+
+Fix reconnecting after changing credentials.

--- a/tools/diagnostics-app/src/app/views/layout.tsx
+++ b/tools/diagnostics-app/src/app/views/layout.tsx
@@ -43,7 +43,7 @@ export default function ViewsLayout({ children }: { children: React.ReactNode })
   const powerSync = usePowerSync();
   const navigate = useNavigate();
 
-  const [syncStatus, setSyncStatus] = React.useState(sync.syncStatus);
+  const [syncStatus, setSyncStatus] = React.useState(sync?.syncStatus);
   const [syncError, setSyncError] = React.useState<Error | null>(null);
   const { title } = useNavigationPanel();
 
@@ -101,13 +101,13 @@ export default function ViewsLayout({ children }: { children: React.ReactNode })
 
   // Cannot use `useStatus()`, since we're not using the default sync implementation.
   React.useEffect(() => {
-    const l = sync.registerListener({
+    const l = sync?.registerListener({
       statusChanged: (status) => {
         setSyncStatus(status);
         setSyncError(status.dataFlowStatus.downloadError ?? null);
       }
     });
-    return () => l();
+    return () => l?.();
   }, []);
 
   const drawerWidth = 320;

--- a/tools/diagnostics-app/src/app/views/sync-diagnostics.tsx
+++ b/tools/diagnostics-app/src/app/views/sync-diagnostics.tsx
@@ -82,7 +82,7 @@ export default function SyncDiagnosticsPage() {
     // Similar to db.currentState.hasSynced, but synchronized to the onChange events
     const { synced_at } = await db.get<{ synced_at: string | null }>('SELECT powersync_last_synced_at() as synced_at');
     setlastSyncedAt(synced_at ? new Date(synced_at + 'Z') : null);
-    if (synced_at != null && !sync.syncStatus.dataFlowStatus.downloading) {
+    if (synced_at != null && !sync?.syncStatus.dataFlowStatus.downloading) {
       // These are potentially expensive queries - do not run during initial sync
       const bucketRows = await db.getAll(BUCKETS_QUERY);
       const tableRows = await db.getAll(TABLES_QUERY);


### PR DESCRIPTION
Since #604, credentials are cached on the Remote, and diagnostics-app re-used the same WebRemote when reconnecting with different credentials (token and/or endpoint). This caused the diagnostics-app to re-use old credentials, which is confusing if you edit it directly on the login screen.

This did not affect the hosted version of the diagnostics-app, which is still on an older version.

This should not affect other apps in the same way, since apps typically don't instantiate the Remote directly.
