### PR TITLE
Include metadata and previous values in CRUD entry JSON

### DIFF
--- a/.changeset/slimy-cougars-rush.md
+++ b/.changeset/slimy-cougars-rush.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Include metadata and previous values when serializing CRUD entries to JSON.

--- a/packages/common/src/client/sync/bucket/CrudEntry.ts
+++ b/packages/common/src/client/sync/bucket/CrudEntry.ts
@@ -42,6 +42,8 @@ type CrudEntryOutputJSON = {
   id: string;
   tx_id?: number;
   data?: Record<string, any>;
+  old?: Record<string, any>;
+  metadata?: string;
 };
 
 /**
@@ -132,7 +134,9 @@ export class CrudEntry {
       type: this.table,
       id: this.id,
       tx_id: this.transactionId,
-      data: this.opData
+      data: this.opData,
+      old: this.previousValues,
+      metadata: this.metadata
     };
   }
 
@@ -154,6 +158,15 @@ export class CrudEntry {
    * Generates an array for use in deep comparison operations
    */
   toComparisonArray() {
-    return [this.transactionId, this.clientId, this.op, this.table, this.id, this.opData];
+    return [
+      this.transactionId,
+      this.clientId,
+      this.op,
+      this.table,
+      this.id,
+      this.opData,
+      this.previousValues,
+      this.metadata
+    ];
   }
 }


### PR DESCRIPTION
This makes `CrudEntry.toJSON()` include previous values and metadata, with the same keys for serialization as thos used in the Dart SDK.