### PR TITLE
Update core version to version 0.4.0

### DIFF
--- a/.changeset/short-gifts-turn.md
+++ b/.changeset/short-gifts-turn.md
@@ -1,0 +1,8 @@
+---
+'@powersync/op-sqlite': patch
+'@powersync/react-native': patch
+'@powersync/node': patch
+'@powersync/web': patch
+---
+
+Update PowerSync core extension to 0.4.0

--- a/demos/django-react-native-todolist/package.json
+++ b/demos/django-react-native-todolist/package.json
@@ -11,7 +11,7 @@
     "@azure/core-asynciterator-polyfill": "^1.0.2",
     "@expo/metro-runtime": "^4.0.1",
     "@expo/vector-icons": "^14.0.0",
-    "@journeyapps/react-native-quick-sqlite": "^2.4.4",
+    "@journeyapps/react-native-quick-sqlite": "^2.4.5",
     "@powersync/common": "workspace:*",
     "@powersync/react": "workspace:*",
     "@powersync/react-native": "workspace:*",

--- a/demos/react-native-supabase-group-chat/package.json
+++ b/demos/react-native-supabase-group-chat/package.json
@@ -22,7 +22,7 @@
     "@azure/core-asynciterator-polyfill": "^1.0.2",
     "@expo/metro-runtime": "^4.0.1",
     "@faker-js/faker": "8.3.1",
-    "@journeyapps/react-native-quick-sqlite": "^2.4.4",
+    "@journeyapps/react-native-quick-sqlite": "^2.4.5",
     "@powersync/common": "workspace:*",
     "@powersync/react": "workspace:*",
     "@powersync/react-native": "workspace:*",

--- a/demos/react-native-supabase-todolist/package.json
+++ b/demos/react-native-supabase-todolist/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@azure/core-asynciterator-polyfill": "^1.0.2",
     "@expo/vector-icons": "^14.0.3",
-    "@journeyapps/react-native-quick-sqlite": "^2.4.4",
+    "@journeyapps/react-native-quick-sqlite": "^2.4.5",
     "@powersync/attachments": "workspace:*",
     "@powersync/common": "workspace:*",
     "@powersync/react": "workspace:*",

--- a/demos/react-native-web-supabase-todolist/package.json
+++ b/demos/react-native-web-supabase-todolist/package.json
@@ -13,7 +13,7 @@
     "@azure/core-asynciterator-polyfill": "^1.0.2",
     "@expo/metro-runtime": "^4.0.1",
     "@expo/vector-icons": "^14.0.2",
-    "@journeyapps/react-native-quick-sqlite": "^2.4.0",
+    "@journeyapps/react-native-quick-sqlite": "^2.4.5",
     "@journeyapps/wa-sqlite": "^1.2.0",
     "@powersync/attachments": "workspace:*",
     "@powersync/react": "workspace:*",

--- a/packages/node/download_core.js
+++ b/packages/node/download_core.js
@@ -8,13 +8,13 @@ import { finished } from 'node:stream/promises';
 import { exit } from 'node:process';
 
 // When changing this version, run node download_core.js update_hashes
-const version = '0.3.14';
+const version = '0.4.0';
 const versionHashes = {
-  'powersync_x64.dll': 'ba0fda2496878d195ea5530562509cc585fa4702fd308594d0eef6f37060dafe',
-  'libpowersync_x64.so': '4cee8675b78af786f26f1e1666367de3d228f584084cca257e879060302c1371',
-  'libpowersync_aarch64.so': 'ed4ec55cb29ac4b295dc076de71e4247b08d46db562a53e2875cc47420a97a55',
-  'libpowersync_x64.dylib': 'cec6fb04732dd8c9a8ec6c6028b1b996965a0a359b0461d7dd6aa885d6eccddf',
-  'libpowersync_aarch64.dylib': '55b60e156c3ddc9e7d6fae273943b94b83481c861676c9bcd1e2cfcea02b0a18'
+  'powersync_x64.dll': 'f15ba428cda09ed671cf54996a93745e2ff268475ea82bccba102acb1c1d2398',
+  'libpowersync_x64.so': 'b9175b6b235619aa3eb80d69a42cab961ecf12ecb1a2ae7d7d1e3fb817117ed8',
+  'libpowersync_aarch64.so': 'fe6cbe67b5bc8944a3a01829c1f72407ada0c8d5f7a2eb18f7f1326f90125451',
+  'libpowersync_x64.dylib': '8175c97148ecc25a13e4c31fa413a34c5ace24fc11fbf2655da5948e832b733b',
+  'libpowersync_aarch64.dylib': '7c1c9189e564c06214d8035ec5830670cef5b21eb37715db0289a57b25e84aa5'
 };
 
 const platform = OS.platform();

--- a/packages/powersync-op-sqlite/android/build.gradle
+++ b/packages/powersync-op-sqlite/android/build.gradle
@@ -107,7 +107,7 @@ repositories {
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
-  implementation 'co.powersync:powersync-sqlite-core:0.3.14'
+  implementation 'co.powersync:powersync-sqlite-core:0.4.0'
   // For < 0.71, this will be from the local maven repo
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion

--- a/packages/powersync-op-sqlite/powersync-op-sqlite.podspec
+++ b/packages/powersync-op-sqlite/powersync-op-sqlite.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React-callinvoker"
   s.dependency "React"
-  s.dependency "powersync-sqlite-core", "~> 0.3.14"
+  s.dependency "powersync-sqlite-core", "~> 0.4.0"
   if defined?(install_modules_dependencies())
     install_modules_dependencies(s)
   else

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://docs.powersync.com/",
   "peerDependencies": {
-    "@journeyapps/react-native-quick-sqlite": "^2.4.4",
+    "@journeyapps/react-native-quick-sqlite": "^2.4.5",
     "@powersync/common": "workspace:^1.32.0",
     "react": "*",
     "react-native": "*"
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@craftzdog/react-native-buffer": "^6.0.5",
-    "@journeyapps/react-native-quick-sqlite": "^2.4.4",
+    "@journeyapps/react-native-quick-sqlite": "^2.4.5",
     "@rollup/plugin-alias": "^5.1.0",
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-inject": "^5.0.5",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -60,7 +60,7 @@
   "author": "JOURNEYAPPS",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@journeyapps/wa-sqlite": "^1.2.4",
+    "@journeyapps/wa-sqlite": "^1.2.5",
     "@powersync/common": "workspace:^1.32.0"
   },
   "dependencies": {
@@ -71,7 +71,7 @@
     "commander": "^12.1.0"
   },
   "devDependencies": {
-    "@journeyapps/wa-sqlite": "^1.2.4",
+    "@journeyapps/wa-sqlite": "^1.2.5",
     "@types/uuid": "^9.0.6",
     "crypto-browserify": "^3.12.0",
     "p-defer": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
         version: 19.2.14(@angular/core@19.2.14(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2)
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.4
+        version: 1.2.5
       '@powersync/web':
         specifier: workspace:*
         version: link:../../packages/web
@@ -121,8 +121,8 @@ importers:
         specifier: ^14.0.0
         version: 14.1.0(fdc5ce3de8aabd6226c79743411018d7)
       '@journeyapps/react-native-quick-sqlite':
-        specifier: ^2.4.4
-        version: 2.4.4(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: ^2.4.5
+        version: 2.4.5(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@powersync/common':
         specifier: workspace:*
         version: link:../../packages/common
@@ -255,7 +255,7 @@ importers:
         version: 7.0.1(@capacitor/core@7.3.0)
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.4
+        version: 1.2.5
       '@powersync/react':
         specifier: workspace:*
         version: link:../../packages/react
@@ -310,7 +310,7 @@ importers:
         version: 11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.4
+        version: 1.2.5
       '@mui/icons-material':
         specifier: ^5.15.16
         version: 5.17.1(@mui/material@5.17.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
@@ -498,7 +498,7 @@ importers:
         version: 5.2.5
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.4
+        version: 1.2.5
       '@lexical/react':
         specifier: ^0.15.0
         version: 0.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(yjs@13.6.27)
@@ -653,7 +653,7 @@ importers:
     dependencies:
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.4
+        version: 1.2.5
       '@powersync/react':
         specifier: workspace:*
         version: link:../../packages/react
@@ -807,8 +807,8 @@ importers:
         specifier: 8.3.1
         version: 8.3.1
       '@journeyapps/react-native-quick-sqlite':
-        specifier: ^2.4.4
-        version: 2.4.4(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.3.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: ^2.4.5
+        version: 2.4.5(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.3.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@powersync/common':
         specifier: workspace:*
         version: link:../../packages/common
@@ -823,7 +823,7 @@ importers:
         version: 1.23.1(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.3.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))
       '@shopify/flash-list':
         specifier: 1.7.3
-        version: 1.7.3(@babel/runtime@7.27.4)(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.3.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        version: 1.7.3(@babel/runtime@7.27.6)(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.3.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@supabase/supabase-js':
         specifier: 2.39.0
         version: 2.39.0
@@ -940,8 +940,8 @@ importers:
         specifier: ^14.0.3
         version: 14.1.0(fdc5ce3de8aabd6226c79743411018d7)
       '@journeyapps/react-native-quick-sqlite':
-        specifier: ^2.4.4
-        version: 2.4.4(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: ^2.4.5
+        version: 2.4.5(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@powersync/attachments':
         specifier: workspace:*
         version: link:../../packages/attachments
@@ -1079,11 +1079,11 @@ importers:
         specifier: ^14.0.2
         version: 14.1.0(fdc5ce3de8aabd6226c79743411018d7)
       '@journeyapps/react-native-quick-sqlite':
-        specifier: ^2.4.0
-        version: 2.4.4(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: ^2.4.5
+        version: 2.4.5(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.4
+        version: 1.2.5
       '@powersync/attachments':
         specifier: workspace:*
         version: link:../../packages/attachments
@@ -1237,7 +1237,7 @@ importers:
         version: 11.11.5(@emotion/react@11.11.4(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.4
+        version: 1.2.5
       '@mui/icons-material':
         specifier: ^5.15.12
         version: 5.17.1(@mui/material@5.17.1(@emotion/react@11.11.4(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
@@ -1322,7 +1322,7 @@ importers:
         version: 11.11.5(@emotion/react@11.11.4(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.4
+        version: 1.2.5
       '@mui/icons-material':
         specifier: ^5.15.12
         version: 5.17.1(@mui/material@5.17.1(@emotion/react@11.11.4(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.23)(react@18.3.1)
@@ -1471,7 +1471,7 @@ importers:
     dependencies:
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.4
+        version: 1.2.5
       '@mui/material':
         specifier: ^5.15.12
         version: 5.17.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1489,10 +1489,10 @@ importers:
         version: 2.49.9
       '@tiptap/extension-collaboration':
         specifier: 2.2.2
-        version: 2.2.2(@tiptap/core@2.12.0(@tiptap/pm@2.12.0))(@tiptap/pm@2.12.0)(y-prosemirror@1.3.5(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.39.3)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27))
+        version: 2.2.2(@tiptap/core@2.12.0(@tiptap/pm@2.12.0))(@tiptap/pm@2.12.0)(y-prosemirror@1.3.5(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.40.0)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27))
       '@tiptap/extension-collaboration-cursor':
         specifier: 2.2.2
-        version: 2.2.2(@tiptap/core@2.12.0(@tiptap/pm@2.12.0))(y-prosemirror@1.3.5(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.39.3)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27))
+        version: 2.2.2(@tiptap/core@2.12.0(@tiptap/pm@2.12.0))(y-prosemirror@1.3.5(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.40.0)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27))
       '@tiptap/extension-highlight':
         specifier: 2.2.2
         version: 2.2.2(@tiptap/core@2.12.0(@tiptap/pm@2.12.0))
@@ -1715,7 +1715,7 @@ importers:
     devDependencies:
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.4
+        version: 1.2.5
       '@powersync/web':
         specifier: workspace:*
         version: link:../web
@@ -1746,7 +1746,7 @@ importers:
     devDependencies:
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.4
+        version: 1.2.5
       '@powersync/web':
         specifier: workspace:*
         version: link:../web
@@ -1886,8 +1886,8 @@ importers:
         specifier: ^6.0.5
         version: 6.1.0(react-native@0.72.4(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@journeyapps/react-native-quick-sqlite':
-        specifier: ^2.4.4
-        version: 2.4.4(react-native@0.72.4(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
+        specifier: ^2.4.5
+        version: 2.4.5(react-native@0.72.4(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
       '@rollup/plugin-alias':
         specifier: ^5.1.0
         version: 5.1.1(rollup@4.14.3)
@@ -1996,8 +1996,8 @@ importers:
         version: 12.1.0
     devDependencies:
       '@journeyapps/wa-sqlite':
-        specifier: ^1.2.4
-        version: 1.2.4
+        specifier: ^1.2.5
+        version: 1.2.5
       '@types/uuid':
         specifier: ^9.0.6
         version: 9.0.8
@@ -2045,7 +2045,7 @@ importers:
     dependencies:
       '@journeyapps/wa-sqlite':
         specifier: ^1.2.0
-        version: 1.2.4
+        version: 1.2.5
       '@mui/material':
         specifier: ^5.15.12
         version: 5.17.1(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3384,6 +3384,10 @@ packages:
 
   '@babel/runtime@7.27.4':
     resolution: {integrity: sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.27.6':
+    resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
@@ -5463,14 +5467,14 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  '@journeyapps/react-native-quick-sqlite@2.4.4':
-    resolution: {integrity: sha512-XoAGByoyxJqKNTh0lqakRb/A8uZwksbP4KaYXqcEmeGyOBxhOdjBDR15pkCIMoJU1JTBzU8LXxQRtx20+7jCWg==}
+  '@journeyapps/react-native-quick-sqlite@2.4.5':
+    resolution: {integrity: sha512-jFXGC0uklFgEBFS9rekyUmHG1LrG/3bl1r7RKjX42RS70Ir6TOj2naPd/Gj4laKepSxUByOqWQhXSoNwD8WBNQ==}
     peerDependencies:
       react: '*'
       react-native: '*'
 
-  '@journeyapps/wa-sqlite@1.2.4':
-    resolution: {integrity: sha512-pr8fksYO7lX27XoRH6CC1Qh1YvzoKxi4AzQFJuNNPhXEwahOvgM/Ln7P6dLH7uHRSKqyQ1fyHqHrDMsXzCPI9g==}
+  '@journeyapps/wa-sqlite@1.2.5':
+    resolution: {integrity: sha512-h04kyOtKoZbGG9Zslgq8K4+umeiVNvauYoR6fPFOzzacIlfnh6VWYevuFOKIM7yUIQo15q1tYOym3eDiyTsVUA==}
 
   '@jridgewell/gen-mapping@0.3.8':
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
@@ -5593,8 +5597,8 @@ packages:
     bundledDependencies:
       - '@libsql/libsql-wasm-experimental'
 
-  '@libsql/core@0.15.8':
-    resolution: {integrity: sha512-oX2fQqDbZkaBUvFMGvJq1Jh+mVzJrgNbEwK6Wzvp91z3uMe9iaIIXgO8yxB72RpUf7BqzjiKHjEiRXytfTdbUw==}
+  '@libsql/core@0.15.9':
+    resolution: {integrity: sha512-4OVdeAmuaCUq5hYT8NNn0nxlO9AcA/eTjXfUZ+QK8MT3Dz7Z76m73x7KxjU6I64WyXX98dauVH2b9XM+d84npw==}
 
   '@listr2/prompt-adapter-inquirer@2.0.18':
     resolution: {integrity: sha512-0hz44rAcrphyXcA8IS7EJ2SCoaBZD2u5goE8S/e+q/DL+dOGpqpcLidVOFeLG3VgML62SXmfRLAhWt0zL1oW4Q==}
@@ -17058,8 +17062,8 @@ packages:
   prosemirror-transform@1.10.4:
     resolution: {integrity: sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==}
 
-  prosemirror-view@1.39.3:
-    resolution: {integrity: sha512-bY/7kg0LzRE7ytR0zRdSMWX3sknEjw68l836ffLPMh0OG3OYnNuBDUSF3v0vjvnzgYjgY9ZH/RypbARURlcMFA==}
+  prosemirror-view@1.40.0:
+    resolution: {integrity: sha512-2G3svX0Cr1sJjkD/DYWSe3cfV5VPVTBOxI9XQEGWJDFEpsZb/gh4MV29ctv+OJx2RFX4BLt09i+6zaGM/ldkCw==}
 
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
@@ -22222,6 +22226,8 @@ snapshots:
 
   '@babel/runtime@7.27.4': {}
 
+  '@babel/runtime@7.27.6': {}
+
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -25639,22 +25645,22 @@ snapshots:
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@journeyapps/react-native-quick-sqlite@2.4.4(react-native@0.72.4(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+  '@journeyapps/react-native-quick-sqlite@2.4.5(react-native@0.72.4(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
       react-native: 0.72.4(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(encoding@0.1.13)(react@18.3.1)
 
-  '@journeyapps/react-native-quick-sqlite@2.4.4(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.3.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+  '@journeyapps/react-native-quick-sqlite@2.4.5(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.3.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
       react-native: 0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.3.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1)
 
-  '@journeyapps/react-native-quick-sqlite@2.4.4(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+  '@journeyapps/react-native-quick-sqlite@2.4.5(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
       react-native: 0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.8.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1)
 
-  '@journeyapps/wa-sqlite@1.2.4': {}
+  '@journeyapps/wa-sqlite@1.2.5': {}
 
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
@@ -25848,10 +25854,10 @@ snapshots:
 
   '@libsql/client-wasm@0.15.8':
     dependencies:
-      '@libsql/core': 0.15.8
+      '@libsql/core': 0.15.9
       js-base64: 3.7.7
 
-  '@libsql/core@0.15.8':
+  '@libsql/core@0.15.9':
     dependencies:
       js-base64: 3.7.7
 
@@ -25889,7 +25895,7 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.27.4
+      '@babel/runtime': 7.27.6
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -28980,9 +28986,9 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@shopify/flash-list@1.7.3(@babel/runtime@7.27.4)(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.3.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
+  '@shopify/flash-list@1.7.3(@babel/runtime@7.27.6)(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.3.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.4
+      '@babel/runtime': 7.27.6
       react: 18.3.1
       react-native: 0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.3.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1)
       recyclerlistview: 4.2.1(react-native@0.76.9(@babel/core@7.26.10)(@babel/preset-env@7.27.2(@babel/core@7.26.10))(@react-native-community/cli@15.1.3(typescript@5.3.3))(@types/react@18.3.23)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)
@@ -29046,7 +29052,7 @@ snapshots:
 
   '@slorber/react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.27.4
+      '@babel/runtime': 7.27.6
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 18.3.1
@@ -30309,16 +30315,16 @@ snapshots:
     dependencies:
       '@tiptap/core': 2.12.0(@tiptap/pm@2.12.0)
 
-  '@tiptap/extension-collaboration-cursor@2.2.2(@tiptap/core@2.12.0(@tiptap/pm@2.12.0))(y-prosemirror@1.3.5(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.39.3)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27))':
+  '@tiptap/extension-collaboration-cursor@2.2.2(@tiptap/core@2.12.0(@tiptap/pm@2.12.0))(y-prosemirror@1.3.5(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.40.0)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27))':
     dependencies:
       '@tiptap/core': 2.12.0(@tiptap/pm@2.12.0)
-      y-prosemirror: 1.3.5(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.39.3)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27)
+      y-prosemirror: 1.3.5(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.40.0)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27)
 
-  '@tiptap/extension-collaboration@2.2.2(@tiptap/core@2.12.0(@tiptap/pm@2.12.0))(@tiptap/pm@2.12.0)(y-prosemirror@1.3.5(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.39.3)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27))':
+  '@tiptap/extension-collaboration@2.2.2(@tiptap/core@2.12.0(@tiptap/pm@2.12.0))(@tiptap/pm@2.12.0)(y-prosemirror@1.3.5(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.40.0)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27))':
     dependencies:
       '@tiptap/core': 2.12.0(@tiptap/pm@2.12.0)
       '@tiptap/pm': 2.12.0
-      y-prosemirror: 1.3.5(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.39.3)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27)
+      y-prosemirror: 1.3.5(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.40.0)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27)
 
   '@tiptap/extension-document@2.12.0(@tiptap/core@2.12.0(@tiptap/pm@2.12.0))':
     dependencies:
@@ -30412,9 +30418,9 @@ snapshots:
       prosemirror-schema-list: 1.5.1
       prosemirror-state: 1.4.3
       prosemirror-tables: 1.7.1
-      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.39.3)
+      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.40.0)
       prosemirror-transform: 1.10.4
-      prosemirror-view: 1.39.3
+      prosemirror-view: 1.40.0
 
   '@tiptap/react@2.2.2(@tiptap/core@2.12.0(@tiptap/pm@2.12.0))(@tiptap/pm@2.12.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -39604,7 +39610,7 @@ snapshots:
 
   metro-runtime@0.76.7:
     dependencies:
-      '@babel/runtime': 7.27.4
+      '@babel/runtime': 7.27.6
       react-refresh: 0.4.3
 
   metro-runtime@0.76.8:
@@ -42031,20 +42037,20 @@ snapshots:
     dependencies:
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.4
-      prosemirror-view: 1.39.3
+      prosemirror-view: 1.40.0
 
   prosemirror-gapcursor@1.3.2:
     dependencies:
       prosemirror-keymap: 1.2.3
       prosemirror-model: 1.25.1
       prosemirror-state: 1.4.3
-      prosemirror-view: 1.39.3
+      prosemirror-view: 1.40.0
 
   prosemirror-history@1.4.1:
     dependencies:
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.4
-      prosemirror-view: 1.39.3
+      prosemirror-view: 1.40.0
       rope-sequence: 1.3.4
 
   prosemirror-inputrules@1.5.0:
@@ -42088,7 +42094,7 @@ snapshots:
     dependencies:
       prosemirror-model: 1.25.1
       prosemirror-transform: 1.10.4
-      prosemirror-view: 1.39.3
+      prosemirror-view: 1.40.0
 
   prosemirror-tables@1.7.1:
     dependencies:
@@ -42096,21 +42102,21 @@ snapshots:
       prosemirror-model: 1.25.1
       prosemirror-state: 1.4.3
       prosemirror-transform: 1.10.4
-      prosemirror-view: 1.39.3
+      prosemirror-view: 1.40.0
 
-  prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.39.3):
+  prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.40.0):
     dependencies:
       '@remirror/core-constants': 3.0.0
       escape-string-regexp: 4.0.0
       prosemirror-model: 1.25.1
       prosemirror-state: 1.4.3
-      prosemirror-view: 1.39.3
+      prosemirror-view: 1.40.0
 
   prosemirror-transform@1.10.4:
     dependencies:
       prosemirror-model: 1.25.1
 
-  prosemirror-view@1.39.3:
+  prosemirror-view@1.40.0:
     dependencies:
       prosemirror-model: 1.25.1
       prosemirror-state: 1.4.3
@@ -46717,7 +46723,7 @@ snapshots:
       '@apideck/better-ajv-errors': 0.3.6(ajv@8.17.1)
       '@babel/core': 7.26.10
       '@babel/preset-env': 7.27.2(@babel/core@7.26.10)
-      '@babel/runtime': 7.27.4
+      '@babel/runtime': 7.27.6
       '@rollup/plugin-babel': 5.3.1(@babel/core@7.26.10)(@types/babel__core@7.20.5)(rollup@2.79.2)
       '@rollup/plugin-node-resolve': 15.2.3(rollup@2.79.2)
       '@rollup/plugin-replace': 2.4.2(rollup@2.79.2)
@@ -46932,12 +46938,12 @@ snapshots:
 
   xterm@4.19.0: {}
 
-  y-prosemirror@1.3.5(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.39.3)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27):
+  y-prosemirror@1.3.5(prosemirror-model@1.25.1)(prosemirror-state@1.4.3)(prosemirror-view@1.40.0)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27):
     dependencies:
       lib0: 0.2.108
       prosemirror-model: 1.25.1
       prosemirror-state: 1.4.3
-      prosemirror-view: 1.39.3
+      prosemirror-view: 1.40.0
       y-protocols: 1.0.6(yjs@13.6.27)
       yjs: 13.6.27
 


### PR DESCRIPTION
This updates dependencies to include version `0.4.0` of the core extension:

- `wa-sqlite`
- `react-native-quick-sqlite`
- The version downloaded by the node sdk
- The version linked by our op-sqlite helper package
