### PR TITLE
Fix new sync client with RNQS

### DIFF
--- a/.changeset/weak-chairs-complain.md
+++ b/.changeset/weak-chairs-complain.md
@@ -1,0 +1,5 @@
+---
+'@powersync/react-native': patch
+---
+
+Fix issues forwarding array buffers to Rust sync client.

--- a/demos/react-native-supabase-todolist/library/powersync/system.ts
+++ b/demos/react-native-supabase-todolist/library/powersync/system.ts
@@ -1,6 +1,6 @@
 import '@azure/core-asynciterator-polyfill';
 
-import { createBaseLogger, LogLevel, PowerSyncDatabase } from '@powersync/react-native';
+import { createBaseLogger, LogLevel, PowerSyncDatabase, SyncClientImplementation } from '@powersync/react-native';
 import React from 'react';
 import { SupabaseStorageAdapter } from '../storage/SupabaseStorageAdapter';
 
@@ -68,7 +68,7 @@ export class System {
 
   async init() {
     await this.powersync.init();
-    await this.powersync.connect(this.supabaseConnector);
+    await this.powersync.connect(this.supabaseConnector, { clientImplementation: SyncClientImplementation.RUST });
 
     if (this.attachmentQueue) {
       await this.attachmentQueue.init();

--- a/packages/react-native/src/db/PowerSyncDatabase.ts
+++ b/packages/react-native/src/db/PowerSyncDatabase.ts
@@ -5,12 +5,12 @@ import {
   DBAdapter,
   PowerSyncBackendConnector,
   PowerSyncDatabaseOptionsWithSettings,
-  type RequiredAdditionalConnectionOptions,
-  SqliteBucketStorage
+  type RequiredAdditionalConnectionOptions
 } from '@powersync/common';
 import { ReactNativeRemote } from '../sync/stream/ReactNativeRemote';
 import { ReactNativeStreamingSyncImplementation } from '../sync/stream/ReactNativeStreamingSyncImplementation';
 import { ReactNativeQuickSqliteOpenFactory } from './adapters/react-native-quick-sqlite/ReactNativeQuickSQLiteOpenFactory';
+import { ReactNativeBucketStorageAdapter } from './../sync/bucket/ReactNativeBucketStorageAdapter';
 
 /**
  * A PowerSync database which provides SQLite functionality
@@ -39,7 +39,7 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
   }
 
   protected generateBucketStorageAdapter(): BucketStorageAdapter {
-    return new SqliteBucketStorage(this.database, AbstractPowerSyncDatabase.transactionMutex);
+    return new ReactNativeBucketStorageAdapter(this.database, AbstractPowerSyncDatabase.transactionMutex);
   }
 
   protected generateSyncStreamImplementation(

--- a/packages/react-native/src/sync/bucket/ReactNativeBucketStorageAdapter.ts
+++ b/packages/react-native/src/sync/bucket/ReactNativeBucketStorageAdapter.ts
@@ -1,0 +1,13 @@
+import { PowerSyncControlCommand, SqliteBucketStorage } from '@powersync/common';
+
+export class ReactNativeBucketStorageAdapter extends SqliteBucketStorage {
+  control(op: PowerSyncControlCommand, payload: string | ArrayBuffer | null): Promise<string> {
+    if (payload != null && typeof payload != 'string') {
+      // For some reason, we need to copy array buffers for RNQS to recognize them. We're doing that here because we
+      // don't want to pay the cost of a copy on platforms where it's not necessary.
+      payload = new Uint8Array(payload).buffer;
+    }
+
+    return super.control(op, payload);
+  }
+}


### PR DESCRIPTION
For reasons I don't fully understand, the array buffers we get from the RSocket package can't be passed to RNQS directly (it doesn't recognize them as array buffers and binds parameters to null). So, we copy once more.

I've also used this to benchmark syncing 1M rows once more (using RNQS with the demo todolist app and again with the barebones op-sqlite app). The sync is with an app launched using `pnpm ios` on an simulator and a sync service + Postgres on localhost. I've reinstalled the app before each run. Note that the checkpoint applies extremely slowely on the todolist app because there are FTS5 triggers.

| Implementation | Time downloading | Time until data availability |
|-----------------|----------------------------------------|----------------------------------------|
| Baseline (RNQS + JS) | 234.2s | 312.5s |
| Rust (RNQS + Rust) | 61.6s (-73% 😎 ) | 139s (still -55%) |
| Rust and OP-sqlite | 47s (-80% from baseline, -23% from RNQS) <img src="https://github.com/user-attachments/assets/8be32aac-d872-4d30-a8c6-8b8a513e2513" title="Speed and Power!" width="20"> | (not measured, different schema) |

I thought fine-tuning the backpressure handling with RSocket might speed things up even further (and there's still a bit of a "stop and go" behavior visible from sync progress), but increasing the local buffer or raising the watermark did not improve things. Anyway, the results are very promising already.