### PR TITLE
Remove unused compaction logic

### DIFF
--- a/.changeset/healthy-carrots-exercise.md
+++ b/.changeset/healthy-carrots-exercise.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Remove unused compaction logic.

--- a/packages/common/src/client/sync/bucket/BucketStorageAdapter.ts
+++ b/packages/common/src/client/sync/bucket/BucketStorageAdapter.ts
@@ -96,16 +96,6 @@ export interface BucketStorageAdapter extends BaseObserver<BucketStorageListener
 
   hasCompletedSync(): Promise<boolean>;
   updateLocalTarget(cb: () => Promise<string>): Promise<boolean>;
-  /**
-   * Exposed for tests only.
-   */
-  autoCompact(): Promise<void>;
-
-  /**
-   * Exposed for tests only.
-   */
-  forceCompact(): Promise<void>;
-
   getMaxOpId(): string;
 
   /**

--- a/packages/web/tests/bucket_storage.test.ts
+++ b/packages/web/tests/bucket_storage.test.ts
@@ -514,8 +514,6 @@ describe('Bucket Storage', { sequential: true }, () => {
       buckets: [{ bucket: 'bucket1', checksum: 7, priority: 3 }]
     });
 
-    await bucketStorage.forceCompact();
-
     await syncLocalChecked({
       last_op_id: '4',
       write_checkpoint: '4',


### PR DESCRIPTION
This removes logic in the bucket adapters related to compaction. We check at runtime that we're talking to version 0.3.11 of the core extension or later, so compacion operations are a guaranteed no-op that will be handled during regular sync instead.
