### PR TITLE
Fix `connect()` resolving early with Rust client

### DIFF
--- a/.changeset/new-readers-dance.md
+++ b/.changeset/new-readers-dance.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Rust sync client: Fix `connect()` resolving before a connection is made.

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -945,11 +945,16 @@ The next upload iteration will be delayed.`);
         }
 
         const info = instruction.UpdateSyncStatus.status;
+        const lastStatus = syncImplementation.syncStatus;
         const coreCompleteSync = info.priority_status.find((s) => s.priority == FULL_SYNC_PRIORITY);
         const completeSync = coreCompleteSync != null ? coreStatusToJs(coreCompleteSync) : null;
 
         syncImplementation.updateSyncStatus({
-          connected: info.connected,
+          // The first update to the connected field should only happen when it has really changed - there's a
+          // statusUpdated listener in connect() that will only make the promise complete once connected has changed.
+          // We only want to apply that workaround while we're connecting because it's only relevant in the initial
+          // connect call. Afterwards, we want to forward the sync status unchanged.
+          connected: lastStatus.connected == info.connected && info.connecting ? undefined : info.connected,
           connecting: info.connecting,
           dataFlow: {
             downloading: info.downloading != null,

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -342,17 +342,18 @@ export abstract class AbstractStreamingSyncImplementation
         let checkedCrudItem: CrudEntry | undefined;
 
         while (true) {
-          this.updateSyncStatus({
-            dataFlow: {
-              uploading: true
-            }
-          });
           try {
             /**
              * This is the first item in the FIFO CRUD queue.
              */
             const nextCrudItem = await this.options.adapter.nextCrudItem();
             if (nextCrudItem) {
+              this.updateSyncStatus({
+                dataFlow: {
+                  uploading: true
+                }
+              });
+
               if (nextCrudItem.clientId == checkedCrudItem?.clientId) {
                 // This will force a higher log level than exceptions which are caught here.
                 this.logger.warn(`Potentially previously uploaded CRUD entries are still present in the upload queue.

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -881,6 +881,10 @@ The next upload iteration will be delayed.`);
         );
       }
 
+      // The rust client will set connected: true after the first sync line because that's when it gets invoked, but
+      // we're already connected here and can report that.
+      syncImplementation.updateSyncStatus({ connected: true });
+
       try {
         while (!controlInvocations.closed) {
           const line = await controlInvocations.read();

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -414,7 +414,7 @@ The next upload iteration will be delayed.`);
     // Return a promise that resolves when the connection status is updated to indicate that we're connected.
     return new Promise<void>((resolve) => {
       const disposer = this.registerListener({
-        statusChanged(status) {
+        statusChanged: (status) => {
           if (status.dataFlowStatus.downloadError != null) {
             this.logger.warn('Initial connect attempt did not successfully connect to server');
           } else if (status.connecting) {

--- a/packages/node/tests/sync.test.ts
+++ b/packages/node/tests/sync.test.ts
@@ -144,8 +144,9 @@ function defineSyncTests(impl: SyncClientImplementation) {
     expect(connectCompleted).toBeFalsy();
 
     await vi.waitFor(() => expect(syncService.connectedListeners).toHaveLength(1));
-    // Opening the socket is not enough, we set connected: true when the first line is received.
-    expect(connectCompleted).toBeFalsy();
+    // We want connected: true once we have a connection
+    await vi.waitFor(() => connectCompleted);
+    expect(database.currentStatus.dataFlowStatus.downloading).toBeFalsy();
 
     syncService.pushLine({
       checkpoint: {
@@ -153,7 +154,8 @@ function defineSyncTests(impl: SyncClientImplementation) {
         buckets: [bucket('a', 10)]
       }
     });
-    await vi.waitFor(() => connectCompleted);
+
+    await vi.waitFor(() => expect(database.currentStatus.dataFlowStatus.downloading).toBeTruthy());
   });
 
   describe('reports progress', () => {


### PR DESCRIPTION
With the JavaScript sync client, the promise returned by `connect()` is supposed to return after a connection has been established and the first sync line received (this is different to all our other SDKs, which return as soon as a connection task has been set up and started).

The way this behavior is implemented is that `connect()` registers a `statusUpdated` handler that completes once the `connected` status is changed. This works with the JavaScript client because it only changes fields that actually need to change. With Rust however, we receive a full `SyncStatus` snapshot instead (so we call `updateSyncStatus` with a complete status that will always have `connected` set - even to `false` initially).

The workaround feels a bit hacky, but since something like `statusUpdated` doesn't really work with the Rust client at all, the best approach I could come up with is to exclude `connected` from the options passed to `updateSyncStatus` in the initial connection setup status.

This fixes a bug [reported on Discord](https://discord.com/channels/1138230179878154300/1385731015804326020/1386736722905272552). However, I could not report longer connection times with the new Rust client after adding the `connect()` call with the fix.