### PR TITLE
feat(common): use `addEventListener` instead of `onabort` in async utils `onAbortPromise`

### DIFF
--- a/.changeset/moody-hats-sleep.md
+++ b/.changeset/moody-hats-sleep.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Use addEventListener instead of overwriting the onabort property, which can lead to bugs and race conditions.

--- a/packages/common/src/utils/async.ts
+++ b/packages/common/src/utils/async.ts
@@ -54,7 +54,7 @@ export function onAbortPromise(signal: AbortSignal): Promise<void> {
     if (signal.aborted) {
       resolve();
     } else {
-      signal.onabort = () => resolve();
+      signal.addEventListener('abort', () => resolve(), { once: true });
     }
   });
 }

--- a/packages/common/tests/utils/async.test.ts
+++ b/packages/common/tests/utils/async.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import { onAbortPromise } from '../../src/utils/async';
+
+describe('onAbortPromise', () => {
+  it('should resolve when signal is aborted', async () => {
+    const controller = new AbortController();
+    const promise = onAbortPromise(controller.signal);
+
+    // Abort the signal after a short delay
+    setTimeout(() => controller.abort(), 10);
+
+    // The promise should resolve
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it('should resolve immediately if signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort(); // Abort before creating promise
+
+    const promise = onAbortPromise(controller.signal);
+
+    // Should resolve immediately
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  // This test emphasizes why not to use the 'onabort' property.
+  it('should demonstrate that overwriting onabort property supersedes previous onabort logic', async () => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    // Set up first onabort handler
+    const firstHandler = vi.fn();
+    signal.onabort = firstHandler;
+
+    // Overwrite onabort property with a second handler
+    const secondHandler = vi.fn();
+    signal.onabort = secondHandler;
+
+    // Abort the signal
+    controller.abort();
+
+    // Only the second handler should be called (first one was overwritten)
+    expect(firstHandler).not.toHaveBeenCalled();
+    expect(secondHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show that onAbortPromise does not interfere with onabort property or other event listeners', async () => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    // Set up onabort property handler
+    const onabortHandler = vi.fn();
+    signal.onabort = onabortHandler;
+
+    // Set up another event listener
+    const eventListenerHandler = vi.fn();
+    signal.addEventListener('abort', eventListenerHandler);
+
+    // Create onAbortPromise (which uses addEventListener internally)
+    const promise = onAbortPromise(signal);
+
+    // Abort the signal
+    controller.abort();
+
+    // All handlers should be called
+    expect(onabortHandler).toHaveBeenCalledTimes(1);
+    expect(eventListenerHandler).toHaveBeenCalledTimes(1);
+
+    // The promise should also resolve
+    await expect(promise).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
This pull request updates the `onAbortPromise` utility function to use `addEventListener` instead of the `onabort` property, addressing potential bugs and race conditions. It also introduces comprehensive tests to validate the behavior of the updated implementation.

### Update to `onAbortPromise` implementation:

* [`packages/common/src/utils/async.ts`](diffhunk://#diff-c09dfd0c9c5d96373c98c7a6dcc014d177c66f65ebb40c3a245d796eb86424ffL57-R57): Replaced the use of the `onabort` property with `addEventListener('abort', ..., { once: true })` to ensure proper event handling and avoid overwriting existing logic, which could lead to bugs or race conditions.

### Tests for `onAbortPromise`:

* [`packages/common/tests/utils/async.test.ts`](diffhunk://#diff-527f9f75bdc1ccf3fc1851ea3efb049b4d110242939b6d83c216ec969c746497R1-R72): Added tests to verify the updated behavior of `onAbortPromise`, including scenarios where the signal is already aborted, demonstrating the risks of overwriting the `onabort` property, and ensuring compatibility with existing `onabort` handlers and other event listeners.

### Documentation:

* [`.changeset/moody-hats-sleep.md`](diffhunk://#diff-2345d486e36b8a3ced2657b66caffd89a73f0ab167b6e87e563e04d6b5641003R1-R5): Documented the change as a patch update for `@powersync/common`, highlighting the switch to `addEventListener` for improved reliability.