### PR TITLE
Fix `lastSyncedAt` values with Rust client

### DIFF
--- a/.changeset/tall-dolphins-sleep.md
+++ b/.changeset/tall-dolphins-sleep.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Rust sync client: Fix reported `lastSyncedAt` values in sync status.

--- a/.changeset/tall-dolphins-sleep.md
+++ b/.changeset/tall-dolphins-sleep.md
@@ -1,5 +1,8 @@
 ---
 '@powersync/common': patch
+'@powersync/node': patch
+'@powersync/web': patch
+'@powersync/react-native': patch
 ---
 
 Rust sync client: Fix reported `lastSyncedAt` values in sync status.

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -923,7 +923,7 @@ The next upload iteration will be delayed.`);
           return {
             priority: status.priority,
             hasSynced: status.has_synced ?? undefined,
-            lastSyncedAt: status?.last_synced_at != null ? new Date(status!.last_synced_at!) : undefined
+            lastSyncedAt: status?.last_synced_at != null ? new Date(status!.last_synced_at! * 1000) : undefined
           };
         }
 


### PR DESCRIPTION
When the Rust client exports timestamps for the sync status, they're encoded as UTC seconds. `new Date` expects milliseconds though, and so the reported time used to be close to 1970 instead of the actual time.