### PR TITLE
Web: Use `BEGIN EXCLUSIVE` for write transactions

### DIFF
--- a/.changeset/chilled-birds-cheer.md
+++ b/.changeset/chilled-birds-cheer.md
@@ -1,0 +1,5 @@
+---
+'@powersync/web': patch
+---
+
+Use `BEGIN EXCLUSIVE` to open write transactions

--- a/packages/web/src/db/adapters/LockedAsyncDatabaseAdapter.ts
+++ b/packages/web/src/db/adapters/LockedAsyncDatabaseAdapter.ts
@@ -196,7 +196,7 @@ export class LockedAsyncDatabaseAdapter
   }
 
   writeTransaction<T>(fn: (tx: Transaction) => Promise<T>, options?: DBLockOptions | undefined): Promise<T> {
-    return this.writeLock(this.wrapTransaction(fn));
+    return this.writeLock(this.wrapTransaction(fn, true));
   }
 
   private generateDBHelpers<
@@ -240,9 +240,9 @@ export class LockedAsyncDatabaseAdapter
   /**
    * Wraps a lock context into a transaction context
    */
-  private wrapTransaction<T>(cb: (tx: Transaction) => Promise<T>) {
+  private wrapTransaction<T>(cb: (tx: Transaction) => Promise<T>, write = false) {
     return async (tx: LockContext): Promise<T> => {
-      await this._execute('BEGIN TRANSACTION');
+      await this._execute(write ? 'BEGIN EXCLUSIVE' : 'BEGIN');
       let finalized = false;
       const commit = async (): Promise<QueryResult> => {
         if (finalized) {


### PR DESCRIPTION
On the web, use `BEGIN EXCLUSIVE` instead of a regular `BEGIN` when starting a write transaction. The motivation for this is:

1. A regular `BEGIN` will start as a read transaction and then upgrade to a write transaction when necessary. Since we're likely to issue writing statements in `writeTransaction`, we can skip the read->write upgrade step.
2. In particular with WA-sqlite, obtaining locks is implemented by the VFS returning `BUSY` and then automatically retrying the SQLite call. There were some issues with this and the new Rust sync client. We will fix those in a core extension update, but obtaining a write transaction directly instead of in `powersync_control` could still avoid some of those retries.
