### PR TITLE
Mention metro workaround for op-sqlite

### DIFF
--- a/packages/powersync-op-sqlite/README.md
+++ b/packages/powersync-op-sqlite/README.md
@@ -16,6 +16,10 @@ Follow the installation instructions for the [React Native SDK](https://github.c
 npx expo install @powersync/op-sqlite
 ```
 
+When using this package without a frameowrk like Expo, we recommend adding [this metro config](https://github.com/powersync-ja/powersync-js/tree/main/packages/react-native#metro-config-optional)
+to avoid issues related to bundling PowerSync.
+Without it, you may be getting `TypeError: Cannot read property 'PowerSyncDatabase' of undefined` or similar errors.
+
 ### Install Peer Dependency:
 
 This SDK currently requires `@op-engineering/op-sqlite` as a peer dependency.


### PR DESCRIPTION
This links the workaround we recommend as a metro config when using the React Native SDK without Expo in the OP-sqlite adapter readme as well. The reason is that we've seen users get weird errors when adopting OP-sqlite without Expo in their existing projects, and the metro configuration we suggest seems to fix them.