### PR TITLE
Fix broken `src/` import in `SyncProgress.ts`

### DIFF
--- a/.changeset/twenty-cats-cry.md
+++ b/.changeset/twenty-cats-cry.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Fix compilation error due to broken import in `SyncProgress.d.ts`

--- a/packages/common/src/db/crud/SyncProgress.ts
+++ b/packages/common/src/db/crud/SyncProgress.ts
@@ -1,4 +1,4 @@
-import { BucketProgress } from 'src/client/sync/stream/core-instruction.js';
+import type { BucketProgress } from '../../client/sync/stream/core-instruction.js';
 import type { SyncStatus } from './SyncStatus.js';
 
 // (bucket, progress) pairs


### PR DESCRIPTION
This uses a relative import because the absolute one can't be resolved by tsc for users depending on `@powersync/common`.