### PR TITLE
Improve logging

### DIFF
--- a/.changeset/fresh-laws-join.md
+++ b/.changeset/fresh-laws-join.md
@@ -5,4 +5,4 @@
 '@powersync/web': minor
 ---
 
-Propagate logger from PowerSyncDatabase to streaming sync implementation.
+Propagate logger from PowerSyncDatabase to streaming sync and remote implementations, and tweak some log messages.

--- a/.changeset/fresh-laws-join.md
+++ b/.changeset/fresh-laws-join.md
@@ -1,0 +1,8 @@
+---
+'@powersync/react-native': minor
+'@powersync/common': minor
+'@powersync/node': minor
+'@powersync/web': minor
+---
+
+Propagate logger from PowerSyncDatabase to streaming sync implementation.

--- a/packages/common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/common/src/client/AbstractPowerSyncDatabase.ts
@@ -127,7 +127,6 @@ export const DEFAULT_WATCH_THROTTLE_MS = 30;
 
 export const DEFAULT_POWERSYNC_DB_OPTIONS = {
   retryDelayMs: 5000,
-  logger: Logger.get('PowerSyncDatabase'),
   crudUploadThrottleMs: DEFAULT_CRUD_UPLOAD_THROTTLE_MS
 };
 
@@ -182,6 +181,8 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
 
   protected runExclusiveMutex: Mutex;
 
+  logger: ILogger;
+
   constructor(options: PowerSyncDatabaseOptionsWithDBAdapter);
   constructor(options: PowerSyncDatabaseOptionsWithOpenFactory);
   constructor(options: PowerSyncDatabaseOptionsWithSettings);
@@ -204,6 +205,8 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
     } else {
       throw new Error('The provided `database` option is invalid.');
     }
+
+    this.logger = options.logger ?? Logger.get(`PowerSyncDatabase[${this._database.name}]`);
 
     this.bucketStorageAdapter = this.generateBucketStorageAdapter();
     this.closed = false;
@@ -425,17 +428,13 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
     try {
       schema.validate();
     } catch (ex) {
-      this.options.logger?.warn('Schema validation failed. Unexpected behaviour could occur', ex);
+      this.logger.warn('Schema validation failed. Unexpected behaviour could occur', ex);
     }
     this._schema = schema;
 
     await this.database.execute('SELECT powersync_replace_schema(?)', [JSON.stringify(this.schema.toJSON())]);
     await this.database.refreshSchema();
     this.iterateListeners(async (cb) => cb.schemaChanged?.(schema));
-  }
-
-  get logger() {
-    return this.options.logger!;
   }
 
   /**
@@ -883,7 +882,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
    * @param options Options for configuring watch behavior
    */
   watchWithCallback(sql: string, parameters?: any[], handler?: WatchHandler, options?: SQLWatchOptions): void {
-    const { onResult, onError = (e: Error) => this.options.logger?.error(e) } = handler ?? {};
+    const { onResult, onError = (e: Error) => this.logger.error(e) } = handler ?? {};
     if (!onResult) {
       throw new Error('onResult is required');
     }
@@ -1038,7 +1037,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
    * @returns A dispose function to stop watching for changes
    */
   onChangeWithCallback(handler?: WatchOnChangeHandler, options?: SQLWatchOptions): () => void {
-    const { onChange, onError = (e: Error) => this.options.logger?.error(e) } = handler ?? {};
+    const { onChange, onError = (e: Error) => this.logger.error(e) } = handler ?? {};
     if (!onChange) {
       throw new Error('onChange is required');
     }

--- a/packages/common/src/client/sync/bucket/SqliteBucketStorage.ts
+++ b/packages/common/src/client/sync/bucket/SqliteBucketStorage.ts
@@ -94,11 +94,11 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
   async saveSyncData(batch: SyncDataBatch, fixedKeyFormat: boolean = false) {
     await this.writeTransaction(async (tx) => {
       for (const b of batch.buckets) {
-        const result = await tx.execute('INSERT INTO powersync_operations(op, data) VALUES(?, ?)', [
+        await tx.execute('INSERT INTO powersync_operations(op, data) VALUES(?, ?)', [
           'save',
           JSON.stringify({ buckets: [b.toJSON(fixedKeyFormat)] })
         ]);
-        this.logger.debug('saveSyncData', JSON.stringify(result));
+        this.logger.debug(`Saved batch of data for  bucket: ${b.bucket}, operations: ${b.data.length}`);
       }
     });
   }
@@ -117,7 +117,7 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
       await tx.execute('INSERT INTO powersync_operations(op, data) VALUES(?, ?)', ['delete_bucket', bucket]);
     });
 
-    this.logger.debug('done deleting bucket');
+    this.logger.debug(`Done deleting bucket ${bucket}`);
   }
 
   async hasCompletedSync() {
@@ -141,6 +141,11 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
       }
       return { ready: false, checkpointValid: false, checkpointFailures: r.checkpointFailures };
     }
+    if (priority == null) {
+      this.logger.debug(`Validated checksums checkpoint ${checkpoint.last_op_id}`);
+    } else {
+      this.logger.debug(`Validated checksums for partial checkpoint ${checkpoint.last_op_id}, priority ${priority}`);
+    }
 
     let buckets = checkpoint.buckets;
     if (priority !== undefined) {
@@ -160,7 +165,6 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
 
     const valid = await this.updateObjectsFromBuckets(checkpoint, priority);
     if (!valid) {
-      this.logger.debug('Not at a consistent checkpoint - cannot update local db');
       return { ready: false, checkpointValid: true };
     }
 
@@ -223,7 +227,6 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
     ]);
 
     const resultItem = rs.rows?.item(0);
-    this.logger.debug('validateChecksums priority, checkpoint, result item', priority, checkpoint, resultItem);
     if (!resultItem) {
       return {
         checkpointValid: false,
@@ -264,34 +267,32 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
 
     const opId = await cb();
 
-    this.logger.debug(`[updateLocalTarget] Updating target to checkpoint ${opId}`);
-
     return this.writeTransaction(async (tx) => {
       const anyData = await tx.execute('SELECT 1 FROM ps_crud LIMIT 1');
       if (anyData.rows?.length) {
         // if isNotEmpty
-        this.logger.debug('updateLocalTarget', 'ps crud is not empty');
+        this.logger.debug(`New data uploaded since write checkpoint ${opId} - need new write checkpoint`);
         return false;
       }
 
       const rs = await tx.execute("SELECT seq FROM sqlite_sequence WHERE name = 'ps_crud'");
       if (!rs.rows?.length) {
         // assert isNotEmpty
-        throw new Error('SQlite Sequence should not be empty');
+        throw new Error('SQLite Sequence should not be empty');
       }
 
       const seqAfter: number = rs.rows?.item(0)['seq'];
-      this.logger.debug('seqAfter', JSON.stringify(rs.rows?.item(0)));
       if (seqAfter != seqBefore) {
-        this.logger.debug('seqAfter != seqBefore', seqAfter, seqBefore);
+        this.logger.debug(
+          `New data uploaded since write checpoint ${opId} - need new write checkpoint (sequence updated)`
+        );
+
         // New crud data may have been uploaded since we got the checkpoint. Abort.
         return false;
       }
 
-      const response = await tx.execute("UPDATE ps_buckets SET target_op = CAST(? as INTEGER) WHERE name='$local'", [
-        opId
-      ]);
-      this.logger.debug(['[updateLocalTarget] Response from updating target_op ', JSON.stringify(response)]);
+      this.logger.debug(`Updating target write checkpoint to ${opId}`);
+      await tx.execute("UPDATE ps_buckets SET target_op = CAST(? as INTEGER) WHERE name='$local'", [opId]);
       return true;
     });
   }

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -205,7 +205,6 @@ export const DEFAULT_RETRY_DELAY_MS = 5000;
 
 export const DEFAULT_STREAMING_SYNC_OPTIONS = {
   retryDelayMs: DEFAULT_RETRY_DELAY_MS,
-  logger: Logger.get('PowerSyncStream'),
   crudUploadThrottleMs: DEFAULT_CRUD_UPLOAD_THROTTLE_MS
 };
 
@@ -234,6 +233,7 @@ export abstract class AbstractStreamingSyncImplementation
   protected abortController: AbortController | null;
   protected crudUpdateListener?: () => void;
   protected streamingSyncPromise?: Promise<void>;
+  protected logger: ILogger;
 
   private isUploadingCrud: boolean = false;
   private notifyCompletedUploads?: () => void;
@@ -244,6 +244,7 @@ export abstract class AbstractStreamingSyncImplementation
   constructor(options: AbstractStreamingSyncImplementationOptions) {
     super();
     this.options = { ...DEFAULT_STREAMING_SYNC_OPTIONS, ...options };
+    this.logger = options.logger ?? Logger.get('PowerSyncStream');
 
     this.syncStatus = new SyncStatus({
       connected: false,
@@ -316,10 +317,6 @@ export abstract class AbstractStreamingSyncImplementation
 
   get isConnected() {
     return this.syncStatus.connected;
-  }
-
-  protected get logger() {
-    return this.options.logger!;
   }
 
   async dispose() {

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -327,9 +327,12 @@ export abstract class AbstractStreamingSyncImplementation
 
   async getWriteCheckpoint(): Promise<string> {
     const clientId = await this.options.adapter.getClientId();
+    this.logger.debug(`Creating write checkpoint for ${clientId}`);
     let path = `/write-checkpoint2.json?client_id=${clientId}`;
     const response = await this.options.remote.get(path);
-    return response['data']['write_checkpoint'] as string;
+    const checkpoint = response['data']['write_checkpoint'] as string;
+    this.logger.debug(`Got write checkpoint: ${checkpoint}`);
+    return checkpoint;
   }
 
   protected async _uploadAllCrud(): Promise<void> {
@@ -371,6 +374,7 @@ The next upload iteration will be delayed.`);
               });
             } else {
               // Uploading is completed
+              this.logger.debug('Upload complete, updating write checkpoint');
               await this.options.adapter.updateLocalTarget(() => this.getWriteCheckpoint());
               break;
             }

--- a/packages/node/src/db/PowerSyncDatabase.ts
+++ b/packages/node/src/db/PowerSyncDatabase.ts
@@ -78,7 +78,7 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
     connector: PowerSyncBackendConnector,
     options: NodeAdditionalConnectionOptions
   ): AbstractStreamingSyncImplementation {
-    const logger = this.options.logger;
+    const logger = this.logger;
     const remote = new NodeRemote(connector, logger, {
       dispatcher: options.dispatcher,
       ...(this.options as NodePowerSyncDatabaseOptions).remoteOptions

--- a/packages/node/src/db/PowerSyncDatabase.ts
+++ b/packages/node/src/db/PowerSyncDatabase.ts
@@ -64,7 +64,7 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
   }
 
   protected generateBucketStorageAdapter(): BucketStorageAdapter {
-    return new SqliteBucketStorage(this.database, AbstractPowerSyncDatabase.transactionMutex);
+    return new SqliteBucketStorage(this.database, AbstractPowerSyncDatabase.transactionMutex, this.logger);
   }
 
   connect(
@@ -92,7 +92,8 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
       },
       retryDelayMs: this.options.retryDelayMs,
       crudUploadThrottleMs: this.options.crudUploadThrottleMs,
-      identifier: this.database.name
+      identifier: this.database.name,
+      logger: this.logger
     });
   }
 }

--- a/packages/react-native/src/db/PowerSyncDatabase.ts
+++ b/packages/react-native/src/db/PowerSyncDatabase.ts
@@ -39,7 +39,7 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
   }
 
   protected generateBucketStorageAdapter(): BucketStorageAdapter {
-    return new ReactNativeBucketStorageAdapter(this.database, AbstractPowerSyncDatabase.transactionMutex);
+    return new ReactNativeBucketStorageAdapter(this.database, AbstractPowerSyncDatabase.transactionMutex, this.logger);
   }
 
   protected generateSyncStreamImplementation(

--- a/packages/react-native/src/db/PowerSyncDatabase.ts
+++ b/packages/react-native/src/db/PowerSyncDatabase.ts
@@ -46,7 +46,7 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
     connector: PowerSyncBackendConnector,
     options: RequiredAdditionalConnectionOptions
   ): AbstractStreamingSyncImplementation {
-    const remote = new ReactNativeRemote(connector);
+    const remote = new ReactNativeRemote(connector, this.logger);
 
     return new ReactNativeStreamingSyncImplementation({
       adapter: this.bucketStorageAdapter,
@@ -57,7 +57,8 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
       },
       retryDelayMs: options.retryDelayMs,
       crudUploadThrottleMs: options.crudUploadThrottleMs,
-      identifier: this.database.name
+      identifier: this.database.name,
+      logger: this.logger
     });
   }
 

--- a/packages/web/src/db/PowerSyncDatabase.ts
+++ b/packages/web/src/db/PowerSyncDatabase.ts
@@ -186,7 +186,7 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
     connector: PowerSyncBackendConnector,
     options: RequiredAdditionalConnectionOptions
   ): StreamingSyncImplementation {
-    const remote = new WebRemote(connector);
+    const remote = new WebRemote(connector, this.logger);
     const syncOptions: WebStreamingSyncImplementationOptions = {
       ...(this.options as {}),
       retryDelayMs: options.retryDelayMs,
@@ -198,7 +198,8 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
         await this.waitForReady();
         await connector.uploadData(this);
       },
-      identifier: this.database.name
+      identifier: this.database.name,
+      logger: this.logger
     };
 
     switch (true) {


### PR DESCRIPTION
1. Propagate logger instance from PowerSyncDatabase to the StreamingSyncImplementation and Remote implementations in the various SDKs. This means we now actually use the `logger` passed in the constructor, at the cost of not having a more specific prefix like `[PowerSyncStream]`.
2. Include database name in the default logger, i.e. `PowerSyncDatabase[test.db]`. This helps debugging issues when multiple databases are used.
3. Add some logging for write checkpoints / upload complete.
4. Cleanup for some other log messages.
