### PR TITLE
Clear pendingValidatedCheckpoint on new checkpoints

### DIFF
--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -716,6 +716,8 @@ The next upload iteration will be delayed.`);
 
       if (isStreamingSyncCheckpoint(line)) {
         targetCheckpoint = line.checkpoint;
+        // New checkpoint - existing validated checkpoint is no longer valid
+        pendingValidatedCheckpoint = null;
         const bucketsToDelete = new Set<string>(bucketMap.keys());
         const newBuckets = new Map<string, BucketDescription>();
         for (const checksum of line.checkpoint.buckets) {
@@ -737,7 +739,13 @@ The next upload iteration will be delayed.`);
         if (result.endIteration) {
           return;
         } else if (!result.applied) {
+          // "Could not apply checkpoint due to local data". We need to retry after
+          // finishing uploads.
           pendingValidatedCheckpoint = targetCheckpoint;
+        } else {
+          // Nothing to retry later. This would likely already be null from the last
+          // checksum or checksum_diff operation, but we make sure.
+          pendingValidatedCheckpoint = null;
         }
       } else if (isStreamingSyncCheckpointPartiallyComplete(line)) {
         const priority = line.partial_checkpoint_complete.priority;
@@ -773,6 +781,8 @@ The next upload iteration will be delayed.`);
         if (targetCheckpoint == null) {
           throw new Error('Checkpoint diff without previous checkpoint');
         }
+        // New checkpoint - existing validated checkpoint is no longer valid
+        pendingValidatedCheckpoint = null;
         const diff = line.checkpoint_diff;
         const newBuckets = new Map<string, BucketChecksum>();
         for (const checksum of targetCheckpoint.buckets) {

--- a/packages/node/src/db/PowerSyncDatabase.ts
+++ b/packages/node/src/db/PowerSyncDatabase.ts
@@ -78,7 +78,8 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
     connector: PowerSyncBackendConnector,
     options: NodeAdditionalConnectionOptions
   ): AbstractStreamingSyncImplementation {
-    const remote = new NodeRemote(connector, this.options.logger, {
+    const logger = this.options.logger;
+    const remote = new NodeRemote(connector, logger, {
       dispatcher: options.dispatcher,
       ...(this.options as NodePowerSyncDatabaseOptions).remoteOptions
     });
@@ -92,7 +93,8 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
       },
       retryDelayMs: this.options.retryDelayMs,
       crudUploadThrottleMs: this.options.crudUploadThrottleMs,
-      identifier: this.database.name
+      identifier: this.database.name,
+      logger: logger
     });
   }
 }

--- a/packages/node/src/db/PowerSyncDatabase.ts
+++ b/packages/node/src/db/PowerSyncDatabase.ts
@@ -94,7 +94,7 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
       retryDelayMs: this.options.retryDelayMs,
       crudUploadThrottleMs: this.options.crudUploadThrottleMs,
       identifier: this.database.name,
-      logger: logger
+      logger
     });
   }
 }


### PR DESCRIPTION
Fix regression from #661. What would happen:
1. "Could not apply checkpoint due to local data. We will retry applying the checkpoint after that upload is completed." -> sets `pendingValidatedCheckpoint` to checkpoint A.
2. Receive a `data`  and `checkpoint_complete` message -> validates checkpoint B.
3. Crud upload complete -> queues a `crud_upload_completed` message.
4. Attempts `this.applyCheckpoint(pendingValidatedCheckpoint)` with checkpoint A. Checkpoint A is no longer valid, so this results in "Checksums failed", and re-downloading the data.

Was not part of a stable release, so no changeset required.