### PR TITLE
Fix crash in React Native: add optional chaining to stream?.close()

### DIFF
--- a/packages/common/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/common/src/client/sync/stream/AbstractRemote.ts
@@ -310,7 +310,7 @@ export abstract class AbstractRemote {
       clearTimeout(keepAliveTimeout);
       keepAliveTimeout = setTimeout(() => {
         this.logger.error(`No data received on WebSocket in ${SOCKET_TIMEOUT_MS}ms, closing connection.`);
-        stream.close();
+        stream?.close();
       }, SOCKET_TIMEOUT_MS);
     };
     resetTimeout();


### PR DESCRIPTION
This PR fixes a fatal crash (TypeError: Cannot read property 'close' of undefined') occurring in React Native environments.

The issue appears when the app is in the background and a periodic background process triggers. Just before the crash, the last log message is:
`[PowerSyncRemote] No data received on WebSocket in 30000ms, closing connection.`

The root cause is that the stream object can be undefined at this point. Adding optional chaining to the stream.close() call prevents the crash. However, this may mask a deeper issue—ideally, we should investigate why stream is sometimes undefined here.
