### PR TITLE
WebSocket Timeout Fix

### DIFF
--- a/.changeset/bright-yaks-pump.md
+++ b/.changeset/bright-yaks-pump.md
@@ -1,0 +1,7 @@
+---
+'@powersync/common': patch
+'@powersync/react-native': patch
+'@powersync/web': patch
+---
+
+Fixed bug where a WebSocket connection timeout could cause a an uncaught exception.

--- a/.changeset/bright-yaks-pump.md
+++ b/.changeset/bright-yaks-pump.md
@@ -4,4 +4,4 @@
 '@powersync/web': patch
 ---
 
-Fixed bug where a WebSocket connection timeout could cause a an uncaught exception.
+Fixed bug where a WebSocket connection timeout could cause an uncaught exception.

--- a/demos/react-supabase-todolist/src/app/views/layout.tsx
+++ b/demos/react-supabase-todolist/src/app/views/layout.tsx
@@ -90,33 +90,31 @@ export default function ViewsLayout({ children }: { children: React.ReactNode })
               setConnectionAnchor(event.currentTarget);
             }}>
             {status?.connected ? <WifiIcon /> : <SignalWifiOffIcon />}
-            {/* Allows for manual connection and disconnect for testing purposes */}
-            <Menu
-              id="connection-menu"
-              anchorEl={connectionAnchor}
-              open={Boolean(connectionAnchor)}
-              onClose={() => setConnectionAnchor(null)}>
-              {status?.connected ? (
-                <MenuItem
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    setConnectionAnchor(null);
-                    powerSync.disconnect();
-                  }}>
-                  Disconnect
-                </MenuItem>
-              ) : supabase ? (
-                <MenuItem
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    setConnectionAnchor(null);
-                    powerSync.connect(supabase);
-                  }}>
-                  Connect
-                </MenuItem>
-              ) : null}
-            </Menu>
           </Box>
+          {/* Allows for manual connection and disconnect for testing purposes */}
+          <Menu
+            id="connection-menu"
+            anchorEl={connectionAnchor}
+            open={Boolean(connectionAnchor)}
+            onClose={() => setConnectionAnchor(null)}>
+            {status?.connected || status?.connecting ? (
+              <MenuItem
+                onClick={(event) => {
+                  setConnectionAnchor(null);
+                  powerSync.disconnect();
+                }}>
+                Disconnect
+              </MenuItem>
+            ) : supabase ? (
+              <MenuItem
+                onClick={(event) => {
+                  setConnectionAnchor(null);
+                  powerSync.connect(supabase);
+                }}>
+                Connect
+              </MenuItem>
+            ) : null}
+          </Menu>
         </Toolbar>
       </S.TopBar>
       <Drawer anchor={'left'} open={openDrawer} onClose={() => setOpenDrawer(false)}>


### PR DESCRIPTION
# Overview

This is a slightly alternative approach to https://github.com/powersync-ja/powersync-js/pull/668. The fix here declares the `stream` early which should avoid the `(TypeError: Cannot read property 'close' of undefined')` issue highlighted in the linked PR. Additionally the changes here allow the WebSocket initial connection request to be aborted without waiting for it to reject/complete.

## Testing

I've added a button to change the connection status to the React Supabase Todolist demo. I've also testing a slow connection attempt by running the PowerSync service locally with a paused attached debugger. 