### PR TITLE
Fix warning for raw tables with JS client

### DIFF
--- a/.changeset/rude-paws-lie.md
+++ b/.changeset/rude-paws-lie.md
@@ -1,0 +1,9 @@
+---
+'@powersync/common': patch
+'@powersync/node': patch
+'@powersync/react': patch
+'@powersync/react-native': patch
+'@powersync/web': patch
+---
+
+Fix a warning about raw tables being used when they're not.

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -626,7 +626,8 @@ The next upload iteration will be delayed.`);
   }
 
   private async legacyStreamingSyncIteration(signal: AbortSignal, resolvedOptions: RequiredPowerSyncConnectionOptions) {
-    if (resolvedOptions.serializedSchema?.raw_tables != null) {
+    const rawTables = resolvedOptions.serializedSchema?.raw_tables;
+    if (rawTables != null && rawTables.length) {
       this.logger.warn('Raw tables require the Rust-based sync client. The JS client will ignore them.');
     }
 


### PR DESCRIPTION
When raw tables are used with the default JS client that doesn't support them, we emit a warning. Unfortunately, the check compared the `raw_tables` entry in the serialized schema against null, which misses a valid empty array.

This fixes the superfluous warning.

Closes https://github.com/powersync-ja/powersync-js/issues/672