### PR TITLE
fix(adapter-sql-js): Only calling db.export() if a persister is specified.

### DIFF
--- a/.changeset/short-hotels-grow.md
+++ b/.changeset/short-hotels-grow.md
@@ -1,0 +1,5 @@
+---
+'@powersync/adapter-sql-js': patch
+---
+
+Only calling `db.export()` if a persister is specified, otherwise it is no-op. Improves in-memory performance.


### PR DESCRIPTION
Follow up fix for https://github.com/powersync-ja/powersync-js/pull/647#discussion_r2242035611.
Makes a big difference in performance.

| | Time 1 | Time 2 | Time 3 |
|--------|--------|--------|--------|
| Before | 24140ms | 24631ms | 24485ms |
| After | 6242ms | 6536ms | 6411ms |
