### PR TITLE
[PoC] Direct op-sqlite connections

### DIFF
--- a/packages/powersync-op-sqlite/src/db/OPSQLiteConnection.ts
+++ b/packages/powersync-op-sqlite/src/db/OPSQLiteConnection.ts
@@ -58,6 +58,10 @@ export class OPSQLiteConnection extends BaseObserver<DBAdapterListener> {
     });
   }
 
+  hasUpdates(): boolean {
+    return this.updateBuffer.length > 0;
+  }
+
   flushUpdates() {
     if (!this.updateBuffer.length) {
       return;

--- a/packages/powersync-op-sqlite/src/db/OPSqliteDBOpenFactory.ts
+++ b/packages/powersync-op-sqlite/src/db/OPSqliteDBOpenFactory.ts
@@ -1,12 +1,15 @@
 import { DBAdapter, SQLOpenFactory, SQLOpenOptions } from '@powersync/common';
 import { OPSQLiteDBAdapter } from './OPSqliteAdapter';
 import { DEFAULT_SQLITE_OPTIONS, SqliteOptions } from './SqliteOptions';
+import { OPSQLiteConnection } from './OPSQLiteConnection';
+import { DB } from '@op-engineering/op-sqlite';
 
 export interface OPSQLiteOpenFactoryOptions extends SQLOpenOptions {
   sqliteOptions?: SqliteOptions;
 }
 export class OPSqliteOpenFactory implements SQLOpenFactory {
   private sqliteOptions: Required<SqliteOptions>;
+  private adapters: Set<OPSQLiteDBAdapter> = new Set();
 
   constructor(protected options: OPSQLiteOpenFactoryOptions) {
     this.sqliteOptions = {
@@ -16,10 +19,85 @@ export class OPSqliteOpenFactory implements SQLOpenFactory {
   }
 
   openDB(): DBAdapter {
-    return new OPSQLiteDBAdapter({
+    const adapter = new OPSQLiteDBAdapter({
       name: this.options.dbFilename,
       dbLocation: this.options.dbLocation,
       sqliteOptions: this.sqliteOptions
     });
+    this.adapters.add(adapter);
+    (adapter as any).abortController.signal.addEventListener('abort', () => {
+      this.adapters.delete(adapter);
+    });
+
+    return adapter;
+  }
+
+  /**
+   * Opens a direct op-sqlite DB connection. This can be used concurrently with PowerSyncDatabase.
+   *
+   * This can be used to execute synchronous queries, or to access other op-sqlite functionality directly.
+   *
+   * Update notifications are propagated to any other PowerSyncDatabase opened with this factory.
+   *
+   * If a write statement or transaction is currently open on any of the other adapters, any
+   * write statements on this connection will block until the others are done. This may create a deadlock,
+   * since this also blocks the JavaScript thread. For that reason, do any write statements in a
+   * writeLock() on the PowerSyncDatabase.
+   *
+   * Read statements can execute concurrently with write statements, so does not have the same risk.
+   *
+   * This is not recommended for most use cases, as synchronous queries block the JavaScript thread,
+   * and the code is not portable to other platforms.
+   */
+  async openDirectConnection(): Promise<DB> {
+    const adapter = new OPSQLiteDBAdapter({
+      name: this.options.dbFilename,
+      dbLocation: this.options.dbLocation,
+      sqliteOptions: {
+        ...this.sqliteOptions,
+        readConnections: 0,
+        // Configure the BUSY_TIMEOUT to be very short, since this is a direct connection.
+        // In general, we should not wait for a lock when using any synchronous queries,
+        // since any locks won't be released while we lock the JS thread.
+        lockTimeoutMs: 50
+      }
+    });
+    await (adapter as any).initialized;
+
+    const connection = (adapter as any).writeConnection as OPSQLiteConnection;
+    connection.registerListener({
+      tablesUpdated: (updateNotification) => {
+        // Pass on to all other adapters.
+        this.adapters.forEach((adapter) => {
+          adapter.iterateListeners((listener) => {
+            listener.tablesUpdated?.(updateNotification);
+          });
+        });
+      }
+    });
+    const database = (connection as any).DB as DB;
+
+    database.commitHook(() => {
+      // This is effectively a "pre-commit" hook, so changes may not actually reflect yet.
+      // To make sure the changes reflect, we first get start a new write transaction (not just a
+      // write lock, since we need to get a lock on the actual SQLite file).
+      const firstAdapter = [...this.adapters][0];
+      if (firstAdapter != null && connection.hasUpdates()) {
+        firstAdapter
+          .writeLock(async (tx) => {
+            // Slightly less overhead than writeTransaction().
+            await tx.execute('BEGIN EXCLUSIVE; ROLLBACK;');
+          })
+          .catch((e) => {
+            // Ignore
+          })
+          .finally(() => {
+            // This triggers the listeners registered above
+            connection.flushUpdates();
+          });
+      }
+    });
+
+    return database;
   }
 }

--- a/packages/powersync-op-sqlite/src/db/SqliteOptions.ts
+++ b/packages/powersync-op-sqlite/src/db/SqliteOptions.ts
@@ -53,6 +53,11 @@ export interface SqliteOptions {
     path: string;
     entryPoint?: string;
   }>;
+
+  /**
+   * Number of read-only connections to use. Defaults to 5.
+   */
+  readConnections?: number;
 }
 
 export enum TemporaryStorageOption {
@@ -89,5 +94,6 @@ export const DEFAULT_SQLITE_OPTIONS: Required<SqliteOptions> = {
   temporaryStorage: TemporaryStorageOption.MEMORY,
   lockTimeoutMs: 30000,
   encryptionKey: null,
+  readConnections: 5,
   extensions: []
 };


### PR DESCRIPTION
This exposes an additional `OPSqliteOpenFactory.openDirectConnection()` method, to get direct access to an op-sqlite DB.

This is similar to opening another op-sqlite DB directly, but:
1. Uses the same sqlite options directly from the `OPSqliteOpenFactory`.
2. Auto-loads the powersync extension.
3. Propagates any updates in that connection to the PowerSyncDatabase, to trigger watch queries and crud uploads.

We do this rather than exposing the existing DB, since that would bypass any existing transaction locking mechanisms, leading to likely race conditions when the DB is used directly.

One specific advantage of this is allowing synchronous queries to be executed, to make it easier to migrate existing applications currently built on synchronous queries. I would not recommend this for other use cases.

Even with this approach, synchronous writes should be wrapped with `PowerSyncDatabase.writeLock()`, otherwise it could fail with `SQLITE_BUSY` if another transaction is busy. We cannot really use `BUSY_TIMEOUT` for this, since the synchronous query would block the JS thread, preventing the other lock from being released.

Synchronous reads do not have the same restriction, and can run concurrently with any other transaction on the PowerSyncDatabase.

## Other changes

1. This makes the number of read connections configurable.
2. This changes write transactions to use `BEGIN EXCLUSIVE` instead of `BEGIN`: Same as in the web SDK. This reduces the number of lock steps, and avoids triggering SQLITE_BUSY errors later in the transaction.

## TODOs

 * [ ] This currently builds on many private APIs of `OPSQLiteDBAdapter` - this can probably be done better.
 * [ ] Needs testing - I haven't actually tested this at all yet.