### PR TITLE
Mark `dispose` as Deprecated

### DIFF
--- a/.changeset/healthy-grapes-sit.md
+++ b/.changeset/healthy-grapes-sit.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Maked AbstractPowerSyncDatabase.dispose method as deprecated. The AbstractPowerSyncDatabase.close method should be used instead.

--- a/packages/common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/common/src/client/AbstractPowerSyncDatabase.ts
@@ -467,6 +467,14 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
   }
 
   /**
+   * @deprecated Use {@link AbstractPowerSyncDatabase#close} instead.
+   * Clears all listeners registered by {@link AbstractPowerSyncDatabase#registerListener}.
+   */
+  dispose(): void {
+    return super.dispose();
+  }
+
+  /**
    * Locking mechanism for exclusively running critical portions of connect/disconnect operations.
    * Locking here is mostly only important on web for multiple tab scenarios.
    */


### PR DESCRIPTION
# Overview

The `AbstractPowerSyncDatabase` currently extends `BaseObserver` which exposes a public `dispose` method. There aren't many use cases for calling this method directly. Its public visibility can cause confusion. 

This PR marks the `dispose` method as deprecated in order to avoid said confusion.