### PR TITLE
React 19 Fixes

### DIFF
--- a/.changeset/beige-jars-whisper.md
+++ b/.changeset/beige-jars-whisper.md
@@ -1,0 +1,5 @@
+---
+'@powersync/react': patch
+---
+
+Fixed regression in useSuspendingQuery where `releaseHold is not a function` could be thrown during hot reload or if the WatchedQuery `loading` state resolved before the first re-render.

--- a/packages/react/src/hooks/suspense/suspense-utils.ts
+++ b/packages/react/src/hooks/suspense/suspense-utils.ts
@@ -1,33 +1,28 @@
 import { WatchedQuery } from '@powersync/common';
 import React from 'react';
 
-const NO_OP_RELEASE = () => {};
-
 /**
  * The store will dispose this query if it has no subscribers attached to it.
  * The suspense promise adds a subscriber to the query, but the promise could resolve
  * before this component is committed. The promise will release it's listener once the query is no longer loading.
  * This temporary hold is used to ensure that the query is not disposed in the interim.
  * Creates a subscription for state change which creates a temporary hold on the query
- * @returns a function to release the hold
  */
 export const useTemporaryHold = (watchedQuery?: WatchedQuery<unknown>) => {
   // Defaults to a no-op. If the provided WatchedQuery is not loading, we don't need a
   // temporary hold.
-  const releaseTemporaryHold = React.useRef<() => void>(NO_OP_RELEASE);
+  const releaseTemporaryHold = React.useRef<() => void | undefined>(undefined);
   const addedHoldTo = React.useRef<WatchedQuery<unknown> | undefined>(undefined);
 
   if (addedHoldTo.current !== watchedQuery) {
     // The query changed, we no longer need the previous hold if present
     releaseTemporaryHold.current?.();
-    releaseTemporaryHold.current = NO_OP_RELEASE;
+    releaseTemporaryHold.current = undefined;
     addedHoldTo.current = watchedQuery;
 
     if (!watchedQuery || !watchedQuery.state.isLoading) {
-      // No query to hold or no reason to hold, return a no-op
-      return {
-        releaseHold: releaseTemporaryHold.current
-      };
+      // No query to hold or no reason to hold, return
+      return;
     }
 
     // Create a hold by subscribing
@@ -67,10 +62,6 @@ export const useTemporaryHold = (watchedQuery?: WatchedQuery<unknown>) => {
     // Set a timeout to conditionally remove the temporary hold
     setTimeout(checkHold, timeoutPollMs);
   }
-
-  return {
-    releaseHold: releaseTemporaryHold.current
-  };
 };
 
 /**

--- a/packages/react/src/hooks/suspense/suspense-utils.ts
+++ b/packages/react/src/hooks/suspense/suspense-utils.ts
@@ -18,6 +18,7 @@ export const useTemporaryHold = (watchedQuery?: WatchedQuery<unknown>) => {
   const addedHoldTo = React.useRef<WatchedQuery<unknown> | undefined>(undefined);
 
   if (addedHoldTo.current !== watchedQuery) {
+    // The query changed, we no longer need the previous hold if present
     releaseTemporaryHold.current?.();
     releaseTemporaryHold.current = NO_OP_RELEASE;
     addedHoldTo.current = watchedQuery;
@@ -29,6 +30,7 @@ export const useTemporaryHold = (watchedQuery?: WatchedQuery<unknown>) => {
       };
     }
 
+    // Create a hold by subscribing
     const disposeSubscription = watchedQuery.registerListener({
       onStateChange: (state) => {}
     });

--- a/packages/react/src/hooks/suspense/useSingleSuspenseQuery.ts
+++ b/packages/react/src/hooks/suspense/useSingleSuspenseQuery.ts
@@ -37,7 +37,7 @@ export const useSingleSuspenseQuery = <T = any>(
 
   // Only use a temporary watched query if we don't have data yet.
   const watchedQuery = data ? null : (store.getQuery(key, parsedQuery, options) as WatchedQuery<T[]>);
-  const { releaseHold } = useTemporaryHold(watchedQuery);
+  useTemporaryHold(watchedQuery);
   React.useEffect(() => {
     // Set the initial yielded data
     // it should be available once we commit the component
@@ -46,10 +46,6 @@ export const useSingleSuspenseQuery = <T = any>(
     } else if (watchedQuery?.state.isLoading === false) {
       setData(watchedQuery.state.data);
       setError(null);
-    }
-
-    if (!watchedQuery?.state.isLoading) {
-      releaseHold();
     }
   }, []);
 

--- a/packages/react/src/hooks/suspense/useWatchedQuerySuspenseSubscription.ts
+++ b/packages/react/src/hooks/suspense/useWatchedQuerySuspenseSubscription.ts
@@ -29,7 +29,7 @@ export const useWatchedQuerySuspenseSubscription = <
 >(
   query: Query
 ): Query['state'] => {
-  const { releaseHold } = useTemporaryHold(query);
+  useTemporaryHold(query);
 
   // Force update state function
   const [, setUpdateCounter] = React.useState(0);
@@ -43,12 +43,6 @@ export const useWatchedQuerySuspenseSubscription = <
         setUpdateCounter((prev) => prev + 1);
       }
     });
-
-    // This runs on the first iteration before the component is suspended
-    // We should only release the hold once the component is no longer loading
-    if (!query.state.isLoading) {
-      releaseHold();
-    }
 
     return dispose;
   }, []);


### PR DESCRIPTION
# Overview

Closes https://github.com/powersync-ja/powersync-js/issues/687

I have only been able to reproduce the issue above when using React 19 in Strict mode. 

It seems like the flow is as follows.

- Initially `useWatchedQuerySuspenseSubscription` is called. We create a temporary hold and suspend the component during loading.
- After loading is complete React calls `useWatchedQuerySuspenseSubscription` which calls `useTemporaryHold` - since the query is not loading, we don't need to create a temporary hold. We return a no-op `releaseHold` method (we don't assign it to the `releaseTemporaryHold` Ref since it's a no-op).
-  A third invocation of `useWatchedQuerySuspenseSubscription` is eventually triggered, we get the value Ref value of `releaseTemporaryHold` (which has not been assigned). We then enter the useEffect in `useWatchedQuerySuspenseSubscription` and attempt to release using the undefined method.

Generally the current implementation is unnecessarily flawed. We cannot feasibly remove the temporary hold from `useWatchedQuerySuspenseSubscription`. We have to rely on the polling to remove this.

There are primarily 2 scenarios

**If the WatchedQuery is loading on the first render:** 

During the initial render (while the query is loading). We will detect `isLoading == true` and throw the pending promise which triggers suspense. Throwing this promise will not trigger the `useEffect` in this "render".

Once the promise resolves React's suspense will reinvoke `useWatchedQuerySuspenseSubscription` (without any previous state). Calling `useTemporaryHold` will not create a temporary hold since the WatchedQuery is no longer in the loading state. The `useEffect` will run, but releasing would be a no-op.

**If the supplied WatchedQuery was already loaded on the first render:**

We will not suspend or create any temporary hold. There is nothing to release in the `useWatchedQuerySuspenseSubscription::useEffect`.

I'm not entirely sure why React 19 Strict mode triggered the third invocation of `useWatchedQuerySuspenseSubscription` where the `useEffect` was triggered, but removing this unnecessary check avoids this issue entirely. 

The `should suspend on initial load` test ensures that temporary holds are removed correctly. 

I manually verified that the unit tests pass when using React 19. This required manually extracting the unit tests from the Monorepo. We should eventually update React in this monorepo.

