### PR TITLE
Add `getCrudTransactions()` returning an async generator

### DIFF
--- a/.changeset/nice-dragons-smile.md
+++ b/.changeset/nice-dragons-smile.md
@@ -1,0 +1,8 @@
+---
+'@powersync/common': minor
+'@powersync/node': minor
+'@powersync/react-native': minor
+'@powersync/web': minor
+---
+
+Add `getCrudTransactions()`, returning an async iterator of transactions. This can be used to batch transactions when uploading CRUD data.

--- a/.github/workflows/test-simulators.yaml
+++ b/.github/workflows/test-simulators.yaml
@@ -138,6 +138,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up XCode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
       - name: CocoaPods Cache
         uses: actions/cache@v3
         id: cocoapods-cache

--- a/packages/common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/common/src/client/AbstractPowerSyncDatabase.ts
@@ -644,8 +644,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
    *
    * Unlike {@link getNextCrudTransaction}, which always returns the oldest transaction that hasn't been
    * {@link CrudTransaction.complete}d yet, this iterator can be used to receive multiple transactions. Calling
-   * {@link CrudTransaction.complete} will mark _all_ transactions emitted by the iterator until that point as
-   * completed.
+   * {@link CrudTransaction.complete} will mark that and all prior transactions emitted by the iterator as completed.
    *
    * This can be used to upload multiple transactions in a single batch, e.g with:
    *

--- a/packages/common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/common/src/client/AbstractPowerSyncDatabase.ts
@@ -643,11 +643,12 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
    * Returns an async iterator of completed transactions with local writes against the database.
    *
    * This is typically used from the {@link PowerSyncBackendConnector.uploadData} callback. Each entry emitted by the
-   * returned flow is a full transaction containing all local writes made while that transaction was active.
+   * returned iterator is a full transaction containing all local writes made while that transaction was active.
    *
    * Unlike {@link getNextCrudTransaction}, which always returns the oldest transaction that hasn't been
-   * {@link CrudTransaction.complete}d yet, this flow can be used to collect multiple transactions. Calling
-   * {@link CrudTransaction.complete} will mark _all_ transactions emitted by the flow until that point as completed.
+   * {@link CrudTransaction.complete}d yet, this iterator can be used to receive multiple transactions. Calling
+   * {@link CrudTransaction.complete} will mark _all_ transactions emitted by the iterator until that point as
+   * completed.
    *
    * This can be used to upload multiple transactions in a single batch, e.g with:
    *

--- a/packages/common/src/utils/async.ts
+++ b/packages/common/src/utils/async.ts
@@ -1,4 +1,15 @@
 /**
+ * A ponyfill for `Symbol.asyncIterator` that is compatible with the
+ * [recommended polyfill](https://github.com/Azure/azure-sdk-for-js/blob/%40azure/core-asynciterator-polyfill_1.0.2/sdk/core/core-asynciterator-polyfill/src/index.ts#L4-L6)
+ * we recommend for React Native.
+ *
+ * As long as we use this symbol (instead of `for await` and `async *`) in this package, we can be compatible with async
+ * iterators without requiring them.
+ */
+export const symbolAsyncIterator: typeof Symbol.asyncIterator =
+  Symbol.asyncIterator ?? Symbol.for('Symbol.asyncIterator');
+
+/**
  * Throttle a function to be called at most once every "wait" milliseconds,
  * on the trailing edge.
  *

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -37,6 +37,7 @@ npx expo install @journeyapps/react-native-quick-sqlite
 Watched queries can be used with either a callback response or Async Iterator response.
 
 Watched queries using the Async Iterator response format require support for Async Iterators.
+`PowerSyncDatabase.getCrudTransactions()` also returns an Async Iterator and requires this workaround.
 
 Expo apps currently require polyfill and Babel plugins in order to use this functionality.
 


### PR DESCRIPTION
Sometimes, users want a batch of data to upload while also ensuring that that batch respects transaction boundaries. At the moment, we don't really have APIs for that, because:

- `getCrudBatch()` returns a batch of items with a flexible size limit, but doesn't respect transaction boundaries (so it's possible to accidentally upload half of a transaction).
- `getNextCrudTransaction()` returns a complete transaction, but nothing more. It will also always return the oldest transaction, so you can't call `getNextCrudTransaction()` multiple times to get more than one.

This adds `getCrudTransactions()`, an async iterable that starts with the oldest transaction and then keeps on yielding more transactions until the iterator is closed. This gives users a tool to compose batches with flexible sizes while still ensuring everything is grouped by transactions.
