### PR TITLE
Avoid calling hooks conditionally

### DIFF
--- a/.changeset/slow-melons-raise.md
+++ b/.changeset/slow-melons-raise.md
@@ -1,0 +1,5 @@
+---
+'@powersync/react': patch
+---
+
+Refactor useQuery hook to avoid calling internal hooks conditionally.

--- a/packages/react/src/hooks/watched/useSingleQuery.ts
+++ b/packages/react/src/hooks/watched/useSingleQuery.ts
@@ -2,8 +2,11 @@ import React from 'react';
 import { QueryResult } from './watch-types.js';
 import { InternalHookOptions } from './watch-utils.js';
 
+/**
+ * @internal not exported from `index.ts`
+ */
 export const useSingleQuery = <RowType = any>(options: InternalHookOptions<RowType[]>): QueryResult<RowType> => {
-  const { query, powerSync, queryChanged } = options;
+  const { query, powerSync, queryChanged, active } = options;
 
   const [output, setOutputState] = React.useState<QueryResult<RowType>>({
     isLoading: true,
@@ -46,13 +49,16 @@ export const useSingleQuery = <RowType = any>(options: InternalHookOptions<RowTy
   );
 
   // Trigger initial query execution
+  // @ts-ignore: Complains about not all code paths returning a value
   React.useEffect(() => {
-    const abortController = new AbortController();
-    runQuery(abortController.signal);
-    return () => {
-      abortController.abort();
-    };
-  }, [powerSync, queryChanged]);
+    if (active) {
+      const abortController = new AbortController();
+      runQuery(abortController.signal);
+      return () => {
+        abortController.abort();
+      };
+    }
+  }, [powerSync, active, queryChanged]);
 
   return {
     ...output,

--- a/packages/react/src/hooks/watched/useWatchedQuerySubscription.ts
+++ b/packages/react/src/hooks/watched/useWatchedQuerySubscription.ts
@@ -21,18 +21,31 @@ export const useWatchedQuerySubscription = <
 >(
   query: Query
 ): Query['state'] => {
-  const [output, setOutputState] = React.useState(query.state);
+  return useNullableWatchedQuerySubscription(query);
+};
 
+/**
+ * @internal
+ */
+export const useNullableWatchedQuerySubscription = <
+  ResultType = unknown,
+  Query extends WatchedQuery<ResultType> = WatchedQuery<ResultType>
+>(
+  query: Query | null
+): Query['state'] | undefined => {
+  const [output, setOutputState] = React.useState(query?.state);
+
+  // @ts-ignore: Complains about not all code paths returning a value
   React.useEffect(() => {
-    const dispose = query.registerListener({
-      onStateChange: (state) => {
-        setOutputState({ ...state });
-      }
-    });
+    if (query) {
+      setOutputState(query.state);
 
-    return () => {
-      dispose();
-    };
+      return query.registerListener({
+        onStateChange: (state) => {
+          setOutputState({ ...state });
+        }
+      });
+    }
   }, [query]);
 
   return output;

--- a/packages/react/src/hooks/watched/watch-utils.ts
+++ b/packages/react/src/hooks/watched/watch-utils.ts
@@ -7,6 +7,7 @@ export type InternalHookOptions<DataType> = {
   query: WatchCompatibleQuery<DataType>;
   powerSync: AbstractPowerSyncDatabase;
   queryChanged: boolean;
+  active: boolean;
 };
 
 export const checkQueryChanged = <T>(query: WatchCompatibleQuery<T>, options: AdditionalOptions) => {


### PR DESCRIPTION
In `useQuery`, we used to invoke the inner `useWatchedQuery` or `useSingleQuery` hooks depending on options passed to the `useQuery` hook.

This violates the [rules of hooks](https://react.dev/reference/rules/rules-of-hooks), because they must be invoked unconditionally. Mixing them like this can trip up the internal state of `useEffect` hooks and others, causing all kinds of issues that are hard to debug.

So to avoid this, we add an `active: boolean` parameter to the internal hooks to conditionally disable them. Then, we can just call both hooks all the time since the inactive one won't actually do anything. I've added a test that fails with the old implementation but works with the new one.