### PR TITLE
Fix: Rust Client Disconnect Race

### DIFF
--- a/.changeset/honest-penguins-worry.md
+++ b/.changeset/honest-penguins-worry.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Fix issue where Rust sync implementation might not disconnect in some circumstances.

--- a/packages/common/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/common/src/client/sync/stream/AbstractRemote.ts
@@ -502,6 +502,10 @@ export abstract class AbstractRemote {
      *  Aborting the active fetch request while it is being consumed seems to throw
      *  an unhandled exception on the window level.
      */
+    if (abortSignal?.aborted) {
+      throw new AbortOperation('Abort request received before making postStreamRaw request');
+    }
+
     const controller = new AbortController();
     let requestResolved = false;
     abortSignal?.addEventListener('abort', () => {

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -900,7 +900,7 @@ The next upload iteration will be delayed.`);
     let hadSyncLine = false;
 
     if (signal.aborted) {
-      return;
+      throw new AbortOperation('Connection request has been aborted');
     }
     const abortController = new AbortController();
     signal.addEventListener('abort', () => abortController.abort());

--- a/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -899,6 +899,9 @@ The next upload iteration will be delayed.`);
     let receivingLines: Promise<void> | null = null;
     let hadSyncLine = false;
 
+    if (signal.aborted) {
+      return;
+    }
     const abortController = new AbortController();
     signal.addEventListener('abort', () => abortController.abort());
 


### PR DESCRIPTION
# Overview

When disconnecting and connecting frequently, it is currently possible for the Rust sync clients to get locked in a frozen state if the `StreamingSyncClient` is disconnected/aborted before it has connected.

This can happen if:
- The client is triggered for a connect
- A disconnect is requested shortly after
- The `StreamingSyncImplementation`'s `AbortController` is marked as aborted, but we nest the `AbortController` [here](https://github.com/powersync-ja/powersync-js/blob/2f6153c95c9b24e5dca6213c3654e55eb8577cff/packages/common/src/client/sync/stream/AbstractStreamingSyncImplementation.ts#L905). 
- For WebSocket requests, we usually check if the provided `AbortSignal` has been aborted before making the request (and we throw), but due to the wrapped controller used in the Rust implementation we don't detect that the wrapped controller has been aborted. The wrapped controller will also never be aborted since the upstream controller won't emit the `aborted` event again (since it was aborted before)
- This causes the Rust client to remain connected. The `ConnectionManager`'s `disconnectingPromise` never resolves, which causes a shared sync implementation to be frozen.

This checks the upstream AbortSignal before wrapping it. The abort is propagated by throwing a `AbortOperation`. 

This could also have happened with the HTTP connection method. A check has been added there also.