### PR TITLE
fix: prevent isFetching flickering during query parameter changes

### DIFF
--- a/.changeset/real-dolls-peel.md
+++ b/.changeset/real-dolls-peel.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Improved the abort handling for stale watched query results when the query/parameters change. This fixes the edge case where an already fetching query would handle a query change and briefly report `isFetching` being false before becoming true again.

--- a/packages/common/src/client/watched/processors/AbstractQueryProcessor.ts
+++ b/packages/common/src/client/watched/processors/AbstractQueryProcessor.ts
@@ -83,6 +83,7 @@ export abstract class AbstractQueryProcessor<
    * Updates the underlying query.
    */
   async updateSettings(settings: Settings) {
+    this.abortController.abort();
     await this.initialized;
 
     if (!this.state.isFetching && this.reportFetching) {
@@ -92,7 +93,7 @@ export abstract class AbstractQueryProcessor<
     }
 
     this.options.watchOptions = settings;
-    this.abortController.abort();
+
     this.abortController = new AbortController();
     await this.runWithReporting(() =>
       this.linkQuery({
@@ -121,7 +122,6 @@ export abstract class AbstractQueryProcessor<
     if (typeof update.data !== 'undefined') {
       await this.iterateAsyncListenersWithError(async (l) => l.onData?.(this.state.data));
     }
-
     await this.iterateAsyncListenersWithError(async (l) => l.onStateChange?.(this.state));
   }
 

--- a/packages/common/src/client/watched/processors/DifferentialQueryProcessor.ts
+++ b/packages/common/src/client/watched/processors/DifferentialQueryProcessor.ts
@@ -236,7 +236,7 @@ export class DifferentialQueryProcessor<RowType>
     db.onChangeWithCallback(
       {
         onChange: async () => {
-          if (this.closed) {
+          if (this.closed || abortSignal.aborted) {
             return;
           }
           // This fires for each change of the relevant tables
@@ -255,6 +255,10 @@ export class DifferentialQueryProcessor<RowType>
               parameters: [...compiledQuery.parameters],
               db: this.options.db
             });
+
+            if (abortSignal.aborted) {
+              return;
+            }
 
             if (this.reportFetching) {
               partialStateUpdate.isFetching = false;

--- a/packages/common/src/client/watched/processors/OnChangeQueryProcessor.ts
+++ b/packages/common/src/client/watched/processors/OnChangeQueryProcessor.ts
@@ -57,7 +57,7 @@ export class OnChangeQueryProcessor<Data> extends AbstractQueryProcessor<Data, W
     db.onChangeWithCallback(
       {
         onChange: async () => {
-          if (this.closed) {
+          if (this.closed || abortSignal.aborted) {
             return;
           }
           // This fires for each change of the relevant tables
@@ -76,6 +76,10 @@ export class OnChangeQueryProcessor<Data> extends AbstractQueryProcessor<Data, W
               parameters: [...compiledQuery.parameters],
               db: this.options.db
             });
+
+            if (abortSignal.aborted) {
+              return;
+            }
 
             if (this.reportFetching) {
               partialStateUpdate.isFetching = false;


### PR DESCRIPTION
This fixes a reported issue where a query that is busy fetching handles a query/parameter change incorrectly. It would go from reporting isFetching=true, to false, to immediately true again. With the expected behaviour being that it remained true during the transition instead. This also caused `isLoading` to become false prematurely.

This was caused by the stale query handler not aborting correctly.

Example erroneous output, where the param changes from 0->1:
```
{param: '0', dataLength: 0, isFetching: true, isLoading: true}
{param: 1, dataLength: 0, isFetching: true, isLoading: true}
{param: 1, dataLength: 0, isFetching: false, isLoading: false} <--- we don't expect this step
{param: 1, dataLength: 0, isFetching: true, isLoading: false}
{param: 1, dataLength: 1, isFetching: false, isLoading: false}
```

Expected output:
```
{param: '0', dataLength: 0, isFetching: true, isLoading: true}
{param: 1, dataLength: 0, isFetching: true, isLoading: true}
{param: 1, dataLength: 1, isFetching: false, isLoading: false}
```

Added a unit test for both React and Vue packages.