### PR TITLE
Trigger Docs Update

### DIFF
--- a/.changeset/young-bananas-heal.md
+++ b/.changeset/young-bananas-heal.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Update TriggerManager trackTableDiff API example

--- a/packages/common/src/client/triggers/TriggerManager.ts
+++ b/packages/common/src/client/triggers/TriggerManager.ts
@@ -345,7 +345,7 @@ export interface TriggerManager {
    *        },
    *        onChange: async (context) => {
    *          // Fetches the todo records that were inserted during this diff
-   *          const newTodos = await context.getAll<Database['todos']>(`
+   *          const newTodos = await context.withDiff<Database['todos']>(`
    *            SELECT
    *              todos.*
    *            FROM


### PR DESCRIPTION
# Overview

This updates the API doc example for `TriggerManager`.`trackTableDiff` to use `withDiff` for accessing the `DIFF` instead of the `getAll` method. The DIFF is only available with the ` trackTableDiff` method.