### PR TITLE
WatchedQuery Bug Fixes

### DIFF
--- a/.changeset/chilly-penguins-learn.md
+++ b/.changeset/chilly-penguins-learn.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Fixed potential race conditions in WatchedQueries when updateSettings is called frequently.

--- a/.changeset/empty-glasses-camp.md
+++ b/.changeset/empty-glasses-camp.md
@@ -1,0 +1,6 @@
+---
+'@powersync/react': patch
+---
+
+- Fixed bug where the `useQuery` reported `error` state would not clear after updating the query to a valid query.
+- Fixed bug where `useQuery` `isFetching` status would not immediately be reported as true when the query has changed.

--- a/.github/workflows/test-simulators.yaml
+++ b/.github/workflows/test-simulators.yaml
@@ -141,7 +141,8 @@ jobs:
       - name: Set up XCode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          # TODO: Update to latest-stable once GH installs iOS 26 simulators
+          xcode-version: '^16.4.0'
 
       - name: CocoaPods Cache
         uses: actions/cache@v3

--- a/packages/common/src/client/watched/WatchedQuery.ts
+++ b/packages/common/src/client/watched/WatchedQuery.ts
@@ -71,6 +71,7 @@ export enum WatchedQueryListenerEvent {
   ON_DATA = 'onData',
   ON_ERROR = 'onError',
   ON_STATE_CHANGE = 'onStateChange',
+  SETTINGS_WILL_UPDATE = 'settingsWillUpdate',
   CLOSED = 'closed'
 }
 
@@ -78,6 +79,7 @@ export interface WatchedQueryListener<Data> extends BaseListener {
   [WatchedQueryListenerEvent.ON_DATA]?: (data: Data) => void | Promise<void>;
   [WatchedQueryListenerEvent.ON_ERROR]?: (error: Error) => void | Promise<void>;
   [WatchedQueryListenerEvent.ON_STATE_CHANGE]?: (state: WatchedQueryState<Data>) => void | Promise<void>;
+  [WatchedQueryListenerEvent.SETTINGS_WILL_UPDATE]?: () => void;
   [WatchedQueryListenerEvent.CLOSED]?: () => void | Promise<void>;
 }
 

--- a/packages/common/src/client/watched/processors/AbstractQueryProcessor.ts
+++ b/packages/common/src/client/watched/processors/AbstractQueryProcessor.ts
@@ -79,25 +79,21 @@ export abstract class AbstractQueryProcessor<
     return this.options.watchOptions.reportFetching ?? true;
   }
 
-  /**
-   * Updates the underlying query.
-   */
-  async updateSettings(settings: Settings) {
+  protected async updateSettingsInternal(settings: Settings) {
     // Abort any previous requests
     this.abortController.abort();
 
-    this.options.watchOptions = settings;
     // Keep track of this controller's abort status
     const abortController = new AbortController();
     // Allow this to be aborted externally
     this.abortController = abortController;
 
-    await this.initialized;
-
     // This may have been aborted while awaiting or if multiple calls to `updateSettings` were made
     if (abortController.signal.aborted) {
       return;
     }
+
+    this.options.watchOptions = settings;
 
     if (!this.state.isFetching && this.reportFetching) {
       await this.updateState({
@@ -111,6 +107,14 @@ export abstract class AbstractQueryProcessor<
         settings
       })
     );
+  }
+
+  /**
+   * Updates the underlying query.
+   */
+  async updateSettings(settings: Settings) {
+    await this.initialized;
+    return this.updateSettingsInternal(settings);
   }
 
   /**
@@ -163,8 +167,8 @@ export abstract class AbstractQueryProcessor<
     };
 
     // Initial setup
-    this.runWithReporting(async () => {
-      await this.updateSettings(this.options.watchOptions);
+    await this.runWithReporting(async () => {
+      await this.updateSettingsInternal(this.options.watchOptions);
     });
   }
 

--- a/packages/common/src/client/watched/processors/AbstractQueryProcessor.ts
+++ b/packages/common/src/client/watched/processors/AbstractQueryProcessor.ts
@@ -83,8 +83,21 @@ export abstract class AbstractQueryProcessor<
    * Updates the underlying query.
    */
   async updateSettings(settings: Settings) {
+    // Abort any previous requests
     this.abortController.abort();
+
+    this.options.watchOptions = settings;
+    // Keep track of this controller's abort status
+    const abortController = new AbortController();
+    // Allow this to be aborted externally
+    this.abortController = abortController;
+
     await this.initialized;
+
+    // This may have been aborted while awaiting or if multiple calls to `updateSettings` were made
+    if (abortController.signal.aborted) {
+      return;
+    }
 
     if (!this.state.isFetching && this.reportFetching) {
       await this.updateState({
@@ -92,12 +105,9 @@ export abstract class AbstractQueryProcessor<
       });
     }
 
-    this.options.watchOptions = settings;
-
-    this.abortController = new AbortController();
     await this.runWithReporting(() =>
       this.linkQuery({
-        abortSignal: this.abortController.signal,
+        abortSignal: abortController.signal,
         settings
       })
     );

--- a/packages/common/src/client/watched/processors/AbstractQueryProcessor.ts
+++ b/packages/common/src/client/watched/processors/AbstractQueryProcessor.ts
@@ -68,7 +68,7 @@ export abstract class AbstractQueryProcessor<
     this._closed = false;
     this.state = this.constructInitialState();
     this.disposeListeners = null;
-    this.initialized = this.init();
+    this.initialized = this.init(this.abortController.signal);
   }
 
   protected constructInitialState(): WatchedQueryState<Data> {
@@ -113,7 +113,7 @@ export abstract class AbstractQueryProcessor<
    * Updates the underlying query.
    */
   async updateSettings(settings: Settings) {
-    // Abort any previous requests
+    // Abort the previous request
     this.abortController.abort();
 
     // Keep track of this controller's abort status
@@ -154,11 +154,8 @@ export abstract class AbstractQueryProcessor<
   /**
    * Configures base DB listeners and links the query to listeners.
    */
-  protected async init() {
+  protected async init(signal: AbortSignal) {
     const { db } = this.options;
-    // Make a ref copy of this early since it might be updated by updateSettings while this
-    // method is running
-    const { abortController } = this;
 
     const disposeCloseListener = db.registerListener({
       closing: async () => {
@@ -183,7 +180,7 @@ export abstract class AbstractQueryProcessor<
 
     // Initial setup
     await this.runWithReporting(async () => {
-      await this.updateSettingsInternal(this.options.watchOptions, abortController.signal);
+      await this.updateSettingsInternal(this.options.watchOptions, signal);
     });
   }
 

--- a/packages/common/src/client/watched/processors/AbstractQueryProcessor.ts
+++ b/packages/common/src/client/watched/processors/AbstractQueryProcessor.ts
@@ -1,6 +1,12 @@
 import { AbstractPowerSyncDatabase } from '../../../client/AbstractPowerSyncDatabase.js';
 import { MetaBaseObserver } from '../../../utils/MetaBaseObserver.js';
-import { WatchedQuery, WatchedQueryListener, WatchedQueryOptions, WatchedQueryState } from '../WatchedQuery.js';
+import {
+  WatchedQuery,
+  WatchedQueryListener,
+  WatchedQueryListenerEvent,
+  WatchedQueryOptions,
+  WatchedQueryState
+} from '../WatchedQuery.js';
 
 /**
  * @internal
@@ -86,6 +92,8 @@ export abstract class AbstractQueryProcessor<
     }
 
     this.options.watchOptions = settings;
+
+    this.iterateListeners((l) => l[WatchedQueryListenerEvent.SETTINGS_WILL_UPDATE]?.());
 
     if (!this.state.isFetching && this.reportFetching) {
       await this.updateState({

--- a/packages/common/src/client/watched/processors/AbstractQueryProcessor.ts
+++ b/packages/common/src/client/watched/processors/AbstractQueryProcessor.ts
@@ -156,6 +156,9 @@ export abstract class AbstractQueryProcessor<
    */
   protected async init() {
     const { db } = this.options;
+    // Make a ref copy of this early since it might be updated by updateSettings while this
+    // method is running
+    const { abortController } = this;
 
     const disposeCloseListener = db.registerListener({
       closing: async () => {
@@ -180,13 +183,12 @@ export abstract class AbstractQueryProcessor<
 
     // Initial setup
     await this.runWithReporting(async () => {
-      await this.updateSettingsInternal(this.options.watchOptions, this.abortController.signal);
+      await this.updateSettingsInternal(this.options.watchOptions, abortController.signal);
     });
   }
 
   async close() {
     this._closed = true;
-    await this.initialized;
     this.abortController.abort();
     this.disposeListeners?.();
     this.disposeListeners = null;

--- a/packages/common/src/client/watched/processors/DifferentialQueryProcessor.ts
+++ b/packages/common/src/client/watched/processors/DifferentialQueryProcessor.ts
@@ -279,6 +279,10 @@ export class DifferentialQueryProcessor<RowType>
               });
             }
 
+            if (this.state.error) {
+              partialStateUpdate.error = null;
+            }
+
             if (Object.keys(partialStateUpdate).length > 0) {
               await this.updateState(partialStateUpdate);
             }

--- a/packages/common/src/client/watched/processors/OnChangeQueryProcessor.ts
+++ b/packages/common/src/client/watched/processors/OnChangeQueryProcessor.ts
@@ -96,6 +96,10 @@ export class OnChangeQueryProcessor<Data> extends AbstractQueryProcessor<Data, W
               });
             }
 
+            if (this.state.error) {
+              partialStateUpdate.error = null;
+            }
+
             if (Object.keys(partialStateUpdate).length > 0) {
               await this.updateState(partialStateUpdate);
             }

--- a/packages/react/src/hooks/watched/useWatchedQuery.ts
+++ b/packages/react/src/hooks/watched/useWatchedQuery.ts
@@ -55,9 +55,9 @@ export const useWatchedQuery = <RowType = unknown>(
    * as soon as the query has been updated. This prevents a result flow where e.g. the hook:
    *  - already returned a result: isLoading, isFetching are both false
    *  - the query is updated, but the state is still isFetching=false from the previous state
-   * We only need to override the isFetching status on the initial render where the query changed
-   * (if we report the fetching status). The fetching status will be updated internally in the `updateSettings`
-   * method eventually.
+   * We override the isFetching status while the `updateSettings` method is running (if we report `isFetching`).
+   * The query could change multiple times while settings are being updated. In order to cater for this, we
+   * track the latest update operation promise.
    */
   if (queryChanged) {
     // Keep track of this pending operation
@@ -72,7 +72,7 @@ export const useWatchedQuery = <RowType = unknown>(
 
     // Clear the latest pending update operation when the latest
     // operation has completed.
-    pendingUpdate.then(() => {
+    pendingUpdate?.then(() => {
       // Only clear if this iteration was the latest iteration
       if (pendingUpdate == updatingPromise.current) {
         updatingPromise.current = null;

--- a/packages/react/src/hooks/watched/useWatchedQuery.ts
+++ b/packages/react/src/hooks/watched/useWatchedQuery.ts
@@ -39,11 +39,12 @@ export const useWatchedQuery = <RowType = unknown>(
 
   React.useEffect(() => {
     watchedQuery?.close();
-    setWatchedQuery(createWatchedQuery);
+    const newQuery = createWatchedQuery();
+    setWatchedQuery(newQuery);
 
     return () => {
       disposePendingUpdateListener.current?.();
-      watchedQuery?.close();
+      newQuery?.close();
     };
   }, [powerSync, active]);
 

--- a/packages/react/tests/useQuery.test.tsx
+++ b/packages/react/tests/useQuery.test.tsx
@@ -10,6 +10,7 @@ import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest';
 import { PowerSyncContext } from '../src/hooks/PowerSyncContext';
 import { useQuery } from '../src/hooks/watched/useQuery';
 import { useWatchedQuerySubscription } from '../src/hooks/watched/useWatchedQuerySubscription';
+import { QueryResult } from '../src/hooks/watched/watch-types';
 
 export const openPowerSync = () => {
   const db = new PowerSyncDatabase({
@@ -147,6 +148,13 @@ describe('useQuery', () => {
             (uuid (), 'second')
         `);
 
+        type TestEvent = {
+          parameters: string[];
+          hookResults: QueryResult<any>;
+        };
+
+        const hookEvents: TestEvent[] = [];
+
         const query = () => {
           const [parameters, setParameters] = React.useState<string[]>(['first']);
 
@@ -155,7 +163,12 @@ describe('useQuery', () => {
             newParametersPromise.then((params) => setParameters(params));
           }, []);
 
-          return useQuery('SELECT * FROM lists WHERE name = ?', parameters);
+          const result = useQuery('SELECT * FROM lists WHERE name = ?', parameters);
+          hookEvents.push({
+            parameters,
+            hookResults: result
+          });
+          return result;
         };
 
         const { result } = renderHook(query, { wrapper: ({ children }) => testWrapper({ children, db }) });
@@ -168,6 +181,12 @@ describe('useQuery', () => {
           { timeout: 500, interval: 100 }
         );
 
+        // Verify that the fetching status was correlated to the parameters
+        const firstResultEvent = hookEvents.find((event) => event.hookResults.data.length == 1);
+        expect(firstResultEvent).toBeDefined();
+        // Fetching should be false as soon as the results were made available
+        expect(firstResultEvent?.hookResults.isFetching).false;
+
         // Now update the parameter
         updateParameters(['second']);
 
@@ -178,6 +197,135 @@ describe('useQuery', () => {
           },
           { timeout: 500, interval: 100 }
         );
+
+        // finds the first result where the parameters have changed
+        const secondFetchingEvent = hookEvents.find((event) => event.parameters[0] == 'second');
+        expect(secondFetchingEvent).toBeDefined();
+        // We should immediately report that we are fetching once we detect new params
+        expect(secondFetchingEvent?.hookResults.isFetching).true;
+      });
+
+      it('should react to updated queries (fast update)', async () => {
+        const db = openPowerSync();
+
+        await db.execute(/* sql */ `
+          INSERT INTO
+            lists (id, name)
+          VALUES
+            (uuid (), 'first'),
+            (uuid (), 'second')
+        `);
+
+        type TestEvent = {
+          parameters: string[];
+          hookResults: QueryResult<any>;
+        };
+
+        const hookEvents: TestEvent[] = [];
+
+        const queryObserver = new commonSdk.BaseObserver();
+        const baseQuery = 'SELECT * FROM lists WHERE name = ?';
+        const query = () => {
+          const [query, setQuery] = React.useState({
+            sql: baseQuery,
+            params: ['']
+          });
+
+          useEffect(() => {
+            // allow updating the parameters externally
+            queryObserver.registerListener({
+              queryUpdated: (query) => setQuery(query)
+            });
+          }, []);
+
+          const result = useQuery(query.sql, query.params);
+          hookEvents.push({
+            parameters: query.params,
+            hookResults: result
+          });
+          return result;
+        };
+
+        const { result } = renderHook(query, { wrapper: ({ children }) => testWrapper({ children, db }) });
+        // let the hook render once, and immediately update the query
+        queryObserver.iterateListeners((l) =>
+          l.queryUpdated?.({
+            sql: baseQuery,
+            params: ['first']
+          })
+        );
+
+        // We should only receive the first list due to the WHERE clause
+        await vi.waitFor(
+          () => {
+            expect(result.current.data[0]?.name).toEqual('first');
+          },
+          { timeout: 500, interval: 100 }
+        );
+
+        // We changed the params before the initial query could execute (we changed the params immediately)
+        // We should not see isLoading=false for the first set of params
+        expect(
+          hookEvents.find((event) => event.parameters[0] == '' && event.hookResults.isLoading == false)
+        ).toBeUndefined();
+        expect(
+          hookEvents.find(
+            (event) =>
+              event.parameters[0] == 'first' &&
+              event.hookResults.isLoading == true &&
+              event.hookResults.isFetching == true
+          )
+        ).toBeDefined();
+
+        // Verify that the fetching status was correlated to the parameters
+        const firstResultEvent = hookEvents.find((event) => event.hookResults.data.length == 1);
+        expect(firstResultEvent).toBeDefined();
+        // Fetching should be false as soon as the results were made available
+        expect(firstResultEvent?.hookResults.isFetching).false;
+
+        // Now update the parameter with something which will cause an error
+        queryObserver.iterateListeners((l) =>
+          l.queryUpdated?.({
+            sql: 'select this is a broken query',
+            params: ['first']
+          })
+        );
+
+        // wait for the error to have been found
+        await vi.waitFor(
+          () => {
+            console.log(result.current);
+            expect(result.current.error).not.equal(null);
+            expect(result.current.isFetching).false;
+          },
+          { timeout: 500, interval: 100 }
+        );
+
+        // The error should not be present before isFetching is false
+        expect(
+          hookEvents.find((event) => event.hookResults.error != null && event.hookResults.isFetching == true)
+        ).toBeUndefined();
+
+        queryObserver.iterateListeners((l) =>
+          l.queryUpdated?.({
+            sql: baseQuery,
+            params: ['second']
+          })
+        );
+
+        // We should now only receive the second list due to the WHERE clause and updated parameter
+        await vi.waitFor(
+          () => {
+            expect(result.current.data[0]?.name).toEqual('second');
+            expect(result.current.error).null;
+          },
+          { timeout: 500, interval: 100 }
+        );
+
+        const secondFetchingEvent = hookEvents.find((event) => event.parameters[0] == 'second');
+        expect(secondFetchingEvent).toBeDefined();
+        // We should immediately report that we are fetching once we detect new params
+        expect(secondFetchingEvent?.hookResults.isFetching).true;
       });
 
       it('should execute compatible queries', async () => {

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -32,7 +32,7 @@ const config: UserConfigExport = {
        */
       isolate: true,
       provider: 'playwright',
-      headless: true,
+      headless: false,
       instances: [
         {
           browser: 'chromium'

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -32,7 +32,7 @@ const config: UserConfigExport = {
        */
       isolate: true,
       provider: 'playwright',
-      headless: false,
+      headless: true,
       instances: [
         {
           browser: 'chromium'

--- a/packages/web/tests/watch.test.ts
+++ b/packages/web/tests/watch.test.ts
@@ -733,6 +733,47 @@ describe('Watch Tests', { sequential: true }, () => {
     expect(watch.state.data[0].make).equals('nottest');
   });
 
+  it('should allow updating queries', async () => {
+    const watch = powersync
+      .query<{ make: string }>({
+        sql: 'SELECT ? as result',
+        parameters: [0]
+      })
+      .watch({
+        reportFetching: false
+      });
+
+    let states: WatchedQueryState<any>[] = [];
+
+    // Keep track of all the states which have been updated
+    const dispose = watch.registerListener({
+      onStateChange: (state) => {
+        states.push(state);
+      }
+    });
+
+    // Spam the updateSettings
+    let updatePromises = Array.from({ length: 100 }).map(async (_, index) =>
+      watch.updateSettings({
+        query: new GetAllQuery({
+          sql: 'SELECT ? as result',
+          parameters: [index + 1]
+        })
+      })
+    );
+
+    await Promise.all(updatePromises);
+
+    await vi.waitFor(
+      () => {
+        expect(states[states.length - 1].isFetching).false;
+        expect(states[states.length - 1].data[0].result).eq(100);
+      },
+      { timeout: 3000 }
+    );
+    dispose();
+  });
+
   it('should report differential query results', async () => {
     const watch = powersync
       .query({

--- a/packages/web/tests/watch.test.ts
+++ b/packages/web/tests/watch.test.ts
@@ -766,12 +766,14 @@ describe('Watch Tests', { sequential: true }, () => {
 
     await vi.waitFor(
       () => {
+        console.log(JSON.stringify(states));
         expect(states[states.length - 1].isFetching).false;
         expect(states[states.length - 1].data[0].result).eq(100);
       },
       { timeout: 3000 }
     );
     dispose();
+    console.log(JSON.stringify(states));
   });
 
   it('should report differential query results', async () => {

--- a/packages/web/tests/watch.test.ts
+++ b/packages/web/tests/watch.test.ts
@@ -773,7 +773,6 @@ describe('Watch Tests', { sequential: true }, () => {
       { timeout: 3000 }
     );
     dispose();
-    console.log(JSON.stringify(states));
   });
 
   it('should report differential query results', async () => {


### PR DESCRIPTION
# Overview

This PR fixes several bugs and regressions introduced with [Incrementally Watched Queries](https://github.com/powersync-ja/powersync-js/pull/614).  

For background, see [this Discord thread](https://discord.com/channels/1138230179878154300/1411678544085651496/1411678544085651496).  

## Updating Watched Query Settings

This addresses a race condition that could occur when `updateSettings` was called multiple times on the same `WatchedQuery` instance.  
The changes improve how `AbortController` lifecycles are managed, ensuring that updates from linked queries do not execute simultaneously.  

Previously, this could cause `isFetching` to briefly report `false` before toggling back to `true` when query parameters changed.  

## React Hooks

In some cases, `isFetching` was reported as `false` immediately after changing query parameters: before the query had actually executed. This made handling state in `useQuery` unreliable.  

This PR fixes the issue by applying the same approach that was previously implemented [here](https://github.com/powersync-ja/powersync-js/blob/6b38551f2c95e542145740117aeaca1f8ed15f5e/packages/react/src/hooks/useQuery.ts#L74).  
