### PR TITLE
Fix dynamic dependency array for `useMemo` hook

### DIFF
--- a/.changeset/empty-donuts-repair.md
+++ b/.changeset/empty-donuts-repair.md
@@ -1,0 +1,5 @@
+---
+'@powersync/react': patch
+---
+
+Fix "order and size of this array must remain constant" warning.


### PR DESCRIPTION
As per the [React documentation](https://react.dev/reference/react/useMemo#parameters), `useMemo` should receive a constant-length array of dependencies:

> The list of dependencies must have a constant number of items and be written inline like `[dep1, dep2, dep3]`

Since we're currently passing parameters of the query to that hook (which can change when e.g. SQL and parameters are changed at once), React may emit a warning about "The final argument passed to `useMemo` changed size between renders. The order and size of this array must remain constant".

I think that warning is harmless, but it's still something we should consider fixing.

So, this resolves that warning by:

1. Stringifying parameters and using that representation as a dependency instead.
2. To make up for that inefficiency, pass the stringified representation to `checkQueryChanged` to avoid recomputing it there.