### PR TITLE
Set timeouts for CI

### DIFF
--- a/.github/workflows/build-packages.yaml
+++ b/.github/workflows/build-packages.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 10
     name: Build Packages
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/diagnostics-image-build.yaml
+++ b/.github/workflows/diagnostics-image-build.yaml
@@ -8,6 +8,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   build-docker-image:
     name: Build diagnostics-app Docker Image
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/test-isolated.yaml
+++ b/.github/workflows/test-isolated.yaml
@@ -8,6 +8,7 @@ jobs:
   test:
     name: Test Isolated Demos
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test-simulators.yaml
+++ b/.github/workflows/test-simulators.yaml
@@ -28,6 +28,7 @@ jobs:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.should_run == 'true' }}
     runs-on: ubuntu-xl
+    timeout-minutes: 30
     env:
       AVD_NAME: ubuntu-avd-x86_64-31
     steps:
@@ -132,6 +133,7 @@ jobs:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.should_run == 'true' }}
     runs-on: macOS-15
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ jobs:
   test:
     name: Test Packages
     runs-on: ubuntu-xl
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Sometimes, the iOS run spends forever waiting for the iOS simulator to boot up. Before this burns 6 hours of CI time on macOS, it's better to set a timeout to get notified early.

Most successful runs seem to take around 20 minutes, so I've added a timeout after 30 minutes to avoid these surprises.