### PR TITLE
Allow using `syncStream()` instances with hooks

### DIFF
--- a/.changeset/ninety-bears-own.md
+++ b/.changeset/ninety-bears-own.md
@@ -1,0 +1,5 @@
+---
+'@powersync/react': patch
+---
+
+Allow using `db.syncStream()` instances in `useQuery` hooks.

--- a/packages/react/src/hooks/streams.ts
+++ b/packages/react/src/hooks/streams.ts
@@ -24,7 +24,7 @@ export interface UseSyncStreamOptions extends SyncStreamSubscribeOptions {
    * Parameters for the stream subscription. A single stream can have multiple subscriptions with different parameter
    * sets.
    */
-  parameters?: Record<string, any>;
+  parameters?: Record<string, any> | null;
 }
 
 /**

--- a/packages/react/tests/streams.test.tsx
+++ b/packages/react/tests/streams.test.tsx
@@ -52,6 +52,15 @@ describe('stream hooks', () => {
         expect(currentStreams()).toStrictEqual([]);
       });
 
+      it('useQuery can take syncStream instance', async () => {
+        const { result } = renderHook(() => useQuery('SELECT 1', [], { streams: [db.syncStream('a')] }), {
+          wrapper: testWrapper
+        });
+
+        // Not resolving the subscription.
+        await waitFor(() => expect(result.current.data).toHaveLength(1), { timeout: 1000, interval: 100 });
+      });
+
       it('useQuery waiting on stream', async () => {
         const { result } = renderHook(
           () => useQuery('SELECT 1', [], { streams: [{ name: 'a', waitForStream: true }] }),


### PR DESCRIPTION
When passing streams to `useQuery`, one currently needs to spell out `name` and `parameters` explicitly. 

As [a user reported](https://discord.com/channels/1138230179878154300/1422138173907144724/1422252801358299277), it would be quite nice if the objects returned by `syncStream()` could also be used for this. That is almost the case already, a small `undefined` vs `null` issue is the only reason they're not compatible.

This fixes a type and adds a test ensuring we can pass `syncStream()` instances to hooks.