### PR TITLE
[Node.js] Bundle PowerSync Core

### DIFF
--- a/.changeset/seven-fireants-boil.md
+++ b/.changeset/seven-fireants-boil.md
@@ -1,0 +1,5 @@
+---
+'@powersync/node': minor
+---
+
+Bundle PowerSync extension with NPM package

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -13,12 +13,12 @@
     "download_core.js"
   ],
   "scripts": {
-    "install": "node download_core.js",
-    "build": "tsc -b && rollup --config",
-    "build:prod": "tsc -b --sourceMap false && rollup --config",
+    "prepare:core": "node download_core.js",
+    "build": " pnpm prepare:core && tsc -b && rollup --config",
+    "build:prod": "pnpm prepare:core && tsc -b --sourceMap false && rollup --config",
     "clean": "rm -rf lib dist tsconfig.tsbuildinfo",
     "watch": "tsc -b -w",
-    "test": "vitest",
+    "test": " pnpm prepare:core && vitest",
     "test:exports": "attw --pack . --ignore-rules no-resolution"
   },
   "type": "module",

--- a/packages/node/src/db/SqliteWorker.ts
+++ b/packages/node/src/db/SqliteWorker.ts
@@ -1,9 +1,9 @@
-import * as path from 'node:path';
 import BetterSQLite3Database, { Database } from '@powersync/better-sqlite3';
 import * as Comlink from 'comlink';
-import { parentPort, threadId } from 'node:worker_threads';
 import OS from 'node:os';
+import * as path from 'node:path';
 import url from 'node:url';
+import { parentPort, threadId } from 'node:worker_threads';
 import { AsyncDatabase, AsyncDatabaseOpener } from './AsyncDatabase.js';
 
 class BlockingAsyncDatabase implements AsyncDatabase {
@@ -129,13 +129,31 @@ export function startPowerSyncWorker(options?: Partial<PowerSyncWorkerOptions>) 
       const isCommonJsModule = import.meta.isBundlingToCommonJs ?? false;
 
       const platform = OS.platform();
+      const arch = OS.arch();
       let extensionPath: string;
+
       if (platform === 'win32') {
-        extensionPath = 'powersync.dll';
+        if (arch === 'x64') {
+          extensionPath = 'powersync.dll';
+        } else {
+          throw 'Windows platform only supports x64 architecture.';
+        }
       } else if (platform === 'linux') {
-        extensionPath = 'libpowersync.so';
+        if (arch === 'x64') {
+          extensionPath = 'libpowersync.so';
+        } else if (arch === 'arm64') {
+          extensionPath = 'libpowersync-aarch64.so';
+        } else {
+          throw 'Linux platform only supports x64 and arm64 architectures.';
+        }
       } else if (platform === 'darwin') {
-        extensionPath = 'libpowersync.dylib';
+        if (arch === 'x64') {
+          extensionPath = 'libpowersync.dylib';
+        } else if (arch === 'arm64') {
+          extensionPath = 'libpowersync-aarch64.dylib';
+        } else {
+          throw 'macOS platform only supports x64 and arm64 architectures.';
+        }
       } else {
         throw 'Unknown platform, PowerSync for Node.js currently supports Windows, Linux and macOS.';
       }


### PR DESCRIPTION
# Overview

We currently download the relevant binary for the PowerSync rust core as an `install` script of `@powersync/node`. Some environments, such as PNPM require explicitly approving install scripts, which can result in cases where the extension is not downloaded.

This bundles the PowerSync extension for all architectures in the published NPM package - avoiding the need for install scripts.

The extension is also downloaded in local scripts to ease local development. 