### PR TITLE
chore: update Angular demo build

### DIFF
--- a/demos/angular-supabase-todolist/extra-webpack.config.js
+++ b/demos/angular-supabase-todolist/extra-webpack.config.js
@@ -18,7 +18,7 @@ module.exports = (config, options, targetOptions) => {
       ...config.plugins,
       new webpack.DefinePlugin({
         // Embed environment variables starting with `WEBPACK_PUBLIC_`
-        'process.env': JSON.stringify(
+        env: JSON.stringify(
           Object.fromEntries(Object.entries(process.env).filter(([key]) => key.startsWith('WEBPACK_PUBLIC_')))
         )
       })

--- a/demos/angular-supabase-todolist/src/env.d.ts
+++ b/demos/angular-supabase-todolist/src/env.d.ts
@@ -1,8 +1,0 @@
-declare namespace NodeJS {
-  // These are injected in the Webpack config
-  interface ProcessEnv {
-    WEBPACK_PUBLIC_SUPABASE_URL: string;
-    WEBPACK_PUBLIC_SUPABASE_ANON_KEY: string;
-    WEBPACK_PUBLIC_POWERSYNC_URL: string;
-  }
-}

--- a/demos/angular-supabase-todolist/src/environment.ts
+++ b/demos/angular-supabase-todolist/src/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
-  supabaseUrl: process.env.WEBPACK_PUBLIC_SUPABASE_URL,
-  supabaseKey: process.env.WEBPACK_PUBLIC_SUPABASE_ANON_KEY,
-  powersyncUrl: process.env.WEBPACK_PUBLIC_POWERSYNC_URL
+  supabaseUrl: env.WEBPACK_PUBLIC_SUPABASE_URL,
+  supabaseKey: env.WEBPACK_PUBLIC_SUPABASE_ANON_KEY,
+  powersyncUrl: env.WEBPACK_PUBLIC_POWERSYNC_URL
 };

--- a/demos/angular-supabase-todolist/src/global.d.ts
+++ b/demos/angular-supabase-todolist/src/global.d.ts
@@ -1,0 +1,12 @@
+// Ambient declarations for webpack-injected environment variables.
+// webpack's DefinePlugin injects `env` at build time.
+
+declare global {
+  const env: {
+    WEBPACK_PUBLIC_SUPABASE_URL: string;
+    WEBPACK_PUBLIC_SUPABASE_ANON_KEY: string;
+    WEBPACK_PUBLIC_POWERSYNC_URL: string;
+  };
+}
+
+export {};


### PR DESCRIPTION
# Overview

This Angular demo isolated test build is currently failing due to a Node.js typing issue.

```
Error: src/environment.ts:2:16 - error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
2   supabaseUrl: process.env.WEBPACK_PUBLIC_SUPABASE_URL,
                 ~~~~~~~
Error: src/environment.ts:3:16 - error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
3   supabaseKey: process.env.WEBPACK_PUBLIC_SUPABASE_ANON_KEY,
                 ~~~~~~~
Error: src/environment.ts:4:17 - error TS2591: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
4   powersyncUrl: process.env.WEBPACK_PUBLIC_POWERSYNC_URL
```

Failed run: https://github.com/powersync-ja/powersync-js/actions/runs/18650828806/job/53168919561

We currently inject environment variables on `process.env` via a Webpack plugin. The TypeScript compiler errors due to `process.env` being a Node.js concept, while this is an Angular app which is meant for web. 

We could add Node.js types, but that seems strange since this is a web app. Instead this adds a strict definition file for the injected `env`.