### PR TITLE
Fix release CI

### DIFF
--- a/demos/react-supabase-todolist-tanstackdb/package.json
+++ b/demos/react-supabase-todolist-tanstackdb/package.json
@@ -17,6 +17,7 @@
     "@mui/x-data-grid": "^6.19.6",
     "@powersync/react": "workspace:*",
     "@powersync/web": "workspace:*",
+    "@powersync/common": "workspace:*",
     "@supabase/supabase-js": "^2.39.7",
     "@tanstack/db": "^0.4.17",
     "@tanstack/powersync-db-collection": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1556,6 +1556,9 @@ importers:
       '@mui/x-data-grid':
         specifier: ^6.19.6
         version: 6.20.4(@mui/material@5.17.1(@emotion/react@11.11.4(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@5.17.1(@emotion/react@11.11.4(@types/react@18.3.23)(react@18.3.1))(@emotion/styled@11.11.5(@emotion/react@11.11.4(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@powersync/common':
+        specifier: workspace:*
+        version: link:../../packages/common
       '@powersync/react':
         specifier: workspace:*
         version: link:../../packages/react
@@ -1570,7 +1573,7 @@ importers:
         version: 0.4.17(typescript@5.9.2)
       '@tanstack/powersync-db-collection':
         specifier: ^0.1.0
-        version: 0.1.0(@powersync/common@1.41.0)(typescript@5.9.2)
+        version: 0.1.0(@powersync/common@packages+common)(typescript@5.9.2)
       '@tanstack/react-db':
         specifier: ^0.1.39
         version: 0.1.39(react@18.3.1)(typescript@5.9.2)
@@ -6869,9 +6872,6 @@ packages:
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
-
-  '@powersync/common@1.41.0':
-    resolution: {integrity: sha512-N5Tpp2QU0RnP9eEDu+/Ok/IccSk8sNxnCBQgByEHg+DAHvSeSpIFe4nDSZwaRJrcltKi/FMzzjSIBjFrtsUz/g==}
 
   '@powersync/sql-js@0.0.5':
     resolution: {integrity: sha512-+rjUyEzwQIM51dJSbw5bpWyquwiHa5Pyu0Pb6oXhddfxhvuLHMWEM/+bN9em2LkFZ/jtLI9HBCcCsOORDeL5hg==}
@@ -27983,10 +27983,6 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
-  '@powersync/common@1.41.0':
-    dependencies:
-      js-logger: 1.6.1
-
   '@powersync/sql-js@0.0.5': {}
 
   '@radix-ui/react-compose-refs@1.0.0(react@18.3.1)':
@@ -31357,9 +31353,9 @@ snapshots:
 
   '@tanstack/pacer@0.1.0': {}
 
-  '@tanstack/powersync-db-collection@0.1.0(@powersync/common@1.41.0)(typescript@5.9.2)':
+  '@tanstack/powersync-db-collection@0.1.0(@powersync/common@packages+common)(typescript@5.9.2)':
     dependencies:
-      '@powersync/common': 1.41.0
+      '@powersync/common': link:packages/common
       '@standard-schema/spec': 1.0.0
       '@tanstack/db': 0.4.17(typescript@5.9.2)
       '@tanstack/store': 0.8.0


### PR DESCRIPTION
Recent runs of the release CI [are broken](https://github.com/powersync-ja/powersync-js/actions/runs/19235002171/job/54982468985) because we try to fetch a version we're about to potentially release from npm (we should be using the local version instead because the updated version obviously doesn't exist yet).

This can be reproduced locally by running `pnpm changeset version && pnpm install --lockfile-only --frozen-lockfile=false`. I don't understand why this is only happening for the `react-supabase-todolist-tanstackdb` demo, but it can be fixed by adding an explicit workspace dependency on `@powersync/common`. I'm a bit surprised the other demos don't need that because I don't see what's different about the tanstack demo, but this seems to fix it.