### PR TITLE
chore: Fix typo in changeset

### DIFF
--- a/.changeset/gorgeous-scissors-drive.md
+++ b/.changeset/gorgeous-scissors-drive.md
@@ -1,5 +1,5 @@
 ---
-'@powersync/common': patch
+'@powersync/capacitor': patch
 ---
 
 Fixed readTransaction method throwing "not allowed in read-only mode" errors


### PR DESCRIPTION
There currently is a mismatch between changeset package name and update message.