### PR TITLE
fix: Syncing After Uploads when using Triggers

### DIFF
--- a/.changeset/four-falcons-arrive.md
+++ b/.changeset/four-falcons-arrive.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Fixed issue where using triggers could block syncing after performing uploads.

--- a/packages/common/src/client/sync/bucket/SqliteBucketStorage.ts
+++ b/packages/common/src/client/sync/bucket/SqliteBucketStorage.ts
@@ -255,7 +255,7 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
       // Nothing to update
       return false;
     }
-    const rs = await this.db.getAll<{ seq: number }>("SELECT seq FROM sqlite_sequence WHERE name = 'ps_crud'");
+    const rs = await this.db.getAll<{ seq: number }>("SELECT seq FROM main.sqlite_sequence WHERE name = 'ps_crud'");
     if (!rs.length) {
       // Nothing to update
       return false;
@@ -273,7 +273,7 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
         return false;
       }
 
-      const rs = await tx.execute("SELECT seq FROM sqlite_sequence WHERE name = 'ps_crud'");
+      const rs = await tx.execute("SELECT seq FROM main.sqlite_sequence WHERE name = 'ps_crud'");
       if (!rs.rows?.length) {
         // assert isNotEmpty
         throw new Error('SQLite Sequence should not be empty');


### PR DESCRIPTION
# Overview

When using triggers (e.g., `database.triggers.createDiffTrigger()`), the `updateLocalTarget()` method could fail to read the `ps_crud` sequence value, causing sync to be blocked after performing uploads.

## Root Cause

The trigger system creates temporary tables and triggers (`CREATE TEMP TABLE` and `CREATE TEMP TRIGGER`) in the `temp` schema on the connection. When these temporary objects exist, SQLite's schema resolution mechanism prioritizes the `temp` schema when resolving unqualified table names. This means that queries to `sqlite_sequence` without an explicit schema qualifier could resolve to `temp.sqlite_sequence` instead of `main.sqlite_sequence`, returning no rows even though the sequence was actually advancing correctly.

### Solution

Explicitly qualify `sqlite_sequence` queries with the `main.` schema prefix in `SqliteBucketStorage.updateLocalTarget()`:
- Changed `SELECT seq FROM sqlite_sequence` → `SELECT seq FROM main.sqlite_sequence`

This ensures we always query the main database's sequence table, regardless of temporary schema context.

closes https://github.com/powersync-ja/powersync-js/issues/778
