### PR TITLE
Clean up shared sync locks on close/pagehide

### DIFF
--- a/.changeset/shared-sync-lock-cleanup.md
+++ b/.changeset/shared-sync-lock-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@powersync/web": patch
+---
+
+Ensure shared sync releases db-locks on close/pagehide and cleans up pending lock requests.

--- a/packages/web/src/worker/sync/SharedSyncImplementation.ts
+++ b/packages/web/src/worker/sync/SharedSyncImplementation.ts
@@ -487,8 +487,8 @@ export class SharedSyncImplementation extends BaseObserver<SharedSyncImplementat
         });
         lastClient.closeListeners.push(async () => {
           this.logger.info('Aborting open connection because associated tab closed.');
-          await wrapped.close().catch((ex) => this.logger.warn('error closing database connection', ex));
           wrapped.markRemoteClosed();
+          await wrapped.close().catch((ex) => this.logger.warn('error closing database connection', ex));
         });
 
         return wrapped;

--- a/packages/web/tests/force_close_db_lock_abort.test.ts
+++ b/packages/web/tests/force_close_db_lock_abort.test.ts
@@ -1,0 +1,114 @@
+import * as Comlink from 'comlink';
+import { describe, expect, it, vi } from 'vitest';
+import { LockedAsyncDatabaseAdapter } from '../src/db/adapters/LockedAsyncDatabaseAdapter';
+import { WorkerWrappedAsyncDatabaseConnection } from '../src/db/adapters/WorkerWrappedAsyncDatabaseConnection';
+import type { AsyncDatabaseConnection, OpenAsyncDatabaseConnection } from '../src/db/adapters/AsyncDatabaseConnection';
+import {
+  DEFAULT_WEB_SQL_FLAGS,
+  TemporaryStorageOption,
+  type ResolvedWebSQLOpenOptions
+} from '../src/db/adapters/web-sql-flags';
+
+const baseConfig: ResolvedWebSQLOpenOptions = {
+  dbFilename: 'crm.sqlite',
+  flags: DEFAULT_WEB_SQL_FLAGS,
+  temporaryStorage: TemporaryStorageOption.MEMORY,
+  cacheSizeKb: 1
+};
+
+const baseConnection: AsyncDatabaseConnection = {
+  init: async () => {},
+  close: async () => {},
+  markHold: async () => 'hold',
+  releaseHold: async () => {},
+  isAutoCommit: async () => true,
+  execute: async () => ({ rows: { _array: [], length: 0 }, rowsAffected: 0, insertId: 0 }),
+  executeRaw: async () => [],
+  executeBatch: async () => ({ rows: { _array: [], length: 0 }, rowsAffected: 0, insertId: 0 }),
+  registerOnTableChange: async () => () => {},
+  getConfig: async () => baseConfig
+};
+
+describe('forceClose db-lock abort', () => {
+  it('aborts pending db-lock when forceClose happens after lock request', async () => {
+    let lockRequestedResolve!: () => void;
+    const lockRequested = new Promise<void>((resolve) => {
+      lockRequestedResolve = resolve;
+    });
+
+    const mockLocks = {
+      request: ((...args: any[]) => {
+        const [name, optionsOrCallback, callback] = args;
+        const lockCallback = typeof optionsOrCallback === 'function' ? optionsOrCallback : callback;
+        const signal =
+          typeof optionsOrCallback === 'object' && optionsOrCallback ? optionsOrCallback.signal : undefined;
+        return new Promise((resolve, reject) => {
+          const onAbort = () => {
+            reject(new DOMException('Aborted', 'AbortError'));
+          };
+          if (signal) {
+            signal.addEventListener('abort', onAbort);
+          }
+          Promise.resolve()
+            .then(async () => {
+              const callbackPromise = lockCallback?.({ name, mode: 'exclusive' });
+              lockRequestedResolve();
+              return callbackPromise;
+            })
+            .then(resolve)
+            .catch(reject)
+            .finally(() => {
+              if (signal) {
+                signal.removeEventListener('abort', onAbort);
+              }
+            });
+        });
+      }) as LockManager['request'],
+      query: vi.fn()
+    } as LockManager;
+
+    const locksSpy = vi.spyOn(navigator, 'locks', 'get').mockReturnValue(mockLocks);
+
+    const hangingExecute = vi.fn(() => new Promise<never>(() => {}));
+    const connection: AsyncDatabaseConnection = { ...baseConnection, execute: hangingExecute };
+    const remote = {
+      [Comlink.releaseProxy]: () => {}
+    } as Comlink.Remote<OpenAsyncDatabaseConnection<ResolvedWebSQLOpenOptions>>;
+    let wrapped: WorkerWrappedAsyncDatabaseConnection | null = null;
+
+    const adapter = new LockedAsyncDatabaseAdapter({
+      name: 'crm.sqlite',
+      openConnection: async () => {
+        wrapped = new WorkerWrappedAsyncDatabaseConnection({
+          baseConnection: connection,
+          identifier: 'crm.sqlite',
+          remoteCanCloseUnexpectedly: false,
+          remote
+        });
+        return wrapped;
+      }
+    });
+
+    const executePromise = adapter.execute('select 1');
+    const executeOutcome = executePromise.then(
+      () => ({ status: 'resolved' as const }),
+      (error) => ({ status: 'rejected' as const, error })
+    );
+
+    await lockRequested;
+    wrapped!.forceClose();
+
+    const outcome = await Promise.race([
+      executeOutcome,
+      new Promise<{ status: 'timeout' }>((resolve) => setTimeout(() => resolve({ status: 'timeout' }), 150))
+    ]);
+
+    locksSpy.mockRestore();
+
+    expect(outcome.status).not.toBe('timeout');
+    expect(outcome.status).toBe('rejected');
+    if (outcome.status === 'rejected') {
+      expect(outcome.error?.name).toBe('AbortError');
+    }
+  });
+});

--- a/packages/web/tests/shared_sync_db_lock_cleanup.test.ts
+++ b/packages/web/tests/shared_sync_db_lock_cleanup.test.ts
@@ -1,0 +1,163 @@
+import * as Comlink from 'comlink';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { DBAdapter } from '@powersync/common';
+import type { AsyncDatabaseConnection } from '../src/db/adapters/AsyncDatabaseConnection';
+import {
+  DEFAULT_WEB_SQL_FLAGS,
+  TemporaryStorageOption,
+  type ResolvedWebSQLOpenOptions
+} from '../src/db/adapters/web-sql-flags';
+import { SharedSyncImplementation, type WrappedSyncPort } from '../src/worker/sync/SharedSyncImplementation';
+import type { AbstractSharedSyncClientProvider } from '../src/worker/sync/AbstractSharedSyncClientProvider';
+
+vi.mock('comlink', async () => {
+  const actual = await vi.importActual<typeof import('comlink')>('comlink');
+  return {
+    ...actual,
+    wrap: vi.fn()
+  };
+});
+
+describe('Shared sync db-lock cleanup', { sequential: true }, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('releases db-lock when the dedicated worker dies mid-operation', async () => {
+    let lockRequestedResolve!: (name: string) => void;
+    const lockRequested = new Promise<string>((resolve) => {
+      lockRequestedResolve = resolve;
+    });
+
+    const activeLocks = new Set<string>();
+    const mockLocks = {
+      request: ((...args: any[]) => {
+        const [name, optionsOrCallback, callback] = args;
+        const lockCallback = typeof optionsOrCallback === 'function' ? optionsOrCallback : callback;
+        const signal =
+          typeof optionsOrCallback === 'object' && optionsOrCallback ? optionsOrCallback.signal : undefined;
+        activeLocks.add(name);
+        lockRequestedResolve(name);
+        return new Promise((resolve, reject) => {
+          const onAbort = () => {
+            activeLocks.delete(name);
+            reject(new DOMException('Aborted', 'AbortError'));
+          };
+          if (signal) {
+            signal.addEventListener('abort', onAbort);
+          }
+          Promise.resolve()
+            .then(() => lockCallback?.({ name, mode: 'exclusive' }))
+            .then(resolve)
+            .catch(reject)
+            .finally(() => {
+              if (signal) {
+                signal.removeEventListener('abort', onAbort);
+              }
+              activeLocks.delete(name);
+            });
+        });
+      }) as LockManager['request'],
+      query: vi.fn()
+    } as LockManager;
+
+    vi.spyOn(navigator, 'locks', 'get').mockReturnValue(mockLocks);
+
+    let executeCalledResolve!: () => void;
+    const executeCalled = new Promise<void>((resolve) => {
+      executeCalledResolve = resolve;
+    });
+
+    const hangingExecute = vi.fn(() => {
+      executeCalledResolve();
+      return new Promise<never>(() => {});
+    });
+    const hangingClose = vi.fn(() => new Promise<never>(() => {}));
+
+    const baseConfig: ResolvedWebSQLOpenOptions = {
+      dbFilename: 'crm.sqlite',
+      flags: DEFAULT_WEB_SQL_FLAGS,
+      temporaryStorage: TemporaryStorageOption.MEMORY,
+      cacheSizeKb: 1
+    };
+
+    const baseConnection: AsyncDatabaseConnection = {
+      init: async () => {},
+      close: hangingClose,
+      markHold: async () => 'hold',
+      releaseHold: async () => {},
+      isAutoCommit: async () => true,
+      execute: hangingExecute,
+      executeRaw: async () => [],
+      executeBatch: async () => ({ rows: { _array: [], length: 0 }, rowsAffected: 0, insertId: 0 }),
+      registerOnTableChange: async () => () => {},
+      getConfig: async () => baseConfig
+    };
+
+    const openFn = vi.fn(async () => baseConnection) as unknown as Comlink.Remote<
+      (...args: unknown[]) => Promise<AsyncDatabaseConnection>
+    >;
+    (openFn as any)[Comlink.releaseProxy] = vi.fn();
+    const wrapMock = Comlink.wrap as unknown as ReturnType<typeof vi.fn>;
+    wrapMock.mockReturnValue(openFn);
+
+    const implementation = new SharedSyncImplementation();
+    const { port1 } = new MessageChannel();
+
+    const clientProvider = {
+      fetchCredentials: vi.fn(async () => null),
+      invalidateCredentials: vi.fn(),
+      uploadCrud: vi.fn(async () => {}),
+      statusChanged: vi.fn(),
+      getDBWorkerPort: vi.fn(async () => port1),
+      trace: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      time: vi.fn(),
+      timeEnd: vi.fn(),
+      [Comlink.releaseProxy]: vi.fn()
+    } as unknown as Comlink.Remote<AbstractSharedSyncClientProvider>;
+
+    const port: WrappedSyncPort = {
+      port: port1,
+      clientProvider,
+      currentSubscriptions: [],
+      closeListeners: []
+    };
+
+    (implementation as unknown as { ports: WrappedSyncPort[] }).ports.push(port);
+    (implementation as unknown as { syncParams: unknown }).syncParams = {
+      streamOptions: {},
+      dbParams: baseConfig
+    };
+
+    await (implementation as unknown as { openInternalDB: () => Promise<void> }).openInternalDB();
+
+    const adapter = port.db as DBAdapter;
+    const executePromise = adapter.execute('select 1');
+    const executeOutcome = executePromise.then(
+      () => ({ status: 'resolved' as const }),
+      (error) => ({ status: 'rejected' as const, error })
+    );
+
+    const lockName = await lockRequested;
+    await executeCalled;
+    expect(lockName).toBe('db-lock-crm.sqlite');
+    expect(activeLocks.has(lockName)).toBe(true);
+
+    const closeListener = port.closeListeners[0];
+    expect(closeListener).toBeDefined();
+    void Promise.resolve(closeListener?.()).catch(() => {});
+
+    const outcome = await Promise.race([
+      executeOutcome,
+      new Promise<{ status: 'timeout' }>((resolve) => setTimeout(() => resolve({ status: 'timeout' }), 150))
+    ]);
+
+    expect(outcome.status).not.toBe('timeout');
+    await vi.waitFor(() => expect(activeLocks.size).toBe(0), { timeout: 50 });
+  });
+});

--- a/packages/web/tests/shared_sync_pagehide.test.ts
+++ b/packages/web/tests/shared_sync_pagehide.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { BucketStorageAdapter } from '@powersync/common';
+import { SharedWebStreamingSyncImplementation, WebRemote } from '@powersync/web';
+import type { WebDBAdapter } from '../src/db/adapters/WebDBAdapter';
+import { TestConnector } from './utils/MockStreamOpenFactory';
+
+vi.mock('comlink', async () => {
+  const actual = await vi.importActual<typeof import('comlink')>('comlink');
+  return {
+    ...actual,
+    wrap: () => ({
+      setLogLevel: vi.fn(),
+      setParams: vi.fn(() => Promise.resolve()),
+      addLockBasedCloseSignal: vi.fn(),
+      triggerCrudUpload: vi.fn(),
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+      updateSubscriptions: vi.fn(),
+      getWriteCheckpoint: vi.fn(),
+      hasCompletedSync: vi.fn(),
+      _testUpdateAllStatuses: vi.fn(),
+      [actual.releaseProxy]: vi.fn()
+    }),
+    expose: vi.fn()
+  };
+});
+
+describe('Shared sync pagehide cleanup', { sequential: true }, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('releases tab-close-signal lock on pagehide', async () => {
+    let lockRequestedResolve!: (name: string) => void;
+    const lockRequested = new Promise<string>((resolve) => {
+      lockRequestedResolve = resolve;
+    });
+
+    const activeLocks = new Set<string>();
+    let lockCallbackStarted = false;
+    let lockCallbackFinished = false;
+    const mockLocks = {
+      request: ((...args: any[]) => {
+        const [name, optionsOrCallback, callback] = args;
+        const lockCallback = typeof optionsOrCallback === 'function' ? optionsOrCallback : callback;
+        activeLocks.add(name);
+        lockRequestedResolve(name);
+        return Promise.resolve()
+          .then(() => {
+            lockCallbackStarted = true;
+            return lockCallback?.({ name, mode: 'exclusive' });
+          })
+          .finally(() => {
+            lockCallbackFinished = true;
+            activeLocks.delete(name);
+          });
+      }) as LockManager['request'],
+      query: vi.fn()
+    } as LockManager;
+
+    vi.spyOn(navigator, 'locks', 'get').mockReturnValue(mockLocks);
+
+    const adapter = {} as unknown as BucketStorageAdapter;
+    const dbAdapter = {
+      getConfiguration: () => ({}),
+      shareConnection: async () => ({ identifier: 'crm.sqlite', port: {} as MessagePort })
+    } as unknown as WebDBAdapter;
+    const remote = new WebRemote(new TestConnector());
+
+    new SharedWebStreamingSyncImplementation({
+      adapter,
+      remote,
+      uploadCrud: async () => {},
+      identifier: 'crm.sqlite',
+      crudUploadThrottleMs: 1000,
+      retryDelayMs: 1000,
+      db: dbAdapter,
+      subscriptions: [],
+      sync: {
+        worker: () => ({ port: {} as MessagePort } as SharedWorker)
+      }
+    });
+
+    const lockName = await lockRequested;
+    expect(activeLocks.has(lockName)).toBe(true);
+
+    const pagehide =
+      typeof PageTransitionEvent === 'function'
+        ? new PageTransitionEvent('pagehide', { persisted: false })
+        : Object.assign(new Event('pagehide'), { persisted: false });
+    window.dispatchEvent(pagehide);
+
+    await vi.waitFor(() => expect(lockCallbackStarted).toBe(true));
+    await vi.waitFor(() => expect(lockCallbackFinished).toBe(true));
+
+    expect(activeLocks.size).toBe(0);
+  });
+});


### PR DESCRIPTION
Follow-up to #811

## Summary
- Abort pending db-lock requests on worker-wrapped close to avoid hanging lock waits.
- Make worker-wrapped cleanup idempotent and notify close listeners.
- Ensure shared sync pagehide triggers close-signal cleanup for tab-close locks.

## Tests
- pnpm --filter @powersync/web run build:tsc
- pnpm vitest --run tests/force_close_db_lock_abort.test.ts tests/shared_sync_db_lock_cleanup.test.ts tests/shared_sync_pagehide.test.ts
- pnpm build:packages
- pnpm vitest