### PR TITLE
chore: fix release action

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@pnpm/workspace.find-packages": "catalog:",
     "@pnpm/workspace.read-manifest": "catalog:",
     "@types/inquirer": "^8.2.12",
+    "@types/node": "catalog:",
     "@vitest/browser": "^3.2.4",
     "commander": "^12.1.0",
     "husky": "^9.0.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       '@types/inquirer':
         specifier: ^8.2.12
         version: 8.2.12
+      '@types/node':
+        specifier: 'catalog:'
+        version: 24.10.4
       '@vitest/browser':
         specifier: ^3.2.4
         version: 3.2.4(playwright@1.57.0)(vite@6.4.1(@types/node@24.10.4)(jiti@1.21.7)(lightningcss@1.30.2)(terser@5.44.1)(yaml@2.8.2))(vitest@3.2.4)


### PR DESCRIPTION
The Release action has been failing since https://github.com/powersync-ja/powersync-js/pull/767

- https://github.com/powersync-ja/powersync-js/actions/runs/21240887160
- https://github.com/powersync-ja/powersync-js/actions/runs/21207940546

This is due to the error.

```
> powersync-js@1.0.0 demos:update /home/runner/work/powersync-js/powersync-js
> tsc -b scripts && node scripts/dist/bump-demo-packages.js --all

error TS2688: Cannot find type definition file for 'node'.
  The file is in the program because:
    Entry point of type library 'node' specified in compilerOptions
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.
```

I could only reproduce this locally by deleting the `dist` folder in the `scripts` folder. Seems caching prevented this issue from surfacing locally before. 

The simplest fix is to add `@types/node` to the workspace as a shared dev dependency. Alternatively, we could also make `scripts` its own package and add it there. Opting for simple fix for now. 
