### PR TITLE
discussion/fix: powersync/common dependencies

### DIFF
--- a/.changeset/tender-foxes-float.md
+++ b/.changeset/tender-foxes-float.md
@@ -1,0 +1,7 @@
+---
+'@powersync/react-native': minor
+'@powersync/node': minor
+'@powersync/web': minor
+---
+
+Specify @powersync/common only as a direct dependency for main SDK packages. This should prevent some cases where auxillary packages' @powersync/common dependencies are not bumped when SDK packages are bumped.

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -57,7 +57,6 @@
   },
   "homepage": "https://docs.powersync.com/",
   "peerDependencies": {
-    "@powersync/common": "workspace:^1.46.0",
     "better-sqlite3": "12.x"
   },
   "peerDependenciesMeta": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -65,7 +65,7 @@
     }
   },
   "dependencies": {
-    "@powersync/common": "workspace:*",
+    "@powersync/common": "workspace:^",
     "async-mutex": "catalog:",
     "bson": "catalog:",
     "comlink": "catalog:",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -42,7 +42,7 @@
     }
   },
   "dependencies": {
-    "@powersync/common": "workspace:*",
+    "@powersync/common": "workspace:^",
     "@powersync/react": "workspace:*",
     "async-mutex": "catalog:"
   },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -33,7 +33,6 @@
   "homepage": "https://docs.powersync.com/",
   "peerDependencies": {
     "@journeyapps/react-native-quick-sqlite": "^2.5.0",
-    "@powersync/common": "workspace:^1.46.0",
     "react": "*",
     "react-native": "*"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -69,7 +69,7 @@
     "@journeyapps/wa-sqlite": "catalog:"
   },
   "dependencies": {
-    "@powersync/common": "workspace:*",
+    "@powersync/common": "workspace:^",
     "async-mutex": "catalog:",
     "bson": "catalog:",
     "comlink": "catalog:",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -66,8 +66,7 @@
   "author": "JOURNEYAPPS",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@journeyapps/wa-sqlite": "catalog:",
-    "@powersync/common": "workspace:^1.46.0"
+    "@journeyapps/wa-sqlite": "catalog:"
   },
   "dependencies": {
     "@powersync/common": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -511,7 +511,7 @@ importers:
   packages/node:
     dependencies:
       '@powersync/common':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../common
       async-mutex:
         specifier: 'catalog:'
@@ -645,7 +645,7 @@ importers:
   packages/react-native:
     dependencies:
       '@powersync/common':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../common
       '@powersync/react':
         specifier: workspace:*
@@ -755,7 +755,7 @@ importers:
   packages/web:
     dependencies:
       '@powersync/common':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../common
       async-mutex:
         specifier: 'catalog:'
@@ -14983,7 +14983,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/template': 7.27.2
+      '@babel/template': 7.28.6
 
   '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.28.5)':
     dependencies:
@@ -15224,7 +15224,7 @@ snapshots:
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -15409,7 +15409,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       esutils: 2.0.3
 
   '@babel/preset-react@7.28.5(@babel/core@7.28.5)':
@@ -15443,9 +15443,9 @@ snapshots:
 
   '@babel/template@7.27.2':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
 
   '@babel/template@7.28.6':
     dependencies:
@@ -15455,12 +15455,12 @@ snapshots:
 
   '@babel/traverse@7.28.5':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.0
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -19657,9 +19657,7 @@ snapshots:
       metro-runtime: 0.83.3
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.81.5': {}
 
@@ -20229,7 +20227,7 @@ snapshots:
 
   '@svgr/hast-util-to-babel-ast@8.0.0':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       entities: 4.5.0
 
   '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
@@ -20558,8 +20556,8 @@ snapshots:
   '@tanstack/router-utils@1.143.11':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/generator': 7.29.0
+      '@babel/parser': 7.29.0
       ansis: 4.2.0
       diff: 8.0.3
       pathe: 2.0.3
@@ -21793,9 +21791,9 @@ snapshots:
   babel-dead-code-elimination@1.0.12:
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.0
       '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
# Overview

We've seen a few reports of mismatched `@powersync/common` packages in users' applications: 
- https://discord.com/channels/1138230179878154300/1466669956165795968/1467781283387277405
- https://discord.com/channels/1138230179878154300/1383533738415358136/1383533738415358136 

This causes cryptic TypeScript build errors of the form
```
// Your app re-exports or uses types from both packages.
import { PowerSyncDatabase, Schema as SchemaFromWeb } from '@powersync/web';
import { PowerSyncProvider } from '@powersync/react'; // internally uses Schema from its own @powersync/common@1.45.0

const schemaFromWeb: SchemaFromWeb = new SchemaFromWeb({ tables: [...] });
const db = new PowerSyncDatabase({ schema: schemaFromWeb }); // ✅ same package, same Schema class

// Later you pass the same db (or its schema) into React context.
<PowerSyncProvider db={db}> {/* ❌ TypeScript error: PowerSyncProvider expects db from "its" common. Even though both Schema classes have the same shape, they are different declarations (1.46.0 vs 1.45.0), so the types are not assignable. */}
</PowerSyncProvider>
```

While there are multiple factors which can contribute to these package mismatches - one of the primary factors is the upgrade/bumping of  `@powersync/*` NPM packages in an application. The method in which the package manager facilitates these upgrades, currently can easily result in multiple versions of `@powersync/common` being present in a project.

One path which results in issues is:
- Project depends on version `@powersync/web@1.0.1` (which depends on `@powersync/common@1.0.1`). Project also depends on `@powersync/react@1.1.1` which has a peerDependency range for `@powersync/common@^1.0.1`)
- Project upgrades to `@powersync/web@1.5.0` which depends on `@powersync/common@1.5.0`. The upgrade path does not bump the common dependency for `@powersync/react` which causes both `@powersync/common@1.5.0` and `@powersync/common@1.0.1` to be present in the project.
- Type differences in the `@powersync/common` package cause TypeScript build errors

The general desired behaviour is for `@powersync/web` to "provide" `@powersync/common`, where packages such as `@powersync/react` should use the version provided by `@powersync/web`.

The crux of the issue above is that: upgrading `@powersync/web` does not bump the `@powersync/common` version used by `@powersync/react`.

After some investigation, this erroneous behaviour seems to be caused by the current relationship of `@powersync/web` and `@powersync/common`. In https://github.com/powersync-ja/powersync-js/pull/179, `@powersync/common` was declared as a `peerDependency` of `@powersync/web`. I believe the reasoning was to allow for warning if the actual resolved version of `@powersync/common` was incompatible with the SDK... The `peerDependency` should provide warnings, while the direct `dependency` should actually dictate which version of `@powersync/common` was required.

However, declaring the `peerDependency` for `@powersync/common` seems to be root cause of the issues described above, where the `peerDependency` seems to cause bumps in `@powersync/web` not to bump `@powersync/common` - at least with PNPM `10.28.2`.

A video which demonstrates this behaviour is below

https://github.com/user-attachments/assets/456b74b7-18eb-48b9-be88-4110920301f4

When testing with local publishing, removing the `peerDependency` declarations for `@powersync/common` seems to fix the core issues.

The benefit of having `@powersync/common` as a `peerDependency` (in addition to a dependency) seems to be small - if not non-existent. The fact that `@powersync/web` has a direct dependency for `@powersync/common` should result in that peerDependency range always being specified, even if there are mulitiple packages which have direct dependencies for `@powersync/common`


Additional tests were performed to test various future scenarios:

If a user had an older version of `@powersync/react-native` (which still had peerDependency declarations) and only upgraded `@powersync/web` (which will no longer contain peerDependency declarations). The `@powersync/web` declaration will drive the version of `@powersync/common`

```bash
# Web has no peer, old RN has peer
❯ pnpm why @powersync/common
Legend: production dependency, optional only, dev only

versions@1.0.0 /private/tmp/versions

dependencies:
@powersync/drizzle-driver 0.7.2
└── @powersync/common 1.47.0 peer
@powersync/react-native 1.17.0
├── @powersync/common 1.47.0 peer
└─┬ @powersync/react 1.5.1
  └── @powersync/common 1.47.0 peer
@powersync/web 1.33.2
└── @powersync/common 1.47.0
```

If we (only) removed the `peerDependency` requirement for both `@powersync/react-native` and `@powersync/web`. Each package  would have a fixed dependency range for `@powersync/common` which could result in multiple versions of `@powersync/common` being present. 

```bash
# Both have no peer, RN relies on older version
❯ pnpm why @powersync/common
Legend: production dependency, optional only, dev only

versions@1.0.0 /private/tmp/versions

dependencies:
@powersync/drizzle-driver 0.7.2
└── @powersync/common 1.47.0 peer
@powersync/react-native 1.30.0
├── @powersync/common 1.46.0
└─┬ @powersync/react 1.8.2
  └── @powersync/common 1.46.0 peer
@powersync/web 1.33.3
└── @powersync/common 1.47.0
```

If we update the direct dependencies from

```diff
-     "@powersync/common": "workspace:*",
+    "@powersync/common": "workspace:^",
```

Then, updating only `@powersync/web` does not automatically bump `@powersync/common` for `@powersync/react-native`

```bash
❯ pnpm why @powersync/common
Legend: production dependency, optional only, dev only

versions@1.0.0 /private/tmp/versions

dependencies:
@powersync/drizzle-driver 0.7.2
└── @powersync/common 1.51.0 peer
@powersync/react-native 1.50.0
├── @powersync/common 1.47.0
└─┬ @powersync/react 1.8.2
  └── @powersync/common 1.47.0 peer
@powersync/web 1.51.0
└── @powersync/common 1.51.0
```

But, running `pnpm upgrade` will resolve both to a single version of `@powersync/common`

```
❯ pnpm why @powersync/common
Legend: production dependency, optional only, dev only

versions@1.0.0 /private/tmp/versions

dependencies:
@powersync/drizzle-driver 0.7.2
└── @powersync/common 1.51.0 peer
@powersync/react-native 1.50.0
├── @powersync/common 1.51.0
└─┬ @powersync/react 1.8.2
  └── @powersync/common 1.51.0 peer
@powersync/web 1.51.0
└── @powersync/common 1.51.0
```
