### PR TITLE
Return cached subscriptions in useSyncStream

### DIFF
--- a/.changeset/few-months-rest.md
+++ b/.changeset/few-months-rest.md
@@ -1,0 +1,5 @@
+---
+'@powersync/react': patch
+---
+
+Return cached information from `useSyncStream` if available, potentially reducing flicker.

--- a/packages/react/tests/streams.test.tsx
+++ b/packages/react/tests/streams.test.tsx
@@ -52,6 +52,18 @@ describe('stream hooks', () => {
         expect(currentStreams()).toStrictEqual([]);
       });
 
+      it('useSyncStream with cached instance', async () => {
+        const existingSubscription = await db.syncStream('a').subscribe();
+        await existingSubscription.unsubscribe();
+        // The stream is still active at this point due to the TTL.
+
+        // This means that useSyncStream should have a result available on the first render.
+        const { result } = renderHook(() => useSyncStream({ name: 'a' }), {
+          wrapper: testWrapper
+        });
+        expect(result.current).not.toBeNull();
+      });
+
       it('useQuery can take syncStream instance', async () => {
         const { result } = renderHook(() => useQuery('SELECT 1', [], { streams: [db.syncStream('a')] }), {
           wrapper: testWrapper


### PR DESCRIPTION
`useSyncStream` creates a subscription to a Sync Stream and then returns the current status of that instance as long as the hook is used.

Subscribing to a stream is necessarily asynchronous, as we might have to register it in the database to implement TTL behavior. `useSyncStream` used to return `null` before that initial promise resolved. This is the correct behavior when subscribing to fresh streams, and users are encouraged to show a loading indicator until the stream is resolved (and has synced).

But for streams that are already active, returning `null` on the initial render because we're waiting for a promise to resolve to a stream we already have is not great. @khawarizmus suggested introducing a cache, which reminded me that `SyncStatus.forStream` can do exactly that when passing a stream instead of a stream subscription. So, this small improvements makes `useSyncStream` report data right away if possible.