### PR TITLE
example-capacitor: Only sync for Android in test

### DIFF
--- a/demos/example-capacitor/package.json
+++ b/demos/example-capacitor/package.json
@@ -14,7 +14,7 @@
     "sync": "npx cap sync",
     "ios": "pnpm build && pnpm sync && npx cap run ios",
     "android": "pnpm build && pnpm sync && npx cap run android",
-    "test:build": "pnpm build && npx cap sync && npx cap build android",
+    "test:build": "pnpm build && npx cap sync android && npx cap build android",
     "start": "vite",
     "build": "vite build",
     "preview": "vite preview"


### PR DESCRIPTION
Looking at recent CI failures, it looks like `cap sync` is trying to invoke CocoaPods. That's not helpful for our CI running on Ubuntu, so this tries to only invoke it for Android in an attempt to fix that.