### PR TITLE
[Chore] Changed minor changeset entry to patch for `attachments-storage-react-native`

### DIFF
--- a/.changeset/new-attachments-react-native.md
+++ b/.changeset/new-attachments-react-native.md
@@ -1,5 +1,5 @@
 ---
-'@powersync/attachments-storage-react-native': minor
+'@powersync/attachments-storage-react-native': patch
 ---
 
 Added new @powersync/attachments-storage-react-native package providing LocalStorageAdapter implementations for React Native environments. Includes ExpoFileSystemStorageAdapter and ReactNativeFileSystemStorageAdapter for device-based attachment file storage.


### PR DESCRIPTION
I noticed that this package's entry in the `version release` PR was showing 0.1.0 while we started the package on the 0.0.x range in package.json. 