### PR TITLE
Fix Capacitor iOS binary SQLite param handling

### DIFF
--- a/.changeset/wobbly-octopi-juggle.md
+++ b/.changeset/wobbly-octopi-juggle.md
@@ -1,0 +1,5 @@
+---
+'@powersync/capacitor': patch
+---
+
+Normalize binary SQLite parameters for Capacitor iOS so `Uint8Array` sync payloads can be passed through `powersync_control(...)` without hitting `Error in reading buffer`.

--- a/packages/capacitor/src/adapter/CapacitorSQLiteAdapter.ts
+++ b/packages/capacitor/src/adapter/CapacitorSQLiteAdapter.ts
@@ -18,6 +18,7 @@ import {
 import { PowerSyncCore } from '../plugin/PowerSyncCore.js';
 import { messageForErrorCode } from '../plugin/PowerSyncPlugin.js';
 import { CapacitorSQLiteOpenFactoryOptions, DEFAULT_SQLITE_OPTIONS } from './CapacitorSQLiteOpenFactory.js';
+import { normalizeIOSSqliteParams } from './sqliteParams.js';
 /**
  * Monitors the execution time of a query and logs it to the performance timeline.
  */
@@ -39,6 +40,7 @@ class CapacitorConnectionPool extends BaseObserver<DBAdapterListener> implements
   protected initializedPromise: Promise<void>;
   protected writeMutex: Mutex;
   protected readMutex: Mutex;
+  protected readonly platform: string;
 
   constructor(protected options: CapacitorSQLiteOpenFactoryOptions) {
     super();
@@ -46,6 +48,7 @@ class CapacitorConnectionPool extends BaseObserver<DBAdapterListener> implements
     this._readConnection = null;
     this.writeMutex = new Mutex();
     this.readMutex = new Mutex();
+    this.platform = Capacitor.getPlatform();
     this.initializedPromise = this.init();
   }
 
@@ -98,8 +101,7 @@ class CapacitorConnectionPool extends BaseObserver<DBAdapterListener> implements
 
     await this._readConnection.open();
 
-    const platform = Capacitor.getPlatform();
-    if (platform == 'android') {
+    if (this.platform == 'android') {
       /**
        * SQLCipher for Android enables dynamic loading of extensions.
        * On iOS we use a static auto extension registration.
@@ -132,13 +134,11 @@ class CapacitorConnectionPool extends BaseObserver<DBAdapterListener> implements
     };
 
     const _execute = async (query: string, params: any[] = []): Promise<QueryResult> => {
-      const platform = Capacitor.getPlatform();
-
       if (db.getConnectionReadOnly()) {
         return _query(query, params);
       }
 
-      if (platform == 'android') {
+      if (this.platform == 'android') {
         // Android: use query for SELECT and executeSet for mutations
         // We cannot use `run` here for both cases.
         if (query.toLowerCase().trim().startsWith('select')) {
@@ -158,7 +158,8 @@ class CapacitorConnectionPool extends BaseObserver<DBAdapterListener> implements
       }
 
       // iOS (and other platforms): use run("all")
-      const result = await db.run(query, params, false, 'all');
+      const sqliteParams = this.platform == 'ios' ? normalizeIOSSqliteParams(params) : params;
+      const result = await db.run(query, sqliteParams, false, 'all');
       const resultSet = result.changes?.values ?? [];
       return {
         insertId: result.changes?.lastId,

--- a/packages/capacitor/src/adapter/sqliteParams.ts
+++ b/packages/capacitor/src/adapter/sqliteParams.ts
@@ -1,0 +1,33 @@
+export type IOSSqliteBufferParam = Record<string, number>;
+
+export type NormalizedIOSSqliteParam = unknown | IOSSqliteBufferParam;
+
+export function normalizeIOSSqliteParams(params: unknown[]): NormalizedIOSSqliteParam[] {
+  return params.map((param) => normalizeIOSSqliteParam(param));
+}
+
+function normalizeIOSSqliteParam(value: unknown): NormalizedIOSSqliteParam {
+  if (value instanceof Uint8Array) {
+    return uint8ArrayToIOSBuffer(value);
+  }
+
+  if (value instanceof ArrayBuffer) {
+    return uint8ArrayToIOSBuffer(new Uint8Array(value));
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    return uint8ArrayToIOSBuffer(new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
+  }
+
+  return value;
+}
+
+function uint8ArrayToIOSBuffer(array: Uint8Array): IOSSqliteBufferParam {
+  // The Capacitor SQLite iOS bridge expects BLOB params as an index-keyed object
+  // with integer values. It does not accept typed arrays directly.
+  const result: IOSSqliteBufferParam = {};
+  for (let i = 0; i < array.length; i++) {
+    result[String(i)] = array[i];
+  }
+  return result;
+}


### PR DESCRIPTION
Fixes #904.

On Capacitor iOS, PowerSync can pass `Uint8Array` payloads into:

```ts
tx.executeRaw('SELECT powersync_control(?, ?)', [op, payload])
```

The Capacitor SQLite iOS bridge doesn't seem to accept that shape directly, and sync fails with:

```text
Run: failed(message: "Error in reading buffer")
```

This normalizes typed-array payloads at the Capacitor/native SQLite boundary before they hit `run(...)`.

I think that keeps the fix in the right place and doesn't break anything unrelated. The sync layer can still use `Uint8Array`, and we only adapt it where the native bridge needs a different shape.

Not sure if a changeset makes sense here, but I think probably yes if this lands as a package fix.
