### PR TITLE
Run tauri publish action on macOS

### DIFF
--- a/.github/workflows/release-tauri-crate.yml
+++ b/.github/workflows/release-tauri-crate.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   publish_crates_io:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     permissions:
       id-token: write # Required for OIDC token exchange
     steps:


### PR DESCRIPTION
One minor additional fix 🤦 Compiling Tauri apps on Ubuntu runners requires a large number of extra dependencies, so we run Tauri tests on macOS. Publishing via cargo also builds the project, so we want to do that on macOS as well.