### PR TITLE
fix(web): replace unload event with pagehide for Chrome 146+ compatibility

### DIFF
--- a/packages/web/src/db/PowerSyncDatabase.ts
+++ b/packages/web/src/db/PowerSyncDatabase.ts
@@ -71,13 +71,13 @@ export interface WebEncryptionOptions {
 
 type WithWebEncryptionOptions<Base> = Base & WebEncryptionOptions;
 
-export type WebPowerSyncDatabaseOptionsWithAdapter = WithWebSyncOptions<
+export type WebPowerSyncDatabaseOptionsWithAdapter = WithWebSyncOptions
   WithWebFlags<PowerSyncDatabaseOptionsWithDBAdapter>
 >;
-export type WebPowerSyncDatabaseOptionsWithOpenFactory = WithWebSyncOptions<
+export type WebPowerSyncDatabaseOptionsWithOpenFactory = WithWebSyncOptions
   WithWebFlags<PowerSyncDatabaseOptionsWithOpenFactory>
 >;
-export type WebPowerSyncDatabaseOptionsWithSettings = WithWebSyncOptions<
+export type WebPowerSyncDatabaseOptionsWithSettings = WithWebSyncOptions
   WithWebFlags<WithWebEncryptionOptions<PowerSyncDatabaseOptionsWithSettings>>
 >;
 
@@ -143,7 +143,7 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
 
     if (this.resolvedFlags.enableMultiTabs && !this.resolvedFlags.externallyUnload) {
       this.unloadListener = () => this.close({ disconnect: false });
-      window.addEventListener('unload', this.unloadListener);
+      window.addEventListener('pagehide', this.unloadListener);
     }
   }
 
@@ -191,7 +191,7 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
    */
   close(options?: PowerSyncCloseOptions): Promise<void> {
     if (this.unloadListener) {
-      window.removeEventListener('unload', this.unloadListener);
+      window.removeEventListener('pagehide', this.unloadListener);
     }
     return super.close({
       // Don't disconnect by default if multiple tabs are enabled


### PR DESCRIPTION
Fixes #912

## Problem
Chrome 146+ is rolling out deprecation of the `unload` event, causing a Permissions Policy violation for all users with the default `enableMultiTabs: true` flag:

This affects 1% of page loads in Chrome 146, reaching 100% by Chrome 153 (September 2026).

## Fix
Replaced both `unload` references in `PowerSyncDatabase.ts` with `pagehide`, which is the recommended alternative per the [Chrome deprecation guide](https://developer.chrome.com/docs/web-platform/deprecating-unload).

## Changes
- `packages/web/src/db/PowerSyncDatabase.ts`
  - `window.addEventListener('unload', ...)` → `window.addEventListener('pagehide', ...)`
  - `window.removeEventListener('unload', ...)` → `window.removeEventListener('pagehide', ...)`