### PR TITLE
fix(web): remove unload event listener to fix Chrome 146+ deprecation

### DIFF
--- a/.changeset/grumpy-monkeys-laugh.md
+++ b/.changeset/grumpy-monkeys-laugh.md
@@ -1,0 +1,5 @@
+---
+'@powersync/web': patch
+---
+
+Remove deprecated `unload` listener.

--- a/packages/web/src/db/PowerSyncDatabase.ts
+++ b/packages/web/src/db/PowerSyncDatabase.ts
@@ -38,6 +38,7 @@ import { AsyncDbAdapter } from './adapters/AsyncWebAdapter.js';
 
 export interface WebPowerSyncFlags extends WebSQLFlags {
   /**
+   * @deprecated This flag is no longer used. Navigator locks now handle tab detection automatically.
    * Externally unload open PowerSync database instances when the window closes.
    * Setting this to `true` requires calling `close` on all open PowerSyncDatabase
    * instances before the window unloads

--- a/packages/web/src/db/PowerSyncDatabase.ts
+++ b/packages/web/src/db/PowerSyncDatabase.ts
@@ -72,13 +72,13 @@ export interface WebEncryptionOptions {
 
 type WithWebEncryptionOptions<Base> = Base & WebEncryptionOptions;
 
-export type WebPowerSyncDatabaseOptionsWithAdapter = WithWebSyncOptions
+export type WebPowerSyncDatabaseOptionsWithAdapter = WithWebSyncOptions<
   WithWebFlags<PowerSyncDatabaseOptionsWithDBAdapter>
 >;
-export type WebPowerSyncDatabaseOptionsWithOpenFactory = WithWebSyncOptions
+export type WebPowerSyncDatabaseOptionsWithOpenFactory = WithWebSyncOptions<
   WithWebFlags<PowerSyncDatabaseOptionsWithOpenFactory>
 >;
-export type WebPowerSyncDatabaseOptionsWithSettings = WithWebSyncOptions
+export type WebPowerSyncDatabaseOptionsWithSettings = WithWebSyncOptions<
   WithWebFlags<WithWebEncryptionOptions<PowerSyncDatabaseOptionsWithSettings>>
 >;
 

--- a/packages/web/src/db/PowerSyncDatabase.ts
+++ b/packages/web/src/db/PowerSyncDatabase.ts
@@ -71,13 +71,13 @@ export interface WebEncryptionOptions {
 
 type WithWebEncryptionOptions<Base> = Base & WebEncryptionOptions;
 
-export type WebPowerSyncDatabaseOptionsWithAdapter = WithWebSyncOptions<
+export type WebPowerSyncDatabaseOptionsWithAdapter = WithWebSyncOptions
   WithWebFlags<PowerSyncDatabaseOptionsWithDBAdapter>
 >;
-export type WebPowerSyncDatabaseOptionsWithOpenFactory = WithWebSyncOptions<
+export type WebPowerSyncDatabaseOptionsWithOpenFactory = WithWebSyncOptions
   WithWebFlags<PowerSyncDatabaseOptionsWithOpenFactory>
 >;
-export type WebPowerSyncDatabaseOptionsWithSettings = WithWebSyncOptions<
+export type WebPowerSyncDatabaseOptionsWithSettings = WithWebSyncOptions
   WithWebFlags<WithWebEncryptionOptions<PowerSyncDatabaseOptionsWithSettings>>
 >;
 
@@ -127,7 +127,6 @@ function assertValidDatabaseOptions(options: WebPowerSyncDatabaseOptions): void 
 export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
   static SHARED_MUTEX = new Mutex();
 
-  protected unloadListener?: () => Promise<void>;
   protected resolvedFlags: WebPowerSyncFlags;
 
   constructor(options: WebPowerSyncDatabaseOptionsWithAdapter);
@@ -140,11 +139,6 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
     assertValidDatabaseOptions(options);
 
     this.resolvedFlags = resolveWebPowerSyncFlags(options.flags);
-
-    if (this.resolvedFlags.enableMultiTabs && !this.resolvedFlags.externallyUnload) {
-      this.unloadListener = () => this.close({ disconnect: false });
-      window.addEventListener('unload', this.unloadListener);
-    }
   }
 
   async _initialize(): Promise<void> {
@@ -190,9 +184,6 @@ export class PowerSyncDatabase extends AbstractPowerSyncDatabase {
    * multiple tabs are not enabled.
    */
   close(options?: PowerSyncCloseOptions): Promise<void> {
-    if (this.unloadListener) {
-      window.removeEventListener('unload', this.unloadListener);
-    }
     return super.close({
       // Don't disconnect by default if multiple tabs are enabled
       disconnect: options?.disconnect ?? !this.resolvedFlags.enableMultiTabs


### PR DESCRIPTION
Fixes #912

Based on maintainer feedback in #912, the `unload` event listeners have been removed entirely rather than replaced with `pagehide`.

`pagehide` is not appropriate here because `close()` is a terminal action - if the tab is restored from bfcache, the database would remain closed.

Since navigator locks now reliably handle tab detection, the `unload` listeners are no longer needed.

Changes in `packages/web/src/db/PowerSyncDatabase.ts`:
- Removed `unloadListener` property
- Removed `window.addEventListener('unload', ...)` block from constructor
- Removed `window.removeEventListener('unload', ...)` block from `close()`