### PR TITLE
(fix): pass dbName instead of key to setSyncEnabled in getSyncEnabled…

### DIFF
--- a/demos/react-supabase-todolist-optional-sync/src/library/powersync/SyncMode.ts
+++ b/demos/react-supabase-todolist-optional-sync/src/library/powersync/SyncMode.ts
@@ -5,7 +5,7 @@ export function getSyncEnabled(dbName: string) {
   const value = localStorage.getItem(key);
 
   if (!value) {
-    setSyncEnabled(key, false);
+    setSyncEnabled(dbName, false);
     return false;
   }
 


### PR DESCRIPTION
## Bug

In `getSyncEnabled`, when no value exists in localStorage for the given key, the fallback call to `setSyncEnabled` incorrectly passes `key` (the already-prefixed string e.g. `syncEnabled-example.db`) instead of `dbName`. This causes `setSyncEnabled` to construct a double-prefixed key (`syncEnabled-syncEnabled-example.db`), creating a separate localStorage entry that is never read by `getSyncEnabled`.

## Fix

Pass `dbName` instead of `key` to `setSyncEnabled` in the fallback branch.

## Evidence

Two keys are created in localStorage instead of one when `getSyncEnabled` is called for the first time:

<img width="958" height="220" alt="image" src="https://github.com/user-attachments/assets/7a3b79e8-d960-4722-a08a-fd45f12b30d1" />

- `syncEnabled-example.db` (correct)
- `syncEnabled-syncEnabled-example.db` (erroneous duplicate)