### PR TITLE
Fix compilation errors in demos

### DIFF
--- a/demos/angular-supabase-todolist/src/app/supabase.service.ts
+++ b/demos/angular-supabase-todolist/src/app/supabase.service.ts
@@ -8,7 +8,13 @@ import {
   type User
 } from '@supabase/supabase-js';
 import { environment } from '../environment';
-import { type AbstractPowerSyncDatabase, type CrudEntry, UpdateType, PowerSyncBackendConnector, type PowerSyncCredentials } from '@powersync/web';
+import {
+  type AbstractPowerSyncDatabase,
+  type CrudEntry,
+  UpdateType,
+  PowerSyncBackendConnector,
+  type PowerSyncCredentials
+} from '@powersync/web';
 
 /// Postgres Response codes that we cannot recover from by retrying.
 const FATAL_RESPONSE_CODES = [
@@ -121,7 +127,7 @@ export class SupabaseService implements PowerSyncBackendConnector {
             result = await table.upsert(record);
             break;
           case UpdateType.PATCH:
-            result = await table.update(op.opData).eq('id', op.id);
+            result = await table.update(op.opData ?? {}).eq('id', op.id);
             break;
           case UpdateType.DELETE:
             result = await table.delete().eq('id', op.id);

--- a/demos/react-multi-client/src/library/SupabaseConnector.ts
+++ b/demos/react-multi-client/src/library/SupabaseConnector.ts
@@ -93,7 +93,7 @@ export class SupabaseConnector extends BaseObserver<SupabaseConnectorListener> i
             result = await table.upsert(record);
             break;
           case UpdateType.PATCH:
-            result = await table.update(op.opData).eq('id', op.id);
+            result = await table.update(op.opData ?? {}).eq('id', op.id);
             break;
           case UpdateType.DELETE:
             result = await table.delete().eq('id', op.id);


### PR DESCRIPTION
I suppose a Supabase update made the data parameter for `update()` non-nullable, but `op.opData` can be null. This adds a simple fallback to make TypeScript happy, in practice that value isn't going to be null for update CRUD entries.

This fixes the "Test isolated demos" CI.