### PR TITLE
Remove experimental tag from raw tables

### DIFF
--- a/.changeset/slimy-cups-wonder.md
+++ b/.changeset/slimy-cups-wonder.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Remove experimental label from raw tables.

--- a/packages/common/src/db/schema/RawTable.ts
+++ b/packages/common/src/db/schema/RawTable.ts
@@ -9,11 +9,6 @@ import { TableOrRawTableOptions } from './Table.js';
  * To collect local writes to raw tables with PowerSync, custom triggers are required. See
  * {@link https://docs.powersync.com/usage/use-case-examples/raw-tables the documentation} for details and an example on
  * using raw tables.
- *
- * Note that raw tables are only supported when using the new `SyncClientImplementation.rust` sync client.
- *
- * @experimental Please note that this feature is experimental at the moment, and not covered by PowerSync semver or
- * stability guarantees.
  */
 export type RawTableType = RawTableTypeWithStatements | InferredRawTableType;
 


### PR DESCRIPTION
Raw tables don't have an `@experimental` tag on Dart, Kotlin, or Swift. So we might as well remove the experimental tag here as well.

The note about raw tables only being supported with the new Rust client still applies, but since it's the default and there's an actionable error message if users try to use raw tables with the JS client, I think we don't need that note.