### PR TITLE
Diagnostics app: Support endpoint URL parameter

### DIFF
--- a/.changeset/eleven-pans-unite.md
+++ b/.changeset/eleven-pans-unite.md
@@ -1,0 +1,5 @@
+---
+'@powersync/diagnostics-app': patch
+---
+
+Support endpoint query parameter for deeplinks.

--- a/tools/diagnostics-app/src/routes/index.tsx
+++ b/tools/diagnostics-app/src/routes/index.tsx
@@ -13,7 +13,8 @@ import React from 'react';
 import { useInitError } from '@/components/providers/SystemProvider';
 
 const searchSchema = z.object({
-  token: z.string().optional()
+  token: z.string().optional(),
+  endpoint: z.string().optional()
 });
 
 type LoginFormValues = {
@@ -26,7 +27,7 @@ export const Route = createFileRoute('/')({
   beforeLoad: async ({ search }) => {
     // Handle deep-link auto-sign-in with ?token= query param
     if (search.token) {
-      const endpoint = getTokenEndpoint(search.token);
+      const endpoint = search.endpoint ?? getTokenEndpoint(search.token);
       if (!endpoint) {
         throw new Error('endpoint is required');
       }


### PR DESCRIPTION
Like all clients, the diagnostics app needs both an endpoint and a token to connect. For development tokens generated in the dashboard, we can derive the endpoint from the token alone. We also support a `token` URL parameter that the dashboard uses to deeplink into the diagnostics app.

For other tokens though, it would be helpful if we could encode the endpoint as a query parameter as well. For instance, this might allow tools provided by SDKs to open the diagnostics app with the same configuration currently used by an app.