### PR TITLE
fix: capacitor iOS Buffer read error

### DIFF
--- a/.changeset/rude-squids-unite.md
+++ b/.changeset/rude-squids-unite.md
@@ -1,0 +1,5 @@
+---
+'@powersync/capacitor': patch
+---
+
+Fixed "Error in reading buffer" error on iOS when connecting via WebSocket.

--- a/packages/capacitor/src/PowerSyncDatabase.ts
+++ b/packages/capacitor/src/PowerSyncDatabase.ts
@@ -1,5 +1,6 @@
 import { Capacitor } from '@capacitor/core';
 import {
+  BucketStorageAdapter,
   DBAdapter,
   MEMORY_TRIGGER_CLAIM_MANAGER,
   PowerSyncBackendConnector,
@@ -11,8 +12,8 @@ import {
   WebRemote
 } from '@powersync/web';
 import { CapacitorSQLiteAdapter } from './adapter/CapacitorSQLiteAdapter.js';
+import { CapacitorBucketStorageAdapter } from './sync/CapacitorBucketStorageAdapter.js';
 import { CapacitorStreamingSyncImplementation } from './sync/CapacitorSyncImplementation.js';
-
 /**
  * PowerSyncDatabase class for managing database connections and sync implementations.
  * This extends the WebPowerSyncDatabase to provide platform-specific implementations
@@ -66,6 +67,14 @@ export class PowerSyncDatabase extends WebPowerSyncDatabase {
     } else {
       // Use navigator.locks for web platform
       return super.runExclusive(cb);
+    }
+  }
+
+  protected generateBucketStorageAdapter(): BucketStorageAdapter {
+    if (this.isNativeCapacitorPlatform) {
+      return new CapacitorBucketStorageAdapter(this.database, this.logger);
+    } else {
+      return super.generateBucketStorageAdapter();
     }
   }
 

--- a/packages/capacitor/src/sync/CapacitorBucketStorageAdapter.ts
+++ b/packages/capacitor/src/sync/CapacitorBucketStorageAdapter.ts
@@ -1,0 +1,22 @@
+import { PowerSyncControlCommand, SqliteBucketStorage } from '@powersync/web';
+
+export class CapacitorBucketStorageAdapter extends SqliteBucketStorage {
+  control(op: PowerSyncControlCommand, payload: string | Uint8Array | ArrayBuffer | null): Promise<string> {
+    if (payload instanceof Uint8Array && (payload as any)['_isBuffer'] == true) {
+      /**
+       * The Buffer polyfill, used in @powersync/common, is a Uint8Array subclass which defines additional fields like
+       * `_isBuffer` on its `prototype`. The additional fields are serialized when passed through the native bridge.
+       * The Capacitor Community SQLite lib expects a dictionarty of indexes to numerical bytes.
+       * The additiona fields (which are not an index to numerical byte mapping) cause the parsing logic in the SQLite lib to throw an error:
+       *  "Error in reading buffer".
+       *
+       * Re-wrapping the same backing buffer as a plain Uint8Array removes the Buffer subclass wrapper
+       * while keeping the same underlying bytes. This creates a new view, not a byte copy, so the
+       * overhead should be minimal.
+       */
+      payload = new Uint8Array(payload.buffer, payload.byteOffset, payload.byteLength);
+    }
+
+    return super.control(op, payload);
+  }
+}

--- a/packages/capacitor/src/sync/CapacitorBucketStorageAdapter.ts
+++ b/packages/capacitor/src/sync/CapacitorBucketStorageAdapter.ts
@@ -5,7 +5,7 @@ export class CapacitorBucketStorageAdapter extends SqliteBucketStorage {
     if (payload instanceof Uint8Array && (payload as any)['_isBuffer'] == true) {
       /**
        * The Buffer polyfill, used in @powersync/common, is a Uint8Array subclass which defines additional fields like
-       * `_isBuffer` on its `prototype`. The additional fields are serialized when passed through the native bridge.
+       * `_isBuffer` and `parent` on its `prototype`. The additional fields are serialized when passed through the native bridge.
        * The Capacitor Community SQLite lib expects a dictionarty of indexes to numerical bytes.
        * The additiona fields (which are not an index to numerical byte mapping) cause the parsing logic in the SQLite lib to throw an error:
        *  "Error in reading buffer".


### PR DESCRIPTION
This is an alternative solution to the one provided in https://github.com/powersync-ja/powersync-js/pull/905.

# Overview

Users have reported errors of the form

```
Run: failed(message: "Error in reading buffer")
```

When using the PowerSync Capacitor SDK to connect to a PowerSync service.

# Background

The PowerSync SDK sync stream client sends binary payloads from the PowerSync service to the PowerSync Rust core by making SQL queries of the form

```sql
execute('SELECT powersync_control(?, ?)', ['line-binary', payload]))
```

The RSocket client we use to connect to the PowerSync service requires a polyfill for `Buffer` which is provided and bundled in the `@powersync/common` package. This results in the `payload` above being an instance of the polyfilled `Buffer`.

The Capacitor Community SQLite lib accepts buffer payloads as a dictionary mapping of numerical array indexes to numerical byte values.

```swift
/// Parameter parsing logic in the `run`/`execute` method.
                        } else if let obj = value as? [String: Any] {
                            if var keys = Array(obj.keys) as? [String] {
                                if #available(iOS 15.0, *) {
                                    keys.sort(using: .localizedStandard)
                                    var valuesArr: [UInt8] = []
                                    for key in keys {
                                        if let mVal = obj[key] {
                                            if let iVal = mVal as? Int {
                                                valuesArr.append(UInt8(iVal))
                                            } else {
                                                let msg: String = "Error in reading buffer"
                                                throw CapacitorSQLiteError.failed(message: msg)
                                            }
                                        } else {
                                            let msg: String = "Error in reading buffer"
                                            throw CapacitorSQLiteError.failed(message: msg)
                                        }
                                    }
                                    val.append(valuesArr)
                                } else {
                                    let msg: String = "Error buffer sorted not implemented"
                                    throw CapacitorSQLiteError.failed(message: msg)

                                }
                            }
```

The above parsing logic will fail with a `Error in reading buffer` error if either:
- a value associated with a key cannot be converted to an `Int` type
- a value associated with a key is nil

The `Buffer` polyfil in `@powersync/common` defines a few additional fields in it's implementation, which are passed through the native bridge to the Swift SQLite layer. These additional parameters don't meet the above parsing requirements, which cause the error above.

For example: in the polyfil, we see an `parent` member being declared.

```js
		Object.defineProperty(Buffer.prototype, 'parent', {
		  enumerable: true,
		  get: function () {
		    if (!Buffer.isBuffer(this)) return undefined
		    return this.buffer
		  }
		});
```

When debugging the Swift parsing logic, we can see this value propagates from JS to Swift

Notice the value for `key` is `parent` which has a value which could not be cast to a numerical `Int` value
<img width="764" height="842" alt="image" src="https://github.com/user-attachments/assets/64450820-848a-4bcf-aa66-9abf613b90ca" />

# The Fix

Only the `Buffer` polyfil contains these incompatible member values. We can create a `Uint8Array` view over the `Buffer` and pass that to the SQLite lib instead. This should have minimal overhead.

# Testing

For some reason, I have not been able to reproduce this issue previously... On the current `main` branch with an updated `capacitor` package from `7.4.x` to `7.6.x` I have been able to reproduce the issue. 

I've confirmed manually that the `example-capacitor` demo connects and syncs correctly to a PowerSync service after applying these changes.


