### PR TITLE
Fix `readTransaction` errors on node and op-sqlite drivers

### DIFF
--- a/.changeset/pink-elephants-repair.md
+++ b/.changeset/pink-elephants-repair.md
@@ -1,0 +1,7 @@
+---
+'@powersync/node': patch
+'@powersync/common': patch
+'@powersync/op-sqlite': patch
+---
+
+Fix `attempt to write a readonly database` error in `readTransaction`.

--- a/packages/common/src/db/DBAdapter.ts
+++ b/packages/common/src/db/DBAdapter.ts
@@ -69,7 +69,17 @@ export interface SqlExecutor {
   executeBatch: (query: string, params?: any[][]) => Promise<QueryResult>;
 }
 
-export interface LockContext extends SqlExecutor, DBGetUtils {}
+export interface LockContext extends SqlExecutor, DBGetUtils {
+  /**
+   * How the connection has been opened.
+   *
+   * `writer` indicates that the lock context is capable of writing to the database.
+   * `queryOnly` indicates that the lock context has been opened in a readwrite mode, but a `PRAGMA query_only = TRUE`
+   * disabled writes.
+   * `readOnly` indicates that the lock context has been opened by passing `SQLITE_OPEN_READONLY` to `sqlite3_open_v2`.
+   */
+  connectionType?: 'writer' | 'queryOnly' | 'readOnly';
+}
 
 /**
  * Implements {@link DBGetUtils} on a {@link SqlRunner}.
@@ -192,11 +202,11 @@ export interface DBAdapter extends ConnectionPool, SqlExecutor, DBGetUtils {
 export function DBAdapterDefaultMixin<TBase extends new (...args: any[]) => ConnectionPool>(Base: TBase) {
   return class extends Base implements DBAdapter {
     readTransaction<T>(fn: (tx: Transaction) => Promise<T>, options?: DBLockOptions): Promise<T> {
-      return this.readLock((ctx) => TransactionImplementation.runWith(ctx, fn), options);
+      return this.readLock((ctx) => TransactionImplementation.runWith(ctx, false, fn), options);
     }
 
     writeTransaction<T>(fn: (tx: Transaction) => Promise<T>, options?: DBLockOptions): Promise<T> {
-      return this.writeLock((ctx) => TransactionImplementation.runWith(ctx, fn), options);
+      return this.writeLock((ctx) => TransactionImplementation.runWith(ctx, true, fn), options);
     }
 
     getAll<T>(sql: string, parameters?: any[]): Promise<T[]> {
@@ -260,11 +270,19 @@ class BaseTransaction implements SqlExecutor {
 }
 
 class TransactionImplementation extends DBGetUtilsDefaultMixin(BaseTransaction) {
-  static async runWith<T>(ctx: LockContext, fn: (tx: Transaction) => Promise<T>): Promise<T> {
+  static async runWith<T>(ctx: LockContext, isWrite: boolean, fn: (tx: Transaction) => Promise<T>): Promise<T> {
     let tx = new TransactionImplementation(ctx);
 
+    // For write transactions, use BEGIN IMMEDIATE to immediately obtain a write lock on the database (instead of doing
+    // that on the first statement). If we have a genuine read-only connection, we also use BEGIN IMMEDIATE there: In
+    // WAL mode, that ensures we pin the current state of the database (instead of the state at the first statement in
+    // the transaction). But if we have a "fake" read-only connection implemented through `pragma query_only = true`, we
+    // can't use this trick because it would attempt to lock the connection. So there, we use a regular `BEGIN`
+    // statement.
+    const useBeginImmediate = isWrite || ctx.connectionType != 'queryOnly';
+
     try {
-      await ctx.execute('BEGIN IMMEDIATE');
+      await ctx.execute(useBeginImmediate ? 'BEGIN IMMEDIATE' : 'BEGIN');
 
       const result = await fn(tx);
       await tx.commit();

--- a/packages/common/src/db/DBAdapter.ts
+++ b/packages/common/src/db/DBAdapter.ts
@@ -202,11 +202,11 @@ export interface DBAdapter extends ConnectionPool, SqlExecutor, DBGetUtils {
 export function DBAdapterDefaultMixin<TBase extends new (...args: any[]) => ConnectionPool>(Base: TBase) {
   return class extends Base implements DBAdapter {
     readTransaction<T>(fn: (tx: Transaction) => Promise<T>, options?: DBLockOptions): Promise<T> {
-      return this.readLock((ctx) => TransactionImplementation.runWith(ctx, false, fn), options);
+      return this.readLock((ctx) => TransactionImplementation.runWith(ctx, fn), options);
     }
 
     writeTransaction<T>(fn: (tx: Transaction) => Promise<T>, options?: DBLockOptions): Promise<T> {
-      return this.writeLock((ctx) => TransactionImplementation.runWith(ctx, true, fn), options);
+      return this.writeLock((ctx) => TransactionImplementation.runWith(ctx, fn), options);
     }
 
     getAll<T>(sql: string, parameters?: any[]): Promise<T[]> {
@@ -270,7 +270,7 @@ class BaseTransaction implements SqlExecutor {
 }
 
 class TransactionImplementation extends DBGetUtilsDefaultMixin(BaseTransaction) {
-  static async runWith<T>(ctx: LockContext, isWrite: boolean, fn: (tx: Transaction) => Promise<T>): Promise<T> {
+  static async runWith<T>(ctx: LockContext, fn: (tx: Transaction) => Promise<T>): Promise<T> {
     let tx = new TransactionImplementation(ctx);
 
     // For write transactions, use BEGIN IMMEDIATE to immediately obtain a write lock on the database (instead of doing
@@ -279,7 +279,7 @@ class TransactionImplementation extends DBGetUtilsDefaultMixin(BaseTransaction) 
     // the transaction). But if we have a "fake" read-only connection implemented through `pragma query_only = true`, we
     // can't use this trick because it would attempt to lock the connection. So there, we use a regular `BEGIN`
     // statement.
-    const useBeginImmediate = isWrite || ctx.connectionType != 'queryOnly';
+    const useBeginImmediate = ctx.connectionType != 'queryOnly';
 
     try {
       await ctx.execute(useBeginImmediate ? 'BEGIN IMMEDIATE' : 'BEGIN');

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -74,6 +74,7 @@
     "@powersync/drizzle-driver": "workspace:*",
     "@types/node": "catalog:",
     "better-sqlite3": "^12.2.0",
+    "@types/better-sqlite3": "^7.6.13",
     "bson": "catalog:",
     "drizzle-orm": "catalog:",
     "js-logger": "catalog:",

--- a/packages/node/src/db/BetterSqliteWorker.ts
+++ b/packages/node/src/db/BetterSqliteWorker.ts
@@ -64,7 +64,7 @@ class BlockingAsyncDatabase implements AsyncDatabase {
 
 export async function openDatabase(worker: PowerSyncWorkerOptions, options: AsyncDatabaseOpenOptions) {
   const BetterSQLite3Database = await worker.loadBetterSqlite3();
-  const baseDB = new BetterSQLite3Database(options.path);
+  const baseDB = new BetterSQLite3Database(options.path, { readonly: !options.isWriter });
   baseDB.loadExtension(worker.extensionPath(), 'sqlite3_powersync_init');
 
   const asyncDb = new BlockingAsyncDatabase(baseDB);

--- a/packages/node/src/db/NodeSqliteWorker.ts
+++ b/packages/node/src/db/NodeSqliteWorker.ts
@@ -56,7 +56,7 @@ export async function openDatabase(worker: PowerSyncWorkerOptions, options: Asyn
   // end, since that would make us incompatible with older Node.JS versions.
   const { DatabaseSync } = await dynamicImport('node:sqlite');
 
-  const baseDB = new DatabaseSync(options.path, { allowExtension: true });
+  const baseDB = new DatabaseSync(options.path, { allowExtension: true, readOnly: !options.isWriter });
   baseDB.loadExtension(worker.extensionPath(), 'sqlite3_powersync_init');
 
   return new BlockingNodeDatabase(baseDB, options.isWriter);

--- a/packages/node/src/db/RemoteConnection.ts
+++ b/packages/node/src/db/RemoteConnection.ts
@@ -19,7 +19,12 @@ class BaseRemoteConnection implements SqlExecutor {
 
   private readonly notifyWorkerClosed = new AbortController();
 
-  constructor(worker: Worker, comlink: Remote<AsyncDatabaseOpener>, database: Remote<AsyncDatabase>) {
+  constructor(
+    worker: Worker,
+    comlink: Remote<AsyncDatabaseOpener>,
+    database: Remote<AsyncDatabase>,
+    private readonly readonly: boolean
+  ) {
     this.worker = worker;
     this.comlink = comlink;
     this.database = database;
@@ -27,6 +32,10 @@ class BaseRemoteConnection implements SqlExecutor {
     this.worker.once('exit', (_) => {
       this.notifyWorkerClosed.abort();
     });
+  }
+
+  public get connectionType() {
+    return this.readonly ? 'readOnly' : 'writer';
   }
 
   /**

--- a/packages/node/src/db/WorkerConnectionPool.ts
+++ b/packages/node/src/db/WorkerConnectionPool.ts
@@ -130,13 +130,11 @@ export class WorkerConnectionPool extends BaseObserver<DBAdapterListener> implem
         await database.execute("SELECT powersync_update_hooks('install');", []);
       }
 
-      const connection = new RemoteConnection(worker, comlink, database);
+      const connection = new RemoteConnection(worker, comlink, database, !isWriter);
       if (this.options.initializeConnection) {
         await this.options.initializeConnection(connection, isWriter);
       }
-      if (!isWriter) {
-        await connection.execute('pragma query_only = true');
-      } else {
+      if (isWriter) {
         // We only need to enable this on the writer connection.
         // We can get `database is locked` errors if we enable this on concurrently opening read connections.
         await connection.execute('pragma journal_mode = WAL');

--- a/packages/node/tests/PowerSyncDatabase.test.ts
+++ b/packages/node/tests/PowerSyncDatabase.test.ts
@@ -252,3 +252,25 @@ databaseTest('execute batch', async ({ database }) => {
   await database.executeBatch('INSERT INTO users (id, name) VALUES (uuid(), ?)', [['a'], ['b'], ['c']]);
   expect(await database.getAll('SELECT * FROM users')).toHaveLength(3);
 });
+
+databaseTest('read transaction', async ({ database }) => {
+  await database.execute('INSERT INTO lists (id, name) VALUES (uuid(), ?)', ['before tx']);
+
+  let completeHasRead: () => void, completeDidWrite: () => void;
+  const hasReadTx = new Promise<void>((resolve) => (completeHasRead = resolve));
+  const didWrite = new Promise<void>((resolve) => (completeDidWrite = resolve));
+
+  const listsInReadTx = database.readTransaction(async (tx) => {
+    completeHasRead();
+    await didWrite;
+
+    // Because this transaction was started before the write, we shouldn't see it in here.
+    return await tx.getAll<{ name: string }>('SELECT name FROM lists');
+  });
+
+  await hasReadTx;
+  await database.execute('INSERT INTO lists (id, name) VALUES (uuid(), ?)', ['after tx']);
+  completeDidWrite!();
+
+  expect(await listsInReadTx).toEqual([{ name: 'before tx' }]);
+});

--- a/packages/powersync-op-sqlite/src/db/OPSQLiteConnection.ts
+++ b/packages/powersync-op-sqlite/src/db/OPSQLiteConnection.ts
@@ -13,6 +13,7 @@ import {
 
 export type OPSQLiteConnectionOptions = {
   baseDB: DB;
+  readonly: boolean;
 };
 
 export type OPSQLiteUpdateNotification = {
@@ -116,6 +117,10 @@ class OPSQLiteExecutor extends BaseObserver<DBAdapterListener> implements Omit<S
 }
 
 export class OPSQLiteConnection extends DBGetUtilsDefaultMixin(OPSQLiteExecutor) implements LockContext {
+  get connectionType() {
+    return this.options.readonly ? 'queryOnly' : 'writer';
+  }
+
   async refreshSchema() {
     await this.get("PRAGMA table_info('sqlite_master')");
   }

--- a/packages/powersync-op-sqlite/src/db/OPSqliteAdapter.ts
+++ b/packages/powersync-op-sqlite/src/db/OPSqliteAdapter.ts
@@ -51,7 +51,7 @@ class OPSQLiteConnectionPool extends BaseObserver<DBAdapterListener> implements 
       this.options.sqliteOptions!;
     const dbFilename = this.options.name;
 
-    const underlyingWriteConnection = await this.openConnection(dbFilename);
+    const underlyingWriteConnection = await this.openConnection(false, dbFilename);
 
     const baseStatements = [
       `PRAGMA busy_timeout = ${lockTimeoutMs}`,
@@ -90,7 +90,7 @@ class OPSQLiteConnectionPool extends BaseObserver<DBAdapterListener> implements 
 
     const underlyingReadConnections = [];
     for (let i = 0; i < READ_CONNECTIONS; i++) {
-      const conn = await this.openConnection(dbFilename);
+      const conn = await this.openConnection(true, dbFilename);
       for (let statement of readConnectionStatements) {
         await conn.execute(statement);
       }
@@ -101,7 +101,7 @@ class OPSQLiteConnectionPool extends BaseObserver<DBAdapterListener> implements 
     this.readConnections = new Semaphore(underlyingReadConnections);
   }
 
-  protected async openConnection(filenameOverride?: string): Promise<OPSQLiteConnection> {
+  protected async openConnection(readonly: boolean, filenameOverride?: string): Promise<OPSQLiteConnection> {
     const dbFilename = filenameOverride ?? this.options.name;
     const DB: DB = this.openDatabase(dbFilename, this.options.sqliteOptions?.encryptionKey ?? undefined);
 
@@ -112,7 +112,8 @@ class OPSQLiteConnectionPool extends BaseObserver<DBAdapterListener> implements 
     await DB.execute('SELECT powersync_init()');
 
     return new OPSQLiteConnection({
-      baseDB: DB
+      baseDB: DB,
+      readonly
     });
   }
 

--- a/packages/web/tests/main.test.ts
+++ b/packages/web/tests/main.test.ts
@@ -83,5 +83,14 @@ function describeBasicTests(generateDB: () => PowerSyncDatabase) {
       expect(result[1].name).equals('Steven');
       expect(result[2].name).equals('Chris');
     });
+
+    it('can use readTransaction', async () => {
+      const db = generateDB();
+      await db.execute('INSERT INTO customers (id, name) VALUES (uuid(), ?)', ['name']);
+      const names = await db.readTransaction(async (tx) => {
+        return await tx.getAll<{ name: string }>('SELECT name FROM customers');
+      });
+      expect(names).deep.equal([{ name: 'name' }]);
+    });
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,7 +470,7 @@ importers:
         version: 24.10.13
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)
+        version: 0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)
       rollup:
         specifier: 'catalog:'
         version: 4.59.0
@@ -533,6 +533,9 @@ importers:
       '@powersync/drizzle-driver':
         specifier: workspace:*
         version: link:../drizzle-driver
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.13
@@ -544,7 +547,7 @@ importers:
         version: 6.10.4
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)
+        version: 0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)
       js-logger:
         specifier: 'catalog:'
         version: 1.6.1
@@ -571,7 +574,7 @@ importers:
         version: 3.2.3(magicast@0.5.2)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       '@nuxt/devtools-ui-kit':
         specifier: 'catalog:'
-        version: 3.2.3(@nuxt/devtools@3.2.3(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3)))(@unocss/webpack@66.6.6(webpack@5.105.2(esbuild@0.27.3)))(@vue/compiler-core@3.5.30)(fuse.js@7.1.0)(magicast@0.5.2)(nprogress@0.2.0)(nuxt@4.3.1(f18fc977ac0a9ba52c22934e423a6488))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))(webpack@5.105.2(esbuild@0.27.3))
+        version: 3.2.3(@nuxt/devtools@3.2.3(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3)))(@unocss/webpack@66.6.6(webpack@5.105.2(esbuild@0.27.3)))(@vue/compiler-core@3.5.30)(fuse.js@7.1.0)(magicast@0.5.2)(nprogress@0.2.0)(nuxt@4.3.1(6219f9d0e4ae7499343c542e5dad8fb8))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))(webpack@5.105.2(esbuild@0.27.3))
       '@nuxt/kit':
         specifier: ^4.3.1
         version: 4.3.1(magicast@0.5.2)
@@ -583,7 +586,7 @@ importers:
         version: 14.2.1(vue@3.5.30(typescript@5.9.3))
       '@vueuse/nuxt':
         specifier: ^14.2.1
-        version: 14.2.1(magicast@0.5.2)(nuxt@4.3.1(f18fc977ac0a9ba52c22934e423a6488))(vue@3.5.30(typescript@5.9.3))
+        version: 14.2.1(magicast@0.5.2)(nuxt@4.3.1(6219f9d0e4ae7499343c542e5dad8fb8))(vue@3.5.30(typescript@5.9.3))
       bson:
         specifier: 'catalog:'
         version: 6.10.4
@@ -607,7 +610,7 @@ importers:
         version: 66.6.6(@unocss/webpack@66.6.6(webpack@5.105.2(esbuild@0.27.3)))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))
       unstorage:
         specifier: ^1.17.4
-        version: 1.17.4(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)))(ioredis@5.10.0)
+        version: 1.17.4(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)))(ioredis@5.10.0)
     devDependencies:
       '@journeyapps/wa-sqlite':
         specifier: ^1.7.0
@@ -638,7 +641,7 @@ importers:
         version: 4.4.2
       nuxt:
         specifier: ^4.3.1
-        version: 4.3.1(f18fc977ac0a9ba52c22934e423a6488)
+        version: 4.3.1(6219f9d0e4ae7499343c542e5dad8fb8)
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.5.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@24.1.3)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2)
@@ -717,7 +720,7 @@ importers:
         version: 4.5.1
       drizzle-orm:
         specifier: 'catalog:'
-        version: 0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@18.3.1)(react@18.3.1))(react@18.3.1))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)
+        version: 0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@18.3.1)(react@18.3.1))(react@18.3.1))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)
       jsdom:
         specifier: 'catalog:'
         version: 24.1.3
@@ -6850,6 +6853,9 @@ packages:
 
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -20838,7 +20844,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.5.0
+      '@types/node': 22.19.15
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -20856,7 +20862,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 25.5.0
+      '@types/node': 22.19.15
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -21331,7 +21337,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/devtools-ui-kit@3.2.3(@nuxt/devtools@3.2.3(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3)))(@unocss/webpack@66.6.6(webpack@5.105.2(esbuild@0.27.3)))(@vue/compiler-core@3.5.30)(fuse.js@7.1.0)(magicast@0.5.2)(nprogress@0.2.0)(nuxt@4.3.1(f18fc977ac0a9ba52c22934e423a6488))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))(webpack@5.105.2(esbuild@0.27.3))':
+  '@nuxt/devtools-ui-kit@3.2.3(@nuxt/devtools@3.2.3(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3)))(@unocss/webpack@66.6.6(webpack@5.105.2(esbuild@0.27.3)))(@vue/compiler-core@3.5.30)(fuse.js@7.1.0)(magicast@0.5.2)(nprogress@0.2.0)(nuxt@4.3.1(6219f9d0e4ae7499343c542e5dad8fb8))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))(webpack@5.105.2(esbuild@0.27.3))':
     dependencies:
       '@iconify-json/carbon': 1.2.19
       '@iconify-json/logos': 1.2.10
@@ -21348,7 +21354,7 @@ snapshots:
       '@unocss/reset': 66.6.6
       '@vueuse/core': 14.2.1(vue@3.5.30(typescript@5.9.3))
       '@vueuse/integrations': 14.2.1(focus-trap@8.0.0)(fuse.js@7.1.0)(nprogress@0.2.0)(vue@3.5.30(typescript@5.9.3))
-      '@vueuse/nuxt': 14.2.1(magicast@0.5.2)(nuxt@4.3.1(f18fc977ac0a9ba52c22934e423a6488))(vue@3.5.30(typescript@5.9.3))
+      '@vueuse/nuxt': 14.2.1(magicast@0.5.2)(nuxt@4.3.1(6219f9d0e4ae7499343c542e5dad8fb8))(vue@3.5.30(typescript@5.9.3))
       defu: 6.1.4
       focus-trap: 8.0.0
       splitpanes: 4.0.4(vue@3.5.30(typescript@5.9.3))
@@ -21502,7 +21508,7 @@ snapshots:
       - vue
       - vue-tsc
 
-  '@nuxt/nitro-server@4.3.1(better-sqlite3@12.6.2)(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)))(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0))(encoding@0.1.13)(ioredis@5.10.0)(magicast@0.5.2)(nuxt@4.3.1(f18fc977ac0a9ba52c22934e423a6488))(typescript@5.9.3)':
+  '@nuxt/nitro-server@4.3.1(better-sqlite3@12.6.2)(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)))(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0))(encoding@0.1.13)(ioredis@5.10.0)(magicast@0.5.2)(nuxt@4.3.1(6219f9d0e4ae7499343c542e5dad8fb8))(typescript@5.9.3)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.3.1(magicast@0.5.2)
@@ -21519,8 +21525,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.1(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0))(encoding@0.1.13)
-      nuxt: 4.3.1(f18fc977ac0a9ba52c22934e423a6488)
+      nitropack: 2.13.1(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0))(encoding@0.1.13)
+      nuxt: 4.3.1(6219f9d0e4ae7499343c542e5dad8fb8)
       ohash: 2.0.11
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -21528,7 +21534,7 @@ snapshots:
       std-env: 3.10.0
       ufo: 1.6.3
       unctx: 2.5.0
-      unstorage: 1.17.4(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)))(ioredis@5.10.0)
+      unstorage: 1.17.4(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)))(ioredis@5.10.0)
       vue: 3.5.30(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
@@ -21626,7 +21632,7 @@ snapshots:
       - typescript
       - vite
 
-  '@nuxt/vite-builder@4.3.1(@types/node@25.5.0)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.3.1(f18fc977ac0a9ba52c22934e423a6488))(optionator@0.9.4)(rollup@4.59.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)':
+  '@nuxt/vite-builder@4.3.1(@types/node@25.5.0)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.3.1(6219f9d0e4ae7499343c542e5dad8fb8))(optionator@0.9.4)(rollup@4.59.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)':
     dependencies:
       '@nuxt/kit': 4.3.1(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
@@ -21645,7 +21651,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.1
       mocked-exports: 0.1.1
-      nuxt: 4.3.1(f18fc977ac0a9ba52c22934e423a6488)
+      nuxt: 4.3.1(6219f9d0e4ae7499343c542e5dad8fb8)
       pathe: 2.0.3
       pkg-types: 2.3.0
       postcss: 8.5.8
@@ -25109,14 +25115,18 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 22.19.15
+
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
 
   '@types/bonjour@3.5.13':
     dependencies:
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
 
   '@types/chai-as-promised@8.0.2':
     dependencies:
@@ -25132,11 +25142,11 @@ snapshots:
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
       '@types/express-serve-static-core': 4.19.8
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
 
   '@types/debug@4.1.12':
     dependencies:
@@ -25168,7 +25178,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -25182,7 +25192,7 @@ snapshots:
 
   '@types/fs-extra@8.1.5':
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.15
 
   '@types/graceful-fs@4.1.9':
     dependencies:
@@ -25209,7 +25219,7 @@ snapshots:
 
   '@types/http-proxy@1.17.17':
     dependencies:
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
 
   '@types/inquirer@8.2.12':
     dependencies:
@@ -25272,6 +25282,7 @@ snapshots:
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
+    optional: true
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -25323,18 +25334,18 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
 
   '@types/semver@7.7.1': {}
 
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
 
   '@types/serve-index@1.9.4':
     dependencies:
@@ -25343,7 +25354,7 @@ snapshots:
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
       '@types/send': 0.17.6
 
   '@types/sinonjs__fake-timers@8.1.5':
@@ -25353,7 +25364,7 @@ snapshots:
 
   '@types/sockjs@0.3.36':
     dependencies:
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
 
   '@types/sql.js@1.4.9':
     dependencies:
@@ -25362,13 +25373,13 @@ snapshots:
 
   '@types/ssri@7.1.5':
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 22.19.15
 
   '@types/stack-utils@2.0.3': {}
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 24.10.13
+      '@types/node': 22.19.15
 
   '@types/triple-beam@1.3.5': {}
 
@@ -25389,7 +25400,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -26260,13 +26271,13 @@ snapshots:
 
   '@vueuse/metadata@14.2.1': {}
 
-  '@vueuse/nuxt@14.2.1(magicast@0.5.2)(nuxt@4.3.1(f18fc977ac0a9ba52c22934e423a6488))(vue@3.5.30(typescript@5.9.3))':
+  '@vueuse/nuxt@14.2.1(magicast@0.5.2)(nuxt@4.3.1(6219f9d0e4ae7499343c542e5dad8fb8))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
       '@nuxt/kit': 4.3.1(magicast@0.5.2)
       '@vueuse/core': 14.2.1(vue@3.5.30(typescript@5.9.3))
       '@vueuse/metadata': 14.2.1
       local-pkg: 1.1.2
-      nuxt: 4.3.1(f18fc977ac0a9ba52c22934e423a6488)
+      nuxt: 4.3.1(6219f9d0e4ae7499343c542e5dad8fb8)
       vue: 3.5.30(typescript@5.9.3)
     transitivePeerDependencies:
       - magicast
@@ -27532,7 +27543,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.15
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -27543,7 +27554,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.15
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -28211,10 +28222,10 @@ snapshots:
 
   dayjs@1.11.20: {}
 
-  db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)):
+  db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)):
     optionalDependencies:
       better-sqlite3: 12.6.2
-      drizzle-orm: 0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)
+      drizzle-orm: 0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)
 
   debounce@1.2.1: {}
 
@@ -28530,17 +28541,19 @@ snapshots:
 
   dotenv@17.3.1: {}
 
-  drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@18.3.1)(react@18.3.1))(react@18.3.1))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0):
+  drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@18.3.1)(react@18.3.1))(react@18.3.1))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0):
     optionalDependencies:
       '@op-engineering/op-sqlite': 15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@18.3.1)(react@18.3.1))(react@18.3.1)
+      '@types/better-sqlite3': 7.6.13
       '@types/sql.js': 1.4.9
       better-sqlite3: 12.6.2
       kysely: 0.28.11
       sql.js: 1.14.0
 
-  drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0):
+  drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0):
     optionalDependencies:
       '@op-engineering/op-sqlite': 15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
+      '@types/better-sqlite3': 7.6.13
       '@types/sql.js': 1.4.9
       better-sqlite3: 12.6.2
       kysely: 0.28.11
@@ -29168,7 +29181,7 @@ snapshots:
 
   eval@0.1.8:
     dependencies:
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
       require-like: 0.1.2
 
   event-iterator@2.0.0: {}
@@ -31027,7 +31040,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.5.0
+      '@types/node': 22.19.15
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -31076,7 +31089,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.5.0
+      '@types/node': 22.19.15
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -31213,13 +31226,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.15
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.19.33
+      '@types/node': 22.19.15
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -33187,7 +33200,7 @@ snapshots:
 
   next-path@1.0.0: {}
 
-  nitropack@2.13.1(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0))(encoding@0.1.13):
+  nitropack@2.13.1(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0))(encoding@0.1.13):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.59.0)
@@ -33208,7 +33221,7 @@ snapshots:
       cookie-es: 2.0.0
       croner: 9.1.0
       crossws: 0.3.5
-      db0: 0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0))
+      db0: 0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0))
       defu: 6.1.4
       destr: 2.0.5
       dot-prop: 10.1.0
@@ -33254,7 +33267,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 5.7.0
       unplugin-utils: 0.3.1
-      unstorage: 1.17.4(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)))(ioredis@5.10.0)
+      unstorage: 1.17.4(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)))(ioredis@5.10.0)
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.0
@@ -33438,16 +33451,16 @@ snapshots:
 
   nullthrows@1.1.1: {}
 
-  nuxt@4.3.1(f18fc977ac0a9ba52c22934e423a6488):
+  nuxt@4.3.1(6219f9d0e4ae7499343c542e5dad8fb8):
     dependencies:
       '@dxup/nuxt': 0.3.2(magicast@0.5.2)
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.3.1)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2)
       '@nuxt/devtools': 3.2.3(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3))
       '@nuxt/kit': 4.3.1(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.3.1(better-sqlite3@12.6.2)(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)))(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0))(encoding@0.1.13)(ioredis@5.10.0)(magicast@0.5.2)(nuxt@4.3.1(f18fc977ac0a9ba52c22934e423a6488))(typescript@5.9.3)
+      '@nuxt/nitro-server': 4.3.1(better-sqlite3@12.6.2)(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)))(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0))(encoding@0.1.13)(ioredis@5.10.0)(magicast@0.5.2)(nuxt@4.3.1(6219f9d0e4ae7499343c542e5dad8fb8))(typescript@5.9.3)
       '@nuxt/schema': 4.3.1
       '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.3.1(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.3.1(@types/node@25.5.0)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.3.1(f18fc977ac0a9ba52c22934e423a6488))(optionator@0.9.4)(rollup@4.59.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)
+      '@nuxt/vite-builder': 4.3.1(@types/node@25.5.0)(lightningcss@1.32.0)(magicast@0.5.2)(nuxt@4.3.1(6219f9d0e4ae7499343c542e5dad8fb8))(optionator@0.9.4)(rollup@4.59.0)(terser@5.46.1)(tsx@4.21.0)(typescript@5.9.3)(vue-tsc@3.2.5(typescript@5.9.3))(vue@3.5.30(typescript@5.9.3))(yaml@2.8.2)
       '@unhead/vue': 2.1.12(vue@3.5.30(typescript@5.9.3))
       '@vue/shared': 3.5.30
       c12: 3.3.3(magicast@0.5.2)
@@ -37370,7 +37383,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@7.18.2: {}
+  undici-types@7.18.2:
+    optional: true
 
   undici@5.29.0:
     dependencies:
@@ -37552,7 +37566,7 @@ snapshots:
       picomatch: 4.0.3
       webpack-virtual-modules: 0.6.2
 
-  unstorage@1.17.4(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)))(ioredis@5.10.0):
+  unstorage@1.17.4(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0)))(ioredis@5.10.0):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -37563,7 +37577,7 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.3
     optionalDependencies:
-      db0: 0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0))
+      db0: 0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@op-engineering/op-sqlite@15.2.7(react-native@0.84.1(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4))(@types/better-sqlite3@7.6.13)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(kysely@0.28.11)(sql.js@1.14.0))
       ioredis: 5.10.0
 
   untildify@4.0.0: {}

--- a/tools/powersynctests/src/tests/queries.test.ts
+++ b/tools/powersynctests/src/tests/queries.test.ts
@@ -685,6 +685,14 @@ export function registerBaseTests() {
       await Promise.all(promises);
     });
 
+    it('readTransaction', async () => {
+      await db.execute('INSERT INTO users (id, name) VALUES (uuid(), ?)', ['name']);
+      const names = await db.readTransaction(async (tx) => {
+        return await tx.getAll<{name: string}>('SELECT name FROM users');
+      });
+      expect(names).deep.equal([{name: 'name'}]);
+    });
+
     it('Should handle multiple closes', async () => {
       // Bulk insert 10000 rows without using a transaction
       const bulkInsertCommands = [];
@@ -721,12 +729,6 @@ export function registerBaseTests() {
       }
     });
 
-    it('readTransaction', async () => {
-      await db.execute('INSERT INTO users (id, name) VALUES (uuid(), ?)', ['name']);
-      const names = await db.readTransaction(async (tx) => {
-        return await tx.getAll<{name: string}>('SELECT name FROM users');
-      });
-      expect(names).deep.equal([{name: 'name'}]);
-    });
+    
   });
 }

--- a/tools/powersynctests/src/tests/queries.test.ts
+++ b/tools/powersynctests/src/tests/queries.test.ts
@@ -728,7 +728,5 @@ export function registerBaseTests() {
         expect(results.map((r) => r.status)).deep.equal(['fulfilled', 'rejected', 'rejected', 'rejected']);
       }
     });
-
-    
   });
 }

--- a/tools/powersynctests/src/tests/queries.test.ts
+++ b/tools/powersynctests/src/tests/queries.test.ts
@@ -720,5 +720,13 @@ export function registerBaseTests() {
         expect(results.map((r) => r.status)).deep.equal(['fulfilled', 'rejected', 'rejected', 'rejected']);
       }
     });
+
+    it('readTransaction', async () => {
+      await db.execute('INSERT INTO users (id, name) VALUES (uuid(), ?)', ['name']);
+      const names = await db.readTransaction(async (tx) => {
+        return await tx.getAll<{name: string}>('SELECT name FROM users');
+      });
+      expect(names).deep.equal([{name: 'name'}]);
+    });
   });
 }


### PR DESCRIPTION
Currently, we run a `BEGIN IMMEDIATE` statement to start transactions (both readonly and readwrite). Technically, we're not really supposed to use `BEGIN IMMEDIATE` for readonly transactions since that statement is documented as taking a write lock, but for readonly connections in WAL mode it's still very convenient because there it uses the current state of the database as a snapshot. This has benefits over a regular `BEGIN` because writes between the start of the readonly transaction and its first statement would not be seen (ensuring the entire `readTransaction` block forms a logical transaction).

If we use readwrite connections with `pragma query_only = TRUE` however, attempting to use `BEGIN IMMEDIATE` throws and we shouldn't do it. So, this PR:

1. Changes the Node SDK to use readonly connections instead of the `pragma query_only` workaround.
2. Changes the common package to avoid `BEGIN IMMEDIATE` for connections using the `pragma query_only = TRUE` workaround (which is the case for op-sqlite which can't open actual readonly connections).
3. Adds tests for both behaviors to the node, op-sqlite and web pacakges.