### PR TITLE
Make `js-logger` a regular dependency

### DIFF
--- a/.changeset/hungry-cycles-clean.md
+++ b/.changeset/hungry-cycles-clean.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Make `js-logger` a regular dependency to avoid type issues.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -59,7 +59,8 @@
     "test:exports": "attw --pack . --exclude-entrypoints internal/sync_protocol"
   },
   "dependencies": {
-    "event-iterator": "^2.0.0"
+    "event-iterator": "^2.0.0",
+    "js-logger": "catalog:"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "catalog:",
@@ -71,7 +72,6 @@
     "buffer": "^6.0.3",
     "cross-fetch": "^4.1.0",
     "estree-walker": "^3.0.3",
-    "js-logger": "catalog:",
     "magic-string": "^0.30.21",
     "rollup": "catalog:",
     "rollup-plugin-dts": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -394,6 +394,9 @@ importers:
       event-iterator:
         specifier: ^2.0.0
         version: 2.0.0
+      js-logger:
+        specifier: 'catalog:'
+        version: 1.6.1
     devDependencies:
       '@rollup/plugin-commonjs':
         specifier: 'catalog:'
@@ -422,9 +425,6 @@ importers:
       estree-walker:
         specifier: ^3.0.3
         version: 3.0.3
-      js-logger:
-        specifier: 'catalog:'
-        version: 1.6.1
       magic-string:
         specifier: ^0.30.21
         version: 0.30.21
@@ -16726,6 +16726,7 @@ packages:
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:


### PR DESCRIPTION
`@powersync/common` bundles `js-logger`, but the package can't be a dev dependency because the public `createBaseLogger()` function is declared to return a type from that package, in `common/index.d.cts`:

```TypeScript
import Logger, { ILogger, ILogLevel } from 'js-logger';
export { GlobalLogger, ILogHandler, ILogLevel, ILogger, ILoggerOpts } from 'js-logger';

// ...

declare function createBaseLogger(): typeof Logger;
declare function createLogger(name: string, options?: /* ... */): ILogger;
```

So if users call that method, their TypeScript compiler wouldn't be able to resolve `typeof Logger` and `ILogger` if `js-logger` is nowhere to be found. Making this a regular dependency avoids the issue.

Closes https://github.com/powersync-ja/powersync-js/issues/939.