### PR TITLE
Add unregister token for stream finalization registry

### DIFF
--- a/.changeset/cuddly-bobcats-hang.md
+++ b/.changeset/cuddly-bobcats-hang.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Fix warnings about leaked subscriptions even though `unsubscribe()` was called.

--- a/packages/common/src/client/ConnectionManager.ts
+++ b/packages/common/src/client/ConnectionManager.ts
@@ -368,7 +368,7 @@ class SyncStreamSubscriptionHandle implements SyncStreamSubscription {
 
   constructor(readonly subscription: ActiveSubscription) {
     subscription.refcount++;
-    _finalizer?.register(this, subscription);
+    _finalizer?.register(this, subscription, this);
   }
 
   get name() {


### PR DESCRIPTION
The parameter to `FinalizationRegistry.unregister` is not the object itself but rather a token used to unregister it. We didn't set such token in `register`, making the `unregister` call a noop. This fixes that by using the object itself as an unregister token.

Unfortunately this can't really be tested automatically since finalization callbacks don't run deterministically. This doesn't affect any critical behavior, it just removes a warning message.

Closes https://github.com/powersync-ja/powersync-js/issues/944.