### PR TITLE
Fix background sync gate to wait for sync from current run

### DIFF
--- a/demos/react-native-supabase-background-sync/library/utils.ts
+++ b/demos/react-native-supabase-background-sync/library/utils.ts
@@ -22,19 +22,29 @@ TaskManager.defineTask(BACKGROUND_SYNC_TASK, async () => {
 
     console.log("[Background Task] Initializing PowerSync");
 
+    // Capture the previous lastSyncedAt BEFORE init so we can detect a sync that
+    // completes during this background task run. `lastSyncedAt` is process-scoped
+    // (not listener-scoped) and persists across `system.init()` calls within the
+    // same JS runtime, so on a warm start it will already be set from a prior
+    // foreground session - gating on `Boolean(status.lastSyncedAt)` alone would
+    // resolve immediately without waiting for this run's sync.
+    const previousSyncAt = system.powersync.currentStatus.lastSyncedAt;
+
     await system.init();
 
-    // Wait for first sync to complete to download any new data
+    // Wait for a sync to complete during THIS background task run
     await new Promise<void>((resolve) => {
-      console.log("[Background Task] Waiting for first sync to complete");
+      console.log("[Background Task] Waiting for sync to complete");
       const unregister = system.powersync.registerListener({
         statusChanged: (status) => {
-          const hasSynced = Boolean(status.lastSyncedAt);
+          const syncedThisRun =
+            Boolean(status.lastSyncedAt) &&
+            previousSyncAt?.getTime() !== status.lastSyncedAt?.getTime();
           const downloading = status.dataFlowStatus?.downloading || false;
           const uploading = status.dataFlowStatus?.uploading || false;
 
-          // Resolve when all operations have been downloaded and pending transactions have been uploaded
-          if (hasSynced && !downloading && !uploading) {
+          // Resolve when a fresh sync has completed and no transfers are in flight
+          if (syncedThisRun && !downloading && !uploading) {
             console.log(
               "[Background Task] Download complete"
             );


### PR DESCRIPTION
## Problem

The background task gates on `Boolean(status.lastSyncedAt)` to decide when sync has finished. `lastSyncedAt` is process-scoped, not listener-scoped, and it isn't reset by `system.init()`. On a warm background
wake (JS runtime still alive from a prior foreground session), `lastSyncedAt` is
already populated, so the very first idle `statusChanged` callback passes the gate
and the task resolves without actually waiting for this run's sync.

A customer hit this and patched it on their side. I confirmed the diagnosis by
reading the SDK source and reproducing the warm-start path on Android.

## Fix

Capture `lastSyncedAt` once before `system.init()`, then only resolve when the
status reports a `lastSyncedAt` that differs from that baseline. This means the
gate is "a sync completed during this task run" rather than "any sync has ever
completed in this process".

- Warm start: `previousSyncAt` is defined at task entry, intermediate callbacks
  show `downloading=true` with the stale timestamp, and the gate only opens once
  `lastSyncedAt` advances to a new value.
- Cold start: `previousSyncAt` is undefined, the first sync defines it, gate opens
  on the first idle callback. No regression.
