### PR TITLE
chore: React Supabase Todolist connector minor typing fix

### DIFF
--- a/demos/react-supabase-todolist/src/library/powersync/SupabaseConnector.ts
+++ b/demos/react-supabase-todolist/src/library/powersync/SupabaseConnector.ts
@@ -124,7 +124,7 @@ export class SupabaseConnector extends BaseObserver<SupabaseConnectorListener> i
             result = await table.upsert(record);
             break;
           case UpdateType.PATCH:
-            result = await table.update(op.opData).eq('id', op.id);
+            result = await table.update(op.opData ?? {}).eq('id', op.id);
             break;
           case UpdateType.DELETE:
             result = await table.delete().eq('id', op.id);


### PR DESCRIPTION
I just saw this type issue while spinning up a local demo.
<img width="1354" height="176" alt="image" src="https://github.com/user-attachments/assets/b4da1c08-989a-47b2-857e-c33be169b280" />

It has only become an issue on a recent `ps/web` or `ps/react` version. The change I made here is already on some of the other JS demos.