### PR TITLE
fix(tauri): accept integer SQLite params over WKWebView IPC

### DIFF
--- a/packages/tauri/src/commands.rs
+++ b/packages/tauri/src/commands.rs
@@ -138,11 +138,32 @@ impl<'de> Deserialize<'de> for SqliteValue {
                 Ok(SqliteValue::Integer(v))
             }
 
+            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                // Wrapping cast (v as i64) would silently corrupt values > i64::MAX.
+                i64::try_from(v)
+                    .map(SqliteValue::Integer)
+                    .map_err(E::custom)
+            }
+
             fn visit_f64<E>(self, v: f64) -> std::result::Result<Self::Value, E>
             where
                 E: Error,
             {
-                Ok(SqliteValue::Real(v))
+                // WKWebView (macOS Tauri) serializes all JS numbers as f64 over IPC.
+                // Whole-number floats (LIMIT 1 → 1.0, is_default = 1 → 1.0, etc.)
+                // must be bound as INTEGER so SQLite accepts them in LIMIT/OFFSET
+                // and other integer-typed positions. Real floats are passed through.
+                //
+                // Use < (not <=) on the upper bound: i64::MAX as f64 rounds up to
+                // i64::MAX + 1, so <= would allow an overflow on the v as i64 cast.
+                if v.fract() == 0.0 && v >= i64::MIN as f64 && v < i64::MAX as f64 {
+                    Ok(SqliteValue::Integer(v as i64))
+                } else {
+                    Ok(SqliteValue::Real(v))
+                }
             }
 
             fn visit_str<E>(self, v: &str) -> std::result::Result<Self::Value, E>


### PR DESCRIPTION
## Problem

On macOS, WKWebView serializes **all** JavaScript numbers as `f64` over the Tauri IPC bridge. This means integer values passed as SQL parameters (e.g. `LIMIT 1`, `OFFSET 0`, boolean-as-integer `is_default = 1`) arrive in Rust as `f64` (`1.0`, `0.0`, etc.).

The `SqliteValue` deserializer's `Visitor` only implemented `visit_f64`, which unconditionally mapped every number to `SqliteValue::Real`. SQLite then rejected these values wherever an `INTEGER` type was expected — most visibly in `LIMIT` and `OFFSET` clauses, causing queries to fail on macOS Tauri builds while working fine on other platforms.

## Fix

Two changes to the `Visitor<'de>` impl in `packages/tauri/src/commands.rs`:

1. **Add `visit_u64`** — handles the case where serde deserializes an unsigned integer (e.g. row counts). Uses `i64::try_from` to avoid silent wrapping for values above `i64::MAX`.

2. **Promote whole-number `f64` to `Integer` in `visit_f64`** — if `v.fract() == 0.0` and `v` fits within `i64` range, bind it as `SqliteValue::Integer` instead of `SqliteValue::Real`. True floating-point values (non-zero fractional part or out of `i64` range) continue to be bound as `Real`.

The upper-bound check uses `<` (not `<=`) because `i64::MAX as f64` rounds up by one ULP, so `<= i64::MAX as f64` would allow an overflow on the subsequent `v as i64` cast.

## Testing

Tested on macOS Sonoma + Tauri 2.x. Queries with `LIMIT`/`OFFSET` parameters and boolean integer columns now execute correctly through WKWebView IPC.