### PR TITLE
fix(tauri): sanitize db path for Tauri event-name validation

### DIFF
--- a/packages/tauri/guest-js/database.ts
+++ b/packages/tauri/guest-js/database.ts
@@ -164,9 +164,18 @@ export class PowerSyncTauriDatabase extends AbstractPowerSyncDatabase {
     this.updateSyncStatusFromRust(status);
   }
 
+  /**
+   * Replaces chars outside `[a-zA-Z0-9\-/:_]` with `_` to satisfy Tauri's
+   * event-name restrictions. Must mirror `sanitize_event_name` in database.rs.
+   */
+  private sanitizeEventKey(key: string): string {
+    return key.replace(/[^a-zA-Z0-9\-/:_]/g, '_');
+  }
+
   async _initialize(): Promise<void> {
     const path = await this.resolvePath();
-    this.tableUpdateListener = await listen<string[]>(`table-updates:${path}`, (event) => {
+    const eventKey = this.sanitizeEventKey(path);
+    this.tableUpdateListener = await listen<string[]>(`table-updates:${eventKey}`, (event) => {
       const adapter = this.database;
       if (adapter instanceof RustDatabaseAdapter) {
         adapter.iterateListeners((l) =>
@@ -174,7 +183,7 @@ export class PowerSyncTauriDatabase extends AbstractPowerSyncDatabase {
         );
       }
     });
-    this.syncStatusListener = await listen<SyncStatusOptions>(`sync-status:${path}`, (event) => {
+    this.syncStatusListener = await listen<SyncStatusOptions>(`sync-status:${eventKey}`, (event) => {
       this.updateSyncStatusFromRust(event.payload);
     });
 

--- a/packages/tauri/src/database.rs
+++ b/packages/tauri/src/database.rs
@@ -7,6 +7,21 @@ use tauri::{AppHandle, Emitter, Runtime};
 use tokio::task::JoinHandle;
 use tokio_stream::StreamExt;
 
+/// Replaces characters that Tauri's event system disallows (anything outside
+/// `[a-zA-Z0-9\-/:_]`) with `_`. Must mirror the JS `sanitizeEventKey` helper
+/// so both sides produce identical event names.
+fn sanitize_event_name(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '/' | ':' | '_') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
 pub struct TauriDatabaseState {
     pub database: PowerSyncDatabase,
     forward_updates: JoinHandle<()>,
@@ -15,10 +30,11 @@ pub struct TauriDatabaseState {
 
 impl TauriDatabaseState {
     pub fn new<R: Runtime>(handle: AppHandle<R>, name: &str, source: PowerSyncDatabase) -> Self {
+        let sanitized = sanitize_event_name(name);
         let forward_updates = {
             let handle = handle.clone();
             let db = source.clone();
-            let event_key = format!("table-updates:{}", name);
+            let event_key = format!("table-updates:{}", sanitized);
 
             tokio::spawn(async move {
                 let mut stream = db.watch_all_updates();
@@ -32,7 +48,7 @@ impl TauriDatabaseState {
         };
         let forward_sync_status = {
             let db = source.clone();
-            let event_key = format!("sync-status:{}", name);
+            let event_key = format!("sync-status:{}", sanitized);
 
             tokio::spawn(async move {
                 let mut stream = db.watch_status();


### PR DESCRIPTION
## Problem

Tauri validates event names against the pattern `[a-zA-Z0-9\-/:_]`. The Tauri SDK uses the resolved database file path as the event-name key (e.g. `table-updates:/Library/Application Support/com.barvaz.lacaja-ai/tenant.db`). A typical macOS app data path contains **dots** (`.db` extension, bundle ID components) and **spaces** (e.g. `Application Support`) — both characters are rejected by Tauri's event system, causing:

```
Error: Event name must include only alphanumeric characters, '-', '/', ':' and '_'.
```

This breaks any app that:
- uses a `dbFilename` with a `.db` extension, **or**
- resolves `dbLocationAsync` to a directory that contains spaces or dots (which is the case for the standard macOS app-data directories).

The result is that table-update and sync-status listeners are never registered, so the database appears frozen from JavaScript's perspective.

## Fix

Add a `sanitize_event_name` helper in **`packages/tauri/src/database.rs`** and a mirrored `sanitizeEventKey` private method in **`packages/tauri/guest-js/database.ts`**. Both replace every character outside `[a-zA-Z0-9\-/:_]` with `_`.

Both sides use the same sanitization rule, so the Rust emitter and the JavaScript listener always produce identical event-name keys — the mapping is purely cosmetic and does not affect routing.

**`packages/tauri/src/database.rs`** — new helper + usage:

```rust
fn sanitize_event_name(name: &str) -> String {
    name.chars()
        .map(|c| {
            if c.is_ascii_alphanumeric() || matches!(c, '-' | '/' | ':' | '_') {
                c
            } else {
                '_'
            }
        })
        .collect()
}

// In TauriDatabaseState::new:
let sanitized = sanitize_event_name(name);
let event_key = format!("table-updates:{}", sanitized);
// ...
let event_key = format!("sync-status:{}", sanitized);
```

**`packages/tauri/guest-js/database.ts`** — mirrored helper + usage:

```typescript
private sanitizeEventKey(key: string): string {
  return key.replace(/[^a-zA-Z0-9\-/:_]/g, '_');
}

// In _initialize():
const eventKey = this.sanitizeEventKey(path);
this.tableUpdateListener = await listen<string[]>(`table-updates:${eventKey}`, ...);
this.syncStatusListener = await listen<SyncStatusOptions>(`sync-status:${eventKey}`, ...);
```

cc @simolus3 (author of the Tauri SDK, PR #902)