### PR TITLE
Tauri: Use numeric event identifiers for databases

### DIFF
--- a/.changeset/smooth-lobsters-cross.md
+++ b/.changeset/smooth-lobsters-cross.md
@@ -1,0 +1,6 @@
+---
+'tauri-plugin-powersync': patch
+'@powersync/tauri-plugin': patch
+---
+
+Fix PowerSync using invalid tauri event names.

--- a/packages/tauri/guest-js/command.ts
+++ b/packages/tauri/guest-js/command.ts
@@ -57,7 +57,13 @@ export interface ExecuteBatchResult {
   changes: number;
 }
 
+export interface CreatedDatabase {
+  handle: number;
+  event_key: number;
+}
+
 export type CommandResult =
+  | { CreatedDatabase: CreatedDatabase }
   | { CreatedHandle: number }
   | { ExecuteSqlResult: ExecuteSqlResult }
   | { ExecuteBatchResult: ExecuteBatchResult }

--- a/packages/tauri/guest-js/database.ts
+++ b/packages/tauri/guest-js/database.ts
@@ -13,7 +13,7 @@ import {
   SyncStreamSubscription
 } from '@powersync/common';
 import { LateHandle, RustDatabaseAdapter } from './pool';
-import { powersyncCommand } from './command';
+import { CreatedDatabase, powersyncCommand } from './command';
 import { listen, UnlistenFn } from '@tauri-apps/api/event';
 import { join } from '@tauri-apps/api/path';
 
@@ -166,18 +166,6 @@ export class PowerSyncTauriDatabase extends AbstractPowerSyncDatabase {
 
   async _initialize(): Promise<void> {
     const path = await this.resolvePath();
-    this.tableUpdateListener = await listen<string[]>(`table-updates:${path}`, (event) => {
-      const adapter = this.database;
-      if (adapter instanceof RustDatabaseAdapter) {
-        adapter.iterateListeners((l) =>
-          l.tablesUpdated?.({ tables: event.payload, rawUpdates: [], groupedUpdates: {} })
-        );
-      }
-    });
-    this.syncStatusListener = await listen<SyncStatusOptions>(`sync-status:${path}`, (event) => {
-      this.updateSyncStatusFromRust(event.payload);
-    });
-
     const result = await powersyncCommand({
       OpenDatabase: {
         name: path,
@@ -185,7 +173,20 @@ export class PowerSyncTauriDatabase extends AbstractPowerSyncDatabase {
       }
     });
 
-    this.handle.handle = (result as any).CreatedHandle as number;
+    const { handle, event_key } = (result as any).CreatedDatabase as CreatedDatabase;
+    this.tableUpdateListener = await listen<string[]>(`table-updates:${event_key}`, (event) => {
+      const adapter = this.database;
+      if (adapter instanceof RustDatabaseAdapter) {
+        adapter.iterateListeners((l) =>
+          l.tablesUpdated?.({ tables: event.payload, rawUpdates: [], groupedUpdates: {} })
+        );
+      }
+    });
+    this.syncStatusListener = await listen<SyncStatusOptions>(`sync-status:${event_key}`, (event) => {
+      this.updateSyncStatusFromRust(event.payload);
+    });
+
+    this.handle.handle = handle;
     if (this.database instanceof RustDatabaseAdapter) {
       this.database.name = path;
     }

--- a/packages/tauri/src/commands.rs
+++ b/packages/tauri/src/commands.rs
@@ -249,6 +249,10 @@ pub struct SubscribeToStream {
 
 #[derive(Serialize)]
 pub enum CommandResult {
+    CreatedDatabase {
+        handle: Handle,
+        event_key: i32,
+    },
     CreatedHandle(Handle),
     ExecuteSqlResult(ExecuteSqlResult),
     ExecuteBatchResult {
@@ -273,7 +277,11 @@ pub(crate) async fn powersync<R: Runtime>(
                 SchemaOrCustom::from(open.schema.as_ref()),
             )?;
 
-            CommandResult::CreatedHandle(powersync.handles.put(SharedWithJavaScript::Database(db)))
+            let event_key = db.event_key;
+            CommandResult::CreatedDatabase {
+                handle: powersync.handles.put(SharedWithJavaScript::Database(db)),
+                event_key,
+            }
         }
         Command::CloseHandle(handle) => {
             powersync.handles.delete(handle)?;

--- a/packages/tauri/src/database.rs
+++ b/packages/tauri/src/database.rs
@@ -9,16 +9,21 @@ use tokio_stream::StreamExt;
 
 pub struct TauriDatabaseState {
     pub database: PowerSyncDatabase,
+    pub event_key: i32,
     forward_updates: JoinHandle<()>,
     forward_sync_status: JoinHandle<()>,
 }
 
 impl TauriDatabaseState {
-    pub fn new<R: Runtime>(handle: AppHandle<R>, name: &str, source: PowerSyncDatabase) -> Self {
+    pub fn new<R: Runtime>(
+        handle: AppHandle<R>,
+        event_key: i32,
+        source: PowerSyncDatabase,
+    ) -> Self {
         let forward_updates = {
             let handle = handle.clone();
             let db = source.clone();
-            let event_key = format!("table-updates:{}", name);
+            let event_key = format!("table-updates:{}", event_key);
 
             tokio::spawn(async move {
                 let mut stream = db.watch_all_updates();
@@ -32,7 +37,7 @@ impl TauriDatabaseState {
         };
         let forward_sync_status = {
             let db = source.clone();
-            let event_key = format!("sync-status:{}", name);
+            let event_key = format!("sync-status:{}", event_key);
 
             tokio::spawn(async move {
                 let mut stream = db.watch_status();
@@ -46,6 +51,7 @@ impl TauriDatabaseState {
 
         Self {
             database: source,
+            event_key,
             forward_updates,
             forward_sync_status,
         }

--- a/packages/tauri/src/lib.rs
+++ b/packages/tauri/src/lib.rs
@@ -4,6 +4,7 @@ use powersync::{env::PowerSyncEnvironment, ConnectionPool, PowerSyncDatabase};
 use rusqlite::Connection;
 use std::collections::hash_map::Entry;
 use std::marker::PhantomData;
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Weak};
 use std::{collections::HashMap, sync::Mutex};
 use tauri::{
@@ -35,6 +36,7 @@ impl<R: Runtime, T: Manager<R>> PowerSyncExt<R> for T {
 pub struct PowerSync<R: Runtime> {
     app: PhantomData<AppHandle<R>>,
     databases: Mutex<HashMap<String, Weak<TauriDatabaseState>>>,
+    event_id_counter: AtomicI32,
     pub(crate) handles: JavaScriptHandles,
 }
 
@@ -72,7 +74,8 @@ impl<R: Runtime> PowerSync<R> {
         let database = PowerSyncDatabase::new(env, schema);
         database.async_tasks().spawn_with_tokio();
 
-        let db = Arc::new(TauriDatabaseState::new(app, name, database));
+        let event_id = self.event_id_counter.fetch_add(1, Ordering::SeqCst);
+        let db = Arc::new(TauriDatabaseState::new(app, event_id, database));
         entry.insert_entry(Arc::downgrade(&db));
 
         Ok(db)
@@ -95,6 +98,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
                 app: PhantomData::<AppHandle<R>>,
                 databases: Default::default(),
                 handles: Default::default(),
+                event_id_counter: Default::default(),
             };
             app.manage(powersync);
             Ok(())


### PR DESCRIPTION
As @msvargas pointed out in https://github.com/powersync-ja/powersync-js/pull/956, Tauri doesn't allow arbitrary characters in event names.

Currently, we encode the path of databases into event keys to allow JavaScript clients to listen to changed tables and the sync status. This was mostly me being lazy, using opaque identifiers for databases to generate events is probably a better approach than relying on paths (even when mangled). So, this has Rust assign an incrementing integer to created databases which is then used for events. We inform JavaScript about the id when a database is opened, allowing it to register event listeners.

This is covered by existing tests (`stream subscriptions` and `watch smoke test`).