### PR TITLE
Tauri: Fix binding integer values, emit events on main thread

### DIFF
--- a/.changeset/lovely-needles-beam.md
+++ b/.changeset/lovely-needles-beam.md
@@ -1,0 +1,5 @@
+---
+'tauri-plugin-powersync': patch
+---
+
+Dispatch events on the main thread.

--- a/.changeset/plenty-carrots-breathe.md
+++ b/.changeset/plenty-carrots-breathe.md
@@ -1,0 +1,6 @@
+---
+'tauri-plugin-powersync': patch
+'@powersync/tauri-plugin': patch
+---
+
+Fix integer values being bound as doubles to prepared statements.

--- a/packages/tauri/src/commands.rs
+++ b/packages/tauri/src/commands.rs
@@ -138,6 +138,16 @@ impl<'de> Deserialize<'de> for SqliteValue {
                 Ok(SqliteValue::Integer(v))
             }
 
+            fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                // Wrapping cast (v as i64) would silently corrupt values > i64::MAX.
+                i64::try_from(v)
+                    .map(SqliteValue::Integer)
+                    .map_err(E::custom)
+            }
+
             fn visit_f64<E>(self, v: f64) -> std::result::Result<Self::Value, E>
             where
                 E: Error,

--- a/packages/tauri/src/database.rs
+++ b/packages/tauri/src/database.rs
@@ -23,15 +23,22 @@ impl TauriDatabaseState {
         let forward_updates = {
             let handle = handle.clone();
             let db = source.clone();
-            let event_key = format!("table-updates:{}", event_key);
+            let event_key = Arc::new(format!("table-updates:{}", event_key));
 
             tokio::spawn(async move {
                 let mut stream = db.watch_all_updates();
 
                 while let Some(update) = stream.next().await {
+                    let cloned_handle = handle.clone();
+                    let event_key = event_key.clone();
+
                     handle
-                        .emit(&event_key, &update)
-                        .expect("should emit table update");
+                        .run_on_main_thread(move || {
+                            cloned_handle
+                                .emit(&event_key, &update)
+                                .expect("should emit table update")
+                        })
+                        .expect("should run on main thread");
                 }
             })
         };
@@ -42,9 +49,16 @@ impl TauriDatabaseState {
             tokio::spawn(async move {
                 let mut stream = db.watch_status();
                 while let Some(status) = stream.next().await {
+                    let cloned_handle = handle.clone();
+                    let event_key = event_key.clone();
+
                     handle
-                        .emit(&event_key, SerializableSyncStatus(status))
-                        .expect("should emit sync status change");
+                        .run_on_main_thread(move || {
+                            cloned_handle
+                                .emit(&event_key, SerializableSyncStatus(status))
+                                .expect("should emit sync status change")
+                        })
+                        .expect("should run on main thread");
                 }
             })
         };

--- a/packages/tauri/tests/integration.test.ts
+++ b/packages/tauri/tests/integration.test.ts
@@ -92,3 +92,17 @@ test('can close instances', async () => {
   const second = openDatabase({ schema });
   expect(await second.getAll('SELECT * FROM users')).toHaveLength(0);
 });
+
+test('can bind integers', async () => {
+  const db = openDatabase({ schema });
+  await db.init();
+
+  await db.execute('INSERT INTO users (id, name) VALUES (uuid(), ?)', ['first']);
+  await db.execute('INSERT INTO users (id, name) VALUES (uuid(), ?)', ['second']);
+
+  const { name } = await db.get<{ name: string }>('SELECT name FROM users ORDER BY name LIMIT ?', [1]);
+  expect(name).toStrictEqual('first');
+
+  const row = await db.get<{ a: string; b: string }>('SELECT typeof(?) as a, typeof(?) as b', [123, 1.23]);
+  expect(row).toStrictEqual({ a: 'integer', b: 'real' });
+});


### PR DESCRIPTION
This fixes two issues with the Tauri SDK:

1. Emitting events from an async Tokio task could lead to deadlocks inside of Tauri, emitting them from the main thread seems to improve things (https://github.com/powersync-ja/powersync-js/issues/962).
2. Non-negative integers are parsed as `u64` values by `serde_json`, which we didn't pick up correctly (fix originally contributed in https://github.com/powersync-ja/powersync-js/pull/955, added here so that we can ideally release this today).
