### PR TITLE
fix: use text response path for React Native fetches

### DIFF
--- a/.changeset/fresh-phones-fix.md
+++ b/.changeset/fresh-phones-fix.md
@@ -1,0 +1,5 @@
+---
+'@powersync/react-native': patch
+---
+
+Force React Native remote HTTP requests onto the text response path so RN 0.85 does not drop non-streaming response bodies.

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -18,6 +18,7 @@
     "build": "tsc -b && rollup -c rollup.config.mjs",
     "build:prod": "tsc -b && rollup -c rollup.config.mjs",
     "clean": "rm -rf lib dist tsconfig.tsbuildinfo",
+    "test": "vitest --config vitest.config.ts",
     "watch": "tsc -b -w",
     "test:exports": "attw --pack ."
   },

--- a/packages/react-native/src/sync/stream/ReactNativeRemote.ts
+++ b/packages/react-native/src/sync/stream/ReactNativeRemote.ts
@@ -15,6 +15,10 @@ import { fetch } from 'react-native-fetch-api';
 
 export const STREAMING_POST_TIMEOUT_MS = 30_000;
 
+type ReactNativeFetchOptions = RequestInit & {
+  reactNative?: Record<string, unknown>;
+};
+
 /**
  * Directly imports fetch implementation from react-native-fetch-api.
  * This removes the requirement for the global `fetch` to be overridden by
@@ -36,6 +40,21 @@ export class ReactNativeRemote extends AbstractRemote {
       ...(options ?? {}),
       fetchImplementation: options?.fetchImplementation ?? new ReactNativeFetchProvider()
     });
+  }
+
+  get fetch(): FetchImplementation {
+    const fetchImplementation = super.fetch;
+    return ((input, init) => {
+      const options = (init ?? {}) as ReactNativeFetchOptions;
+
+      return fetchImplementation(input, {
+        ...options,
+        reactNative: {
+          ...(options.reactNative ?? {}),
+          textStreaming: true
+        }
+      } as RequestInit);
+    }) as FetchImplementation;
   }
 
   getUserAgent(): string {

--- a/packages/react-native/tests/mocks/react-native-fetch-api.ts
+++ b/packages/react-native/tests/mocks/react-native-fetch-api.ts
@@ -1,0 +1,3 @@
+export const fetch = async () => {
+  throw new Error('react-native-fetch-api should be injected in tests');
+};

--- a/packages/react-native/tests/mocks/react-native.ts
+++ b/packages/react-native/tests/mocks/react-native.ts
@@ -1,0 +1,10 @@
+export const Platform = {
+  OS: 'ios',
+  Version: '26',
+  constants: {
+    reactNativeVersion: {
+      major: 0,
+      minor: 85
+    }
+  }
+};

--- a/packages/react-native/tests/sync/ReactNativeRemote.test.ts
+++ b/packages/react-native/tests/sync/ReactNativeRemote.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ReactNativeRemote } from '../../src/sync/stream/ReactNativeRemote';
+
+const connector = {
+  fetchCredentials: async () => ({
+    endpoint: 'https://example.com',
+    token: 'token'
+  })
+};
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body,
+    text: async () => JSON.stringify(body)
+  } as Response;
+}
+
+describe('ReactNativeRemote', () => {
+  it('uses text streaming for non-streaming GET requests', async () => {
+    const fetchImplementation = vi.fn(async () => jsonResponse({ ok: true }));
+    const remote = new ReactNativeRemote(connector, undefined, { fetchImplementation });
+
+    await remote.get('/write-checkpoint2.json');
+
+    expect(fetchImplementation).toHaveBeenCalledWith(
+      'https://example.com/write-checkpoint2.json',
+      expect.objectContaining({
+        method: 'GET',
+        reactNative: expect.objectContaining({
+          textStreaming: true
+        })
+      })
+    );
+  });
+
+  it('uses text streaming for non-streaming POST requests', async () => {
+    const fetchImplementation = vi.fn(async () => jsonResponse({ ok: true }));
+    const remote = new ReactNativeRemote(connector, undefined, { fetchImplementation });
+
+    await remote.post('/crud', { op: 'put' });
+
+    expect(fetchImplementation).toHaveBeenCalledWith(
+      'https://example.com/crud',
+      expect.objectContaining({
+        method: 'POST',
+        reactNative: expect.objectContaining({
+          textStreaming: true
+        })
+      })
+    );
+  });
+});

--- a/packages/react-native/tsconfig.json
+++ b/packages/react-native/tsconfig.json
@@ -14,5 +14,6 @@
     {
       "path": "../react"
     }
-  ]
+  ],
+  "include": ["src/**/*"]
 }

--- a/packages/react-native/vitest.config.ts
+++ b/packages/react-native/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from 'path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      'react-native': path.resolve(__dirname, './tests/mocks/react-native.ts'),
+      'react-native-fetch-api': path.resolve(__dirname, './tests/mocks/react-native-fetch-api.ts')
+    }
+  },
+  test: {
+    include: ['tests/**/*.test.ts']
+  }
+});


### PR DESCRIPTION
Fixes #969

## Summary
- Wrap `ReactNativeRemote.fetch` so every React Native HTTP request passes `reactNative: { textStreaming: true }`.
- Add a small React Native vitest harness with `react-native` / `react-native-fetch-api` test aliases.
- Cover non-streaming `get()` and `post()` calls so checkpoint and credential-style requests stay on the text response path in RN 0.85.
- Add a patch changeset for `@powersync/react-native`.

## Reproduction before fix
- `pnpm --filter @powersync/react-native test --run` failed with 2 tests showing `GET` and `POST` fetch options did not include `reactNative.textStreaming`.

## Validation after fix
- `pnpm --filter @powersync/react-native test --run` -> 2 tests passed.
- `pnpm --filter @powersync/react-native build` -> passed.
- `pnpm --filter @powersync/react-native test:exports` -> no problems found.
- `pnpm exec prettier --check ...changed files...` -> all matched files use Prettier style.
- `git diff --check` -> passed.
