### PR TITLE
Build diagnostics client for arm64

### DIFF
--- a/.changeset/curvy-roses-suffer.md
+++ b/.changeset/curvy-roses-suffer.md
@@ -1,0 +1,7 @@
+---
+'@powersync/diagnostics-app': patch
+---
+
+Include arm64 builds in Docker image.
+
+Closes https://github.com/powersync-ja/powersync-js/issues/780.

--- a/.github/workflows/diagnostics-image-build.yaml
+++ b/.github/workflows/diagnostics-image-build.yaml
@@ -14,13 +14,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Build Image
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64
+          platforms: linux/arm64,linux/amd64
           cache-from: type=registry,ref=${{vars.DIAGNOSTICS_DOCKER_REGISTRY}}:latest
           context: .
           file: ./tools/diagnostics-app/Dockerfile

--- a/.github/workflows/diagnostics-image-release.yaml
+++ b/.github/workflows/diagnostics-image-release.yaml
@@ -19,6 +19,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -36,7 +38,7 @@ jobs:
       - name: Build Image and Push
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64
+          platforms: linux/arm64,linux/amd64
           cache-from: type=registry,ref=${{vars.DIAGNOSTICS_DOCKER_REGISTRY}}:latest
           context: .
           tags: ${{vars.DIAGNOSTICS_DOCKER_REGISTRY}}:latest,${{vars.DIAGNOSTICS_DOCKER_REGISTRY}}:${{steps.get_version.outputs.IMAGE_VERSION}}


### PR DESCRIPTION
This adopts the [same setup used by the PowerSync service](https://github.com/powersync-ja/powersync-service/blob/main/.github/workflows/development_image_release.yaml) to build the diagnostics client Docker image for linux/arm64 (in addition to linux/amd64).

Also thanks to @simonlpaige for suggesting the same setup in https://github.com/powersync-ja/powersync-js/issues/780#issuecomment-4544125427.