### PR TITLE
feat:  expose AttachmentQueue's AttachmentContext

### DIFF
--- a/.changeset/rude-schools-mix.md
+++ b/.changeset/rude-schools-mix.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+[Attachments] Make `AttachmentQueue.attachmentService` available for classes extending the base class. This allows for custom saveFile implementations.

--- a/.changeset/rude-schools-mix.md
+++ b/.changeset/rude-schools-mix.md
@@ -1,5 +1,5 @@
 ---
-'@powersync/common': patch
+'@powersync/common': minor
 ---
 
-[Attachments] Make `AttachmentQueue.attachmentService` available for classes extending the base class. This allows for custom saveFile implementations.
+[Attachments] Added `withAttachmentContext` helper method which exposes an `AttachmentContext` for custom attachment logic.

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 .output
 *.tsbuildinfo
 .vscode
+.devcontainer
 .DS_STORE
 .idea
 .fleet

--- a/packages/common/etc/common.api.md
+++ b/packages/common/etc/common.api.md
@@ -373,9 +373,7 @@ export interface ArrayQueryDefinition<RowType = unknown> {
 // @alpha
 export const ATTACHMENT_TABLE = "attachments";
 
-// Warning: (ae-internal-missing-underscore) The name "AttachmentContext" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
+// @alpha
 export class AttachmentContext {
     constructor(db: AbstractPowerSyncDatabase, tableName: string | undefined, logger: ILogger, archivedCacheLimit: number);
     archivedCacheLimit: number;
@@ -454,6 +452,7 @@ export class AttachmentQueue implements AttachmentQueue {
     readonly syncThrottleDuration: number;
     readonly tableName: string;
     verifyAttachments(): Promise<void>;
+    withAttachmentContext<T>(callback: (context: AttachmentContext) => Promise<T>): Promise<T>;
 }
 
 // @alpha

--- a/packages/common/etc/common.api.md
+++ b/packages/common/etc/common.api.md
@@ -376,10 +376,10 @@ export const ATTACHMENT_TABLE = "attachments";
 // @alpha
 export class AttachmentContext {
     constructor(db: AbstractPowerSyncDatabase, tableName: string | undefined, logger: ILogger, archivedCacheLimit: number);
-    archivedCacheLimit: number;
+    readonly archivedCacheLimit: number;
     // (undocumented)
     clearQueue(): Promise<void>;
-    db: AbstractPowerSyncDatabase;
+    readonly db: AbstractPowerSyncDatabase;
     // (undocumented)
     deleteArchivedAttachments(callback?: (attachments: AttachmentRecord[]) => Promise<void>): Promise<boolean>;
     deleteAttachment(attachmentId: string): Promise<void>;
@@ -388,9 +388,9 @@ export class AttachmentContext {
     // (undocumented)
     getAttachment(id: string): Promise<AttachmentRecord | undefined>;
     getAttachments(): Promise<AttachmentRecord[]>;
-    logger: ILogger;
+    readonly logger: ILogger;
     saveAttachments(attachments: AttachmentRecord[]): Promise<void>;
-    tableName: string;
+    readonly tableName: string;
     upsertAttachment(attachment: AttachmentRecord, context: Transaction): Promise<void>;
 }
 

--- a/packages/common/src/attachments/AttachmentContext.ts
+++ b/packages/common/src/attachments/AttachmentContext.ts
@@ -14,16 +14,16 @@ import { AttachmentRecord, AttachmentState, attachmentFromSql } from './Schema.j
  */
 export class AttachmentContext {
   /** PowerSync database instance for executing queries */
-  db: AbstractPowerSyncDatabase;
+  readonly db: AbstractPowerSyncDatabase;
 
   /** Name of the database table storing attachment records */
-  tableName: string;
+  readonly tableName: string;
 
   /** Logger instance for diagnostic information */
-  logger: ILogger;
+  readonly logger: ILogger;
 
   /** Maximum number of archived attachments to keep before cleanup */
-  archivedCacheLimit: number = 100;
+  readonly archivedCacheLimit: number = 100;
 
   /**
    * Creates a new AttachmentContext instance.

--- a/packages/common/src/attachments/AttachmentContext.ts
+++ b/packages/common/src/attachments/AttachmentContext.ts
@@ -1,6 +1,6 @@
 import { AbstractPowerSyncDatabase } from '../client/AbstractPowerSyncDatabase.js';
-import { ILogger } from '../utils/Logger.js';
 import { Transaction } from '../db/DBAdapter.js';
+import { ILogger } from '../utils/Logger.js';
 import { AttachmentRecord, AttachmentState, attachmentFromSql } from './Schema.js';
 
 /**
@@ -9,7 +9,8 @@ import { AttachmentRecord, AttachmentState, attachmentFromSql } from './Schema.j
  * Provides methods to query, insert, update, and delete attachment records with
  * proper transaction management through PowerSync.
  *
- * @internal
+ * @experimental
+ * @alpha
  */
 export class AttachmentContext {
   /** PowerSync database instance for executing queries */

--- a/packages/common/src/attachments/AttachmentQueue.ts
+++ b/packages/common/src/attachments/AttachmentQueue.ts
@@ -345,6 +345,10 @@ export class AttachmentQueue implements AttachmentQueue {
 
   /**
    * Provides an {@link AttachmentContext} to a callback.
+   *
+   * The callback runs while the attachment queue mutex is held. Do not call
+   * other {@link AttachmentQueue} methods from within the callback, as they may
+   * attempt to acquire the same mutex and block indefinitely.
    */
   withAttachmentContext<T>(callback: (context: AttachmentContext) => Promise<T>): Promise<T> {
     /**

--- a/packages/common/src/attachments/AttachmentQueue.ts
+++ b/packages/common/src/attachments/AttachmentQueue.ts
@@ -1,15 +1,15 @@
 import { AbstractPowerSyncDatabase } from '../client/AbstractPowerSyncDatabase.js';
 import { DEFAULT_WATCH_THROTTLE_MS } from '../client/watched/WatchedQuery.js';
 import { DifferentialWatchedQuery } from '../client/watched/processors/DifferentialQueryProcessor.js';
-import { ILogger } from '../utils/Logger.js';
 import { Transaction } from '../db/DBAdapter.js';
+import { ILogger } from '../utils/Logger.js';
+import { AttachmentErrorHandler } from './AttachmentErrorHandler.js';
+import { AttachmentService } from './AttachmentService.js';
 import { AttachmentData, LocalStorageAdapter } from './LocalStorageAdapter.js';
 import { RemoteStorageAdapter } from './RemoteStorageAdapter.js';
 import { ATTACHMENT_TABLE, AttachmentRecord, AttachmentState } from './Schema.js';
 import { SyncingService } from './SyncingService.js';
 import { WatchedAttachmentItem } from './WatchedAttachmentItem.js';
-import { AttachmentService } from './AttachmentService.js';
-import { AttachmentErrorHandler } from './AttachmentErrorHandler.js';
 
 /**
  * AttachmentQueue manages the lifecycle and synchronization of attachments
@@ -70,7 +70,7 @@ export class AttachmentQueue implements AttachmentQueue {
   readonly archivedCacheLimit: number;
 
   /** Service for managing attachment-related database operations */
-  private readonly attachmentService: AttachmentService;
+  protected readonly attachmentService: AttachmentService;
 
   /** PowerSync database instance */
   private readonly db: AbstractPowerSyncDatabase;

--- a/packages/common/src/attachments/AttachmentQueue.ts
+++ b/packages/common/src/attachments/AttachmentQueue.ts
@@ -3,6 +3,7 @@ import { DEFAULT_WATCH_THROTTLE_MS } from '../client/watched/WatchedQuery.js';
 import { DifferentialWatchedQuery } from '../client/watched/processors/DifferentialQueryProcessor.js';
 import { Transaction } from '../db/DBAdapter.js';
 import { ILogger } from '../utils/Logger.js';
+import { AttachmentContext } from './AttachmentContext.js';
 import { AttachmentErrorHandler } from './AttachmentErrorHandler.js';
 import { AttachmentService } from './AttachmentService.js';
 import { AttachmentData, LocalStorageAdapter } from './LocalStorageAdapter.js';
@@ -70,7 +71,7 @@ export class AttachmentQueue implements AttachmentQueue {
   readonly archivedCacheLimit: number;
 
   /** Service for managing attachment-related database operations */
-  protected readonly attachmentService: AttachmentService;
+  private readonly attachmentService: AttachmentService;
 
   /** PowerSync database instance */
   private readonly db: AbstractPowerSyncDatabase;
@@ -342,6 +343,16 @@ export class AttachmentQueue implements AttachmentQueue {
     }
   }
 
+  /**
+   * Provides an {@link AttachmentContext} to a callback.
+   */
+  withAttachmentContext<T>(callback: (context: AttachmentContext) => Promise<T>): Promise<T> {
+    /**
+     * AttachmentService is internal and private in this class.
+     * We only need to expose its locking and context functionality for extending classes.
+     */
+    return this.attachmentService.withContext(callback);
+  }
   /**
    * Saves a file to local storage and queues it for upload to remote storage.
    *

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,4 +1,4 @@
-export * from './attachments/AttachmentContext.js'; // TODO: Remove (internal)
+export * from './attachments/AttachmentContext.js';
 export * from './attachments/AttachmentErrorHandler.js';
 export * from './attachments/AttachmentQueue.js';
 export * from './attachments/AttachmentService.js';
@@ -35,7 +35,7 @@ export * from './db/DBAdapter.js';
 export * from './db/schema/Column.js';
 export * from './db/schema/Index.js';
 export * from './db/schema/IndexedColumn.js';
-export { RawTableType, PendingStatementParameter, PendingStatement } from './db/schema/RawTable.js';
+export { PendingStatement, PendingStatementParameter, RawTableType } from './db/schema/RawTable.js';
 export * from './db/schema/Schema.js';
 export * from './db/schema/Table.js';
 export * from './db/schema/TableV2.js';


### PR DESCRIPTION
Some `AttachmentQueue` users have a use case for custom `saveFile` methods. The `attachmentService` exposes a context to mutate `attachment` records in a safe manner. Unfortunately, the `attachmentService` is  currently marked as `private` which means extending classes cannot access it. 

The `AttachmentsService` contains functionality to watch active attachments and obtain an `AttachmentContext` via a mutex. Users won't likely need to watch the attachment state, but they could need an `AttachmentContext` - which exposes methods for reading and manipulating `AttachmentRecord`s.

This makes `AttachmentContext` a public API and adds a small method to `AttachmentQueue` to access an `AttachmentContext`.

An example use case for requiring access is available at https://github.com/powersync-ja/powersync-js/pull/983 