### PR TITLE
Upgrade `shell-quote` to fix audit issue

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,7 @@ catalogs:
 overrides:
   fast-xml-parser: '>=5.3.5'
   handlebars: ^4.7.9
+  shell-quote: ^1.8.4
 
 importers:
 
@@ -16023,8 +16024,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shiki@3.23.0:
@@ -30485,7 +30486,7 @@ snapshots:
       sanitize-filename: 1.6.3
       semver: 7.7.4
       serialize-error: 8.1.0
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       signal-exit: 3.0.7
       stream-json: 1.9.1
       strip-ansi: 6.0.1
@@ -33409,7 +33410,7 @@ snapshots:
   launch-editor@2.13.1:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
 
   lazystream@1.0.1:
     dependencies:
@@ -37327,7 +37328,7 @@ snapshots:
 
   react-devtools-core@6.1.5:
     dependencies:
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
@@ -38479,7 +38480,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   shiki@3.23.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,8 @@ overrides:
   'fast-xml-parser': '>=5.3.5'
   # To avoid https://github.com/advisories/GHSA-2w6w-674q-4c4q
   'handlebars': ^4.7.9
+  # To avoid https://github.com/advisories/GHSA-w7jw-789q-3m8p
+  'shell-quote': ^1.8.4
 
 catalog:
   '@journeyapps/wa-sqlite': ^1.5.0


### PR DESCRIPTION
Older versions of the `shell-quote` package are affected by [CVE-2026-9277](https://nvd.nist.gov/vuln/detail/CVE-2026-9277) which counts as a critical vulnerability failing our audit checks. So, this adds a dependency override to ensure we're on the latest fixed version.