### PR TITLE
Fix integration test browser issues with ArrayBuffers

### DIFF
--- a/packages/tauri/tests/integration.test.ts
+++ b/packages/tauri/tests/integration.test.ts
@@ -15,6 +15,10 @@ async function installTauriInTestFrameHack() {
 
   current.__TAURI_INTERNALS__ = root.__TAURI_INTERNALS__;
   current.__TAURI_EVENT_PLUGIN_INTERNALS__ = root.__TAURI_EVENT_PLUGIN_INTERNALS__;
+
+  // Fix cross-realm instanceof ArrayBuffer for tauri-plugin-fs binary responses.
+  current.ArrayBuffer = root.ArrayBuffer;
+
 }
 
 const schema = new Schema({

--- a/packages/tauri/tests/integration.test.ts
+++ b/packages/tauri/tests/integration.test.ts
@@ -16,7 +16,10 @@ async function installTauriInTestFrameHack() {
   current.__TAURI_INTERNALS__ = root.__TAURI_INTERNALS__;
   current.__TAURI_EVENT_PLUGIN_INTERNALS__ = root.__TAURI_EVENT_PLUGIN_INTERNALS__;
 
-  // Fix cross-realm instanceof ArrayBuffer for tauri-plugin-fs binary responses.
+  // When binary responses are used, Tauri injects top-level code matching against
+  // ArrayBuffers. Ensure this iframe realm uses the same class for compatibility. We
+  // don't currently use binary responses in the PowerSync plugin, but it serves as an
+  // example for general integration tests with Tauri.
   current.ArrayBuffer = root.ArrayBuffer;
 
 }


### PR DESCRIPTION
Hey there! Recently read [this](https://powersync.com/blog/tauri-integration-tests) great post from @simolus3 on vitest integration tests for Tauri. As soon as I read it I tried it out. My app makes extensive usage of `tauri-plugin-fs` so I started testing and noticed that reading files was broken on the integration tests. 

When Vitest runs Tauri integration tests inside an iframe, `tauri-plugin-fs` and other Tauri IPC internals use `instanceof ArrayBuffer` to detect binary responses from Rust commands.

However, the `ArrayBuffer` returned by `invoke()` is created in the **top-level window's realm** (where Tauri injects its globals), while the test code runs in the **iframe's realm**. Because of JavaScript's cross-realm semantics, `instanceof ArrayBuffer` returns `false` when the constructor and the instance come from different realms. This breaks any binary data transfer — for example, `readFile` from `@tauri-apps/plugin-fs` will silently misbehave or throw because the returned `ArrayBuffer` fails the `instanceof` check.

I've attached a fix in this PR. It's just a small extension of the iframe workaround. Also searched for more instanceof usages across Tauri plugins and did not find any other. So it seems we'll not hit an endless stream of cases like this (hope so)