### PR TITLE
chore: Extracted `AttachmentQueue` constructor options.

### DIFF
--- a/.changeset/silly-emus-burn.md
+++ b/.changeset/silly-emus-burn.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': minor
+---
+
+[Attachments] Extracted `AttachmentQueue` constructor options to an options interface named `AttachmentQueueOptions`.

--- a/packages/common/etc/common.api.md
+++ b/packages/common/etc/common.api.md
@@ -443,22 +443,18 @@ export class AttachmentQueue {
     withAttachmentContext<T>(callback: (context: AttachmentContext) => Promise<T>): Promise<T>;
 }
 
-// @public (undocumented)
+// @alpha
 export interface AttachmentQueueOptions {
     archivedCacheLimit?: number;
     db: AbstractPowerSyncDatabase;
     downloadAttachments?: boolean;
-    // Warning: (ae-incompatible-release-tags) The symbol "errorHandler" is marked as @public, but its signature references "AttachmentErrorHandler" which is marked as @alpha
     errorHandler?: AttachmentErrorHandler;
-    // Warning: (ae-incompatible-release-tags) The symbol "localStorage" is marked as @public, but its signature references "LocalStorageAdapter" which is marked as @alpha
     localStorage: LocalStorageAdapter;
     logger?: ILogger;
-    // Warning: (ae-incompatible-release-tags) The symbol "remoteStorage" is marked as @public, but its signature references "RemoteStorageAdapter" which is marked as @alpha
     remoteStorage: RemoteStorageAdapter;
     syncIntervalMs?: number;
     syncThrottleDuration?: number;
     tableName?: string;
-    // Warning: (ae-incompatible-release-tags) The symbol "watchAttachments" is marked as @public, but its signature references "WatchedAttachmentItem" which is marked as @alpha
     watchAttachments: (onUpdate: (attachment: WatchedAttachmentItem[]) => Promise<void>, signal: AbortSignal) => void;
 }
 

--- a/packages/common/etc/common.api.md
+++ b/packages/common/etc/common.api.md
@@ -408,20 +408,8 @@ export interface AttachmentErrorHandler {
 export function attachmentFromSql(row: any): AttachmentRecord;
 
 // @alpha
-export class AttachmentQueue implements AttachmentQueue {
-    constructor(input: {
-        db: AbstractPowerSyncDatabase;
-        remoteStorage: RemoteStorageAdapter;
-        localStorage: LocalStorageAdapter;
-        watchAttachments: (onUpdate: (attachment: WatchedAttachmentItem[]) => Promise<void>, signal: AbortSignal) => void;
-        tableName?: string;
-        logger?: ILogger;
-        syncIntervalMs?: number;
-        syncThrottleDuration?: number;
-        downloadAttachments?: boolean;
-        archivedCacheLimit?: number;
-        errorHandler?: AttachmentErrorHandler;
-    });
+export class AttachmentQueue {
+    constructor(input: AttachmentQueueOptions);
     readonly archivedCacheLimit: number;
     // (undocumented)
     clearQueue(): Promise<void>;
@@ -453,6 +441,25 @@ export class AttachmentQueue implements AttachmentQueue {
     readonly tableName: string;
     verifyAttachments(): Promise<void>;
     withAttachmentContext<T>(callback: (context: AttachmentContext) => Promise<T>): Promise<T>;
+}
+
+// @public (undocumented)
+export interface AttachmentQueueOptions {
+    archivedCacheLimit?: number;
+    db: AbstractPowerSyncDatabase;
+    downloadAttachments?: boolean;
+    // Warning: (ae-incompatible-release-tags) The symbol "errorHandler" is marked as @public, but its signature references "AttachmentErrorHandler" which is marked as @alpha
+    errorHandler?: AttachmentErrorHandler;
+    // Warning: (ae-incompatible-release-tags) The symbol "localStorage" is marked as @public, but its signature references "LocalStorageAdapter" which is marked as @alpha
+    localStorage: LocalStorageAdapter;
+    logger?: ILogger;
+    // Warning: (ae-incompatible-release-tags) The symbol "remoteStorage" is marked as @public, but its signature references "RemoteStorageAdapter" which is marked as @alpha
+    remoteStorage: RemoteStorageAdapter;
+    syncIntervalMs?: number;
+    syncThrottleDuration?: number;
+    tableName?: string;
+    // Warning: (ae-incompatible-release-tags) The symbol "watchAttachments" is marked as @public, but its signature references "WatchedAttachmentItem" which is marked as @alpha
+    watchAttachments: (onUpdate: (attachment: WatchedAttachmentItem[]) => Promise<void>, signal: AbortSignal) => void;
 }
 
 // @alpha

--- a/packages/common/src/attachments/AttachmentQueue.ts
+++ b/packages/common/src/attachments/AttachmentQueue.ts
@@ -12,6 +12,12 @@ import { ATTACHMENT_TABLE, AttachmentRecord, AttachmentState } from './Schema.js
 import { SyncingService } from './SyncingService.js';
 import { WatchedAttachmentItem } from './WatchedAttachmentItem.js';
 
+/**
+ * Configuration options for {@link AttachmentQueue}.
+ *
+ * @experimental
+ * @alpha This is currently experimental and may change without a major version bump.
+ */
 export interface AttachmentQueueOptions {
   /**
    * PowerSync database instance

--- a/packages/common/src/attachments/AttachmentQueue.ts
+++ b/packages/common/src/attachments/AttachmentQueue.ts
@@ -12,6 +12,52 @@ import { ATTACHMENT_TABLE, AttachmentRecord, AttachmentState } from './Schema.js
 import { SyncingService } from './SyncingService.js';
 import { WatchedAttachmentItem } from './WatchedAttachmentItem.js';
 
+export interface AttachmentQueueOptions {
+  /**
+   * PowerSync database instance
+   */
+  db: AbstractPowerSyncDatabase;
+  /**
+   * Remote storage adapter for upload/download operations
+   */
+  remoteStorage: RemoteStorageAdapter;
+  /**
+   * Local storage adapter for file persistence
+   */
+  localStorage: LocalStorageAdapter;
+  /**
+   * Callback for monitoring attachment changes in your data model
+   */
+  watchAttachments: (onUpdate: (attachment: WatchedAttachmentItem[]) => Promise<void>, signal: AbortSignal) => void;
+  /**
+   * Name of the table to store attachment records. Default: 'ps_attachment_queue'
+   */
+  tableName?: string;
+  /**
+   * Logger instance. Defaults to db.logger
+   */
+  logger?: ILogger;
+  /**
+   * Periodic polling interval in milliseconds for retrying failed uploads/downloads. Default: 30000
+   */
+  syncIntervalMs?: number;
+  /**
+   * Throttle duration in milliseconds for the reactive watch query that detects attachment changes. Prevents rapid-fire syncs during bulk changes. Default: 30
+   */
+  syncThrottleDuration?: number;
+  /**
+   * Whether to automatically download remote attachments. Default: true
+   */
+  downloadAttachments?: boolean;
+  /**
+   * Maximum archived attachments before cleanup. Default: 100
+   */
+  archivedCacheLimit?: number;
+
+  /** Handler for upload, download and delete errors */
+  errorHandler?: AttachmentErrorHandler;
+}
+
 /**
  * AttachmentQueue manages the lifecycle and synchronization of attachments
  * between local and remote storage.
@@ -21,7 +67,7 @@ import { WatchedAttachmentItem } from './WatchedAttachmentItem.js';
  * @experimental
  * @alpha This is currently experimental and may change without a major version bump.
  */
-export class AttachmentQueue implements AttachmentQueue {
+export class AttachmentQueue {
   /** Timer for periodic synchronization operations */
   private periodicSyncTimer?: ReturnType<typeof setInterval>;
 
@@ -100,49 +146,7 @@ export class AttachmentQueue implements AttachmentQueue {
     downloadAttachments = true,
     archivedCacheLimit = 100,
     errorHandler
-  }: {
-    /**
-     * PowerSync database instance
-     */
-    db: AbstractPowerSyncDatabase;
-    /**
-     * Remote storage adapter for upload/download operations
-     */
-    remoteStorage: RemoteStorageAdapter;
-    /**
-     * Local storage adapter for file persistence
-     */
-    localStorage: LocalStorageAdapter;
-    /**
-     * Callback for monitoring attachment changes in your data model
-     */
-    watchAttachments: (onUpdate: (attachment: WatchedAttachmentItem[]) => Promise<void>, signal: AbortSignal) => void;
-    /**
-     * Name of the table to store attachment records. Default: 'ps_attachment_queue'
-     */
-    tableName?: string;
-    /**
-     * Logger instance. Defaults to db.logger
-     */
-    logger?: ILogger;
-    /**
-     * Periodic polling interval in milliseconds for retrying failed uploads/downloads. Default: 30000
-     */
-    syncIntervalMs?: number;
-    /**
-     * Throttle duration in milliseconds for the reactive watch query that detects attachment changes. Prevents rapid-fire syncs during bulk changes. Default: 30
-     */
-    syncThrottleDuration?: number;
-    /**
-     * Whether to automatically download remote attachments. Default: true
-     */
-    downloadAttachments?: boolean;
-    /**
-     * Maximum archived attachments before cleanup. Default: 100
-     */
-    archivedCacheLimit?: number;
-    errorHandler?: AttachmentErrorHandler;
-  }) {
+  }: AttachmentQueueOptions) {
     this.db = db;
     this.remoteStorage = remoteStorage;
     this.localStorage = localStorage;


### PR DESCRIPTION
Allows users to extend the AttachmentQueue's constructor options. See https://github.com/powersync-ja/powersync-js/pull/983/changes#diff-653a500ee4fcb66f46848ac2632c3c566053e985712b7efac50ffe05fb16587bR37-R58 for an example.