### PR TITLE
Remove `event-iterator` dependency

### DIFF
--- a/.changeset/slimy-penguins-cheer.md
+++ b/.changeset/slimy-penguins-cheer.md
@@ -1,0 +1,5 @@
+---
+'@powersync/common': patch
+---
+
+Remove `event-iterator` dependency.

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -59,7 +59,6 @@
     "test:exports": "attw --pack . --exclude-entrypoints internal/sync_protocol"
   },
   "dependencies": {
-    "event-iterator": "^2.0.0",
     "js-logger": "catalog:"
   },
   "devDependencies": {

--- a/packages/common/rollup.config.mjs
+++ b/packages/common/rollup.config.mjs
@@ -19,7 +19,7 @@ function defineBuild(isNode) {
     ]
   ];
   if (!isNode) {
-    plugins.push(applyAsyncIteratorPolyfill());
+    plugins.push(checkNoIllegalAsyncIteratorUse());
   }
 
   return {
@@ -55,70 +55,17 @@ export default () => {
   ];
 };
 
-/**
- * Replaces `Symbol.asyncIterator` with a polyfill in bundled dependencies (specifically `EventIterator`).
- *
- * This is derived from an example in Rollup docs: https://rollupjs.org/plugin-development/#resolveid
- */
-function applyAsyncIteratorPolyfill() {
-  // A fake file we import into every file using Symbol.asyncIterator
-  const POLYFILL_ID = '\0symbol-async-iterator';
-
+function checkNoIllegalAsyncIteratorUse() {
   return {
     name: 'applyAsyncIteratorPonyfill',
-    async resolveId(source) {
-      if (source === POLYFILL_ID) {
-        return { id: POLYFILL_ID };
-      }
-      return null;
-    },
-    load(id) {
-      if (id === POLYFILL_ID) {
-        // Outside of Node.JS, we replace Symbol.asyncIterator with an import to this symbol. This allows us to use
-        // Symbol.asyncIterator internally. If users install the recommended polyfill, https://github.com/Azure/azure-sdk-for-js/blob/%40azure/core-asynciterator-polyfill_1.0.2/sdk/core/core-asynciterator-polyfill/src/index.ts#L4-L6
-        // they can also use our async iterables on React Native.
-        // Of course, we could also inline this definition with a simple replacement. But putting this in a fake module
-        // de-duplicates it.
-        return `
-export const symbolAsyncIterator = Symbol.asyncIterator ?? Symbol.for('Symbol.asyncIterator');
-        `;
-      }
-    },
     transform(code, id) {
-      if (id === POLYFILL_ID) return null;
-      if (!code.includes('Symbol.asyncIterator')) return null;
+      if (id.endsWith('compatibility.js')) return null;
 
-      const ast = this.parse(code);
-      const s = new MagicString(code);
+      if (code.includes('Symbol.asyncIterator')) {
+        throw new Error(`${id} is not allowed to use Symbol.asyncIterator. Import compatibility.ts instead.`);
+      }
 
-      let replaced = false;
-      const symbolName = 'symbolAsyncIterator';
-
-      walk(ast, {
-        enter(node) {
-          // Replace Symbol.asyncIterator
-          if (
-            node.type === 'MemberExpression' &&
-            !node.computed &&
-            node.object.type === 'Identifier' &&
-            node.object.name === 'Symbol' &&
-            node.property.type === 'Identifier' &&
-            node.property.name === 'asyncIterator'
-          ) {
-            replaced = true;
-            s.overwrite(node.start, node.end, symbolName);
-          }
-        }
-      });
-
-      if (!replaced) return null;
-
-      s.prepend(`import { ${symbolName} } from ${JSON.stringify(POLYFILL_ID)};\n`);
-
-      return {
-        code: s.toString(),
-        map: s.generateMap({ hires: true })
-      };
+      return code;
     }
   };
 }

--- a/packages/common/rollup.config.mjs
+++ b/packages/common/rollup.config.mjs
@@ -64,8 +64,6 @@ function checkNoIllegalAsyncIteratorUse() {
       if (code.includes('Symbol.asyncIterator')) {
         throw new Error(`${id} is not allowed to use Symbol.asyncIterator. Import compatibility.ts instead.`);
       }
-
-      return code;
     }
   };
 }

--- a/packages/common/rollup.config.mjs
+++ b/packages/common/rollup.config.mjs
@@ -36,8 +36,7 @@ function defineBuild(isNode) {
         sourcemap: true
       }
     ],
-    plugins,
-    external: [isNode ? 'event-iterator' : undefined]
+    plugins
   };
 }
 

--- a/packages/common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/common/src/client/AbstractPowerSyncDatabase.ts
@@ -46,7 +46,7 @@ import { DEFAULT_WATCH_THROTTLE_MS, WatchCompatibleQuery } from './watched/Watch
 import { OnChangeQueryProcessor } from './watched/processors/OnChangeQueryProcessor.js';
 import { WatchedQueryComparator } from './watched/processors/comparators.js';
 import { Mutex } from '../utils/mutex.js';
-import { doneResult, valueResult } from '../utils/stream_transform.js';
+import { symbolAsyncIterator } from '../utils/compatibility.js';
 
 /**
  * @public
@@ -762,7 +762,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
    * @returns A transaction of CRUD operations to upload, or null if there are none
    */
   async getNextCrudTransaction(): Promise<CrudTransaction | null> {
-    const iterator = this.getCrudTransactions()[Symbol.asyncIterator]();
+    const iterator = this.getCrudTransactions()[symbolAsyncIterator]();
     return (await iterator.next()).value;
   }
 
@@ -799,7 +799,7 @@ export abstract class AbstractPowerSyncDatabase extends BaseObserver<PowerSyncDB
    */
   getCrudTransactions(): AsyncIterable<CrudTransaction, null> {
     return {
-      [Symbol.asyncIterator]: () => {
+      [symbolAsyncIterator]: () => {
         let lastCrudItemId = -1;
         const sql = `
 WITH RECURSIVE crud_entries AS (

--- a/packages/common/src/client/AbstractPowerSyncDatabase.ts
+++ b/packages/common/src/client/AbstractPowerSyncDatabase.ts
@@ -1,4 +1,3 @@
-import { EventIterator } from 'event-iterator';
 import Logger, { ILogger } from 'js-logger';
 import {
   BatchedUpdateNotification,
@@ -14,7 +13,7 @@ import { UploadQueueStats } from '../db/crud/UploadQueueStatus.js';
 import { Schema } from '../db/schema/Schema.js';
 import { BaseObserver } from '../utils/BaseObserver.js';
 import { ControlledExecutor } from '../utils/ControlledExecutor.js';
-import { throttleTrailing } from '../utils/async.js';
+import { EventQueue, throttleTrailing } from '../utils/async.js';
 import {
   ConnectionManager,
   CreateSyncImplementationOptions,
@@ -47,6 +46,7 @@ import { DEFAULT_WATCH_THROTTLE_MS, WatchCompatibleQuery } from './watched/Watch
 import { OnChangeQueryProcessor } from './watched/processors/OnChangeQueryProcessor.js';
 import { WatchedQueryComparator } from './watched/processors/comparators.js';
 import { Mutex } from '../utils/mutex.js';
+import { doneResult, valueResult } from '../utils/stream_transform.js';
 
 /**
  * @public
@@ -1193,22 +1193,18 @@ SELECT * FROM crud_entries;
    * @returns An AsyncIterable that yields QueryResults whenever the data changes
    */
   watchWithAsyncGenerator(sql: string, parameters?: any[], options?: SQLWatchOptions): AsyncIterable<QueryResult> {
-    return new EventIterator<QueryResult>((eventOptions) => {
+    return EventQueue.queueBasedAsyncIterable((queue, abort) => {
       const handler: WatchHandler = {
         onResult: (result) => {
-          eventOptions.push(result);
+          queue.notify(result);
         },
         onError: (error) => {
-          eventOptions.fail(error);
+          queue.notifyError(error);
         }
       };
 
-      this.watchWithCallback(sql, parameters, handler, options);
-
-      options?.signal?.addEventListener('abort', () => {
-        eventOptions.stop();
-      });
-    });
+      this.watchWithCallback(sql, parameters, handler, { ...options, signal: abort });
+    }, options?.signal);
   }
 
   /**
@@ -1353,34 +1349,27 @@ SELECT * FROM crud_entries;
    * This is preferred over {@link AbstractPowerSyncDatabase.watchWithAsyncGenerator} when multiple queries need to be
    * performed together when data is changed.
    *
-   * Note: do not declare this as `async *onChange` as it will not work in React Native.
-   *
    * @param options - Options for configuring watch behavior
    * @returns An AsyncIterable that yields change events whenever the specified tables change
    */
+  // Note: do not declare this as `async *onChange` as it will not work in React Native.
   onChangeWithAsyncGenerator(options?: SQLWatchOptions): AsyncIterable<WatchOnChangeEvent> {
-    const resolvedOptions = options ?? {};
-
-    return new EventIterator<WatchOnChangeEvent>((eventOptions) => {
-      const dispose = this.onChangeWithCallback(
+    return EventQueue.queueBasedAsyncIterable((queue, abort) => {
+      this.onChangeWithCallback(
         {
           onChange: (event): void => {
-            eventOptions.push(event);
+            queue.notify(event);
           },
           onError: (error) => {
-            eventOptions.fail(error);
+            queue.notifyError(error);
           }
         },
-        options
+        { ...options, signal: abort }
       );
 
-      resolvedOptions.signal?.addEventListener('abort', () => {
-        eventOptions.stop();
-        // Maybe fail?
-      });
-
-      return () => dispose();
-    });
+      // Note: We don't have to track the dispose function returned by onChangeWithCallback, it cleans up
+      // after the abort signal completes.
+    }, options?.signal);
   }
 
   private handleTableChanges(

--- a/packages/common/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/common/src/client/sync/stream/AbstractRemote.ts
@@ -9,10 +9,10 @@ import {
   doneResult,
   extractBsonObjects,
   extractJsonLines,
-  SimpleAsyncIterator
+  SimpleAsyncIterator,
+  valueResult
 } from '../../../utils/stream_transform.js';
-import { EventIterator } from 'event-iterator';
-import type { Queue } from 'event-iterator/lib/event-iterator.js';
+import { EventQueue } from '../../../utils/async.js';
 
 /**
  * @internal
@@ -329,8 +329,19 @@ export abstract class AbstractRemote {
     let pendingSocket: WebSocket | null = null;
     let keepAliveTimeout: any;
     let rsocket: RSocket | null = null;
-    let queue: Queue<Uint8Array> | null = null;
+    let paused = false;
+    const queue = new EventQueue<Uint8Array>({
+      eventDelivered: () => {
+        if (queue.countOutstandingEvents <= SYNC_QUEUE_REQUEST_LOW_WATER) {
+          paused = false;
+          requestMore();
+        }
+      }
+    });
     let didClose = false;
+    let connectionEstablished = false;
+    let pendingEventsCount = syncQueueRequestSize;
+    let res: Requestable | null = null;
 
     const abortRequest = () => {
       if (didClose) {
@@ -347,11 +358,22 @@ export abstract class AbstractRemote {
       if (rsocket) {
         rsocket.close();
       }
-
-      if (queue) {
-        queue.stop();
-      }
     };
+
+    function push(event: Uint8Array) {
+      queue.notify(event);
+      if (queue.countOutstandingEvents >= SYNC_QUEUE_REQUEST_HIGH_WATER) {
+        paused = true;
+      }
+    }
+
+    function requestMore() {
+      const delta = syncQueueRequestSize - pendingEventsCount;
+      if (!paused && delta > 0) {
+        res?.request(delta);
+        pendingEventsCount = syncQueueRequestSize;
+      }
+    }
 
     // Handle upstream abort
     if (options.abortSignal.aborted) {
@@ -413,31 +435,16 @@ export abstract class AbstractRemote {
     rsocket.onClose(() => (rsocket = null));
 
     return await new Promise((resolve, reject) => {
-      let connectionEstablished = false;
-      let pendingEventsCount = syncQueueRequestSize;
-      let paused = false;
-      let res: Requestable | null = null;
-
-      function requestMore() {
-        const delta = syncQueueRequestSize - pendingEventsCount;
-        if (!paused && delta > 0) {
-          res?.request(delta);
-          pendingEventsCount = syncQueueRequestSize;
+      const queueAsIterator: SimpleAsyncIterator<Uint8Array> = {
+        next: async () => {
+          const notification = await queue.waitForEvent(options.abortSignal);
+          if (didClose) {
+            return doneResult;
+          } else {
+            return valueResult(notification!);
+          }
         }
-      }
-
-      const events = new EventIterator<Uint8Array>(
-        (q) => {
-          queue = q;
-
-          q.on('highWater', () => (paused = true));
-          q.on('lowWater', () => {
-            paused = false;
-            requestMore();
-          });
-        },
-        { highWaterMark: SYNC_QUEUE_REQUEST_HIGH_WATER, lowWaterMark: SYNC_QUEUE_REQUEST_LOW_WATER }
-      )[Symbol.asyncIterator]();
+      };
 
       res = rsocket!.requestStream(
         {
@@ -476,12 +483,12 @@ export abstract class AbstractRemote {
             // The connection is active
             if (!connectionEstablished) {
               connectionEstablished = true;
-              resolve(events);
+              resolve(queueAsIterator);
             }
             const { data } = payload;
 
             if (data) {
-              queue!.push(data);
+              push(data);
             }
 
             // Less events are now pending

--- a/packages/common/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/common/src/client/sync/stream/AbstractRemote.ts
@@ -330,7 +330,7 @@ export abstract class AbstractRemote {
     let keepAliveTimeout: any;
     let rsocket: RSocket | null = null;
     let paused = false;
-    const queue = new EventQueue<Uint8Array>({
+    const queue = new EventQueue<Uint8Array | null>({
       eventDelivered: () => {
         if (queue.countOutstandingEvents <= SYNC_QUEUE_REQUEST_LOW_WATER) {
           paused = false;
@@ -358,6 +358,10 @@ export abstract class AbstractRemote {
       if (rsocket) {
         rsocket.close();
       }
+
+      // Send a bogus event to the queue to ensure a pending listener gets woken up. We check for didClose and would
+      // return a doneEvent.
+      queue.notify(null);
     };
 
     function push(event: Uint8Array) {
@@ -437,6 +441,8 @@ export abstract class AbstractRemote {
     return await new Promise((resolve, reject) => {
       const queueAsIterator: SimpleAsyncIterator<Uint8Array> = {
         next: async () => {
+          if (didClose) return doneResult;
+
           const notification = await queue.waitForEvent(options.abortSignal);
           if (didClose) {
             return doneResult;

--- a/packages/common/src/utils/async.ts
+++ b/packages/common/src/utils/async.ts
@@ -1,3 +1,4 @@
+import { symbolAsyncIterator } from './compatibility.js';
 import { doneResult, valueResult } from './stream_transform.js';
 
 /**
@@ -149,7 +150,7 @@ export class EventQueue<T> {
     abort?: AbortSignal
   ): AsyncIterable<T> {
     return {
-      [Symbol.asyncIterator]: () => {
+      [symbolAsyncIterator]: () => {
         const queue = new EventQueue<T>();
         const controller = new AbortController();
 

--- a/packages/common/src/utils/async.ts
+++ b/packages/common/src/utils/async.ts
@@ -1,3 +1,5 @@
+import { doneResult, valueResult } from './stream_transform.js';
+
 /**
  * Throttle a function to be called at most once every "wait" milliseconds,
  * on the trailing edge.
@@ -34,44 +36,149 @@ export interface AsyncNotifier {
 }
 
 export function asyncNotifier(): AsyncNotifier {
-  let waitingConsumer: (() => void) | null = null;
-  let hasPendingNotification = false;
+  const queue = new EventQueue<void>();
 
   return {
     notify() {
-      if (waitingConsumer != null) {
-        waitingConsumer();
-        waitingConsumer = null;
+      if (queue.countOutstandingEvents > 0) {
+        // Already has an outstanding event, no need to buffer another one.
       } else {
-        hasPendingNotification = true;
+        queue.notify();
       }
     },
     waitForNotification(signal: AbortSignal) {
-      return new Promise((resolve) => {
-        if (waitingConsumer != null) {
-          throw new Error('Illegal call to waitForNotification, already has a waiter.');
-        }
-
-        if (signal.aborted) {
-          resolve();
-        } else if (hasPendingNotification) {
-          resolve();
-          hasPendingNotification = false;
-        } else {
-          function complete() {
-            signal.removeEventListener('abort', onAbort);
-            resolve();
-          }
-
-          function onAbort() {
-            waitingConsumer = null;
-            resolve();
-          }
-
-          waitingConsumer = complete;
-          signal.addEventListener('abort', onAbort);
-        }
-      });
+      return queue.waitForEvent(signal);
     }
   };
+}
+
+type QueueWaiter<T> = { resolve: (event: T) => void; reject: (error: unknown) => void };
+
+export interface QueueOptions {
+  eventDelivered?: () => void;
+}
+
+export class EventQueue<T> {
+  private waitingConsumer: QueueWaiter<T> | undefined;
+  private readonly outstandingEvents: Array<(waiter: QueueWaiter<T>) => void>;
+
+  constructor(private readonly options: QueueOptions = {}) {
+    this.outstandingEvents = [];
+  }
+
+  /**
+   * The amount of buffered events not yet dispatched to listeners.
+   */
+  get countOutstandingEvents(): number {
+    return this.outstandingEvents.length;
+  }
+
+  private notifyInner(dispatch: (waiter: QueueWaiter<T>) => void) {
+    const existing = this.waitingConsumer;
+    this.waitingConsumer = undefined;
+
+    const dispatchAndNotifyListeners = (waiter: QueueWaiter<T>) => {
+      dispatch(waiter);
+      this.options.eventDelivered?.();
+    };
+
+    if (existing) {
+      dispatchAndNotifyListeners(existing);
+    } else {
+      this.outstandingEvents.push(dispatchAndNotifyListeners);
+    }
+  }
+
+  notify(value: T) {
+    this.notifyInner((l) => l.resolve(value));
+  }
+
+  notifyError(error: unknown) {
+    this.notifyInner((l) => l.reject(error));
+  }
+
+  waitForEvent(signal: AbortSignal): Promise<T | undefined> {
+    return new Promise((resolve, reject) => {
+      if (this.waitingConsumer != null) {
+        throw new Error('Illegal call to waitForEvent, already has a waiter.');
+      }
+
+      const complete = () => {
+        signal?.removeEventListener('abort', onAbort);
+      };
+
+      const onAbort = () => {
+        complete();
+        this.waitingConsumer = undefined;
+        resolve(undefined);
+      };
+
+      const waiter: QueueWaiter<T> = {
+        resolve: (value) => {
+          complete();
+          resolve(value);
+        },
+        reject: (error) => {
+          complete();
+          reject(error);
+        }
+      };
+
+      if (signal.aborted) {
+        resolve(undefined);
+      } else if (this.countOutstandingEvents > 0) {
+        const [event] = this.outstandingEvents.splice(0, 1);
+        event(waiter);
+      } else {
+        this.waitingConsumer = waiter;
+        signal.addEventListener('abort', onAbort);
+      }
+    });
+  }
+
+  /**
+   * Creates an async iterable backed by event queues.
+   *
+   * @param run A function invoked for every new listener. It receives a queue backing the async iterator.
+   * @param abort An additional abort signal. The `run` callback will also be aborted when `AsyncIterator.return` is
+   * called.
+   * @returns An object conforming to the async iterable protocol.
+   */
+  static queueBasedAsyncIterable<T>(
+    run: (queue: EventQueue<T>, abort: AbortSignal) => void,
+    abort?: AbortSignal
+  ): AsyncIterable<T> {
+    return {
+      [Symbol.asyncIterator]: () => {
+        const queue = new EventQueue<T>();
+        const controller = new AbortController();
+
+        function dispose() {
+          controller.abort();
+          abort?.removeEventListener('abort', dispose);
+        }
+
+        if (abort) {
+          if (abort.aborted) {
+            controller.abort();
+          } else {
+            abort.addEventListener('abort', dispose);
+          }
+        }
+
+        run(queue, controller.signal);
+
+        return {
+          async next(): Promise<IteratorResult<T>> {
+            const event = await queue.waitForEvent(controller.signal);
+            return event == null ? doneResult : valueResult(event);
+          },
+          async return(): Promise<IteratorResult<T>> {
+            dispose();
+            return doneResult;
+          }
+        };
+      }
+    };
+  }
 }

--- a/packages/common/src/utils/compatibility.ts
+++ b/packages/common/src/utils/compatibility.ts
@@ -1,0 +1,9 @@
+/**
+ * Some JavaScript engines, in particular older versions of React Native, don't support Symbol.asyncIterator.
+ *
+ * For those, users relying on async generators typically lower them with a transpiler and [this polyfill](polyfill, https://github.com/Azure/azure-sdk-for-js/blob/%40azure/core-asynciterator-polyfill_1.0.2/sdk/core/core-asynciterator-polyfill/src/index.ts#L4-L6).
+ * This definition is compatible with that polyfill, so transpiled apps can use async iterables created by the PowerSync
+ * SDK.
+ */
+export const symbolAsyncIterator: typeof Symbol.asyncIterator =
+  Symbol.asyncIterator ?? Symbol.for('Symbol.asyncIterator');

--- a/packages/common/src/utils/compatibility.ts
+++ b/packages/common/src/utils/compatibility.ts
@@ -1,7 +1,7 @@
 /**
  * Some JavaScript engines, in particular older versions of React Native, don't support Symbol.asyncIterator.
  *
- * For those, users relying on async generators typically lower them with a transpiler and [this polyfill](polyfill, https://github.com/Azure/azure-sdk-for-js/blob/%40azure/core-asynciterator-polyfill_1.0.2/sdk/core/core-asynciterator-polyfill/src/index.ts#L4-L6).
+ * For those, users relying on async generators typically lower them with a transpiler and [this polyfill](https://github.com/Azure/azure-sdk-for-js/blob/%40azure/core-asynciterator-polyfill_1.0.2/sdk/core/core-asynciterator-polyfill/src/index.ts#L4-L6).
  * This definition is compatible with that polyfill, so transpiled apps can use async iterables created by the PowerSync
  * SDK.
  */

--- a/packages/common/tests/utils/async.test.ts
+++ b/packages/common/tests/utils/async.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from 'vitest';
-import { asyncNotifier } from '../../src/utils/async.js';
+import { asyncNotifier, EventQueue } from '../../src/utils/async.js';
+
+const neverAbort = new AbortController().signal;
 
 describe('asyncNotifier', () => {
-  const neverAbort = new AbortController().signal;
-
   test('waits for event', async () => {
     const notifier = asyncNotifier();
     let didReceiveEvent = false;
@@ -49,5 +49,126 @@ describe('asyncNotifier', () => {
   test('completes on abort later', async () => {
     const notifier = asyncNotifier();
     await notifier.waitForNotification(AbortSignal.timeout(10));
+  });
+});
+
+describe('event queue', () => {
+  test('can dispatch events in order', async () => {
+    const queue = new EventQueue<number>();
+    for (let i = 0; i < 1000; i++) {
+      expect(queue.countOutstandingEvents).toStrictEqual(i);
+      queue.notify(i);
+      expect(queue.countOutstandingEvents).toStrictEqual(i + 1);
+    }
+
+    for (let i = 0; i < 1000; i++) {
+      expect(queue.countOutstandingEvents).toStrictEqual(1000 - i);
+      await queue.waitForEvent(neverAbort);
+      expect(queue.countOutstandingEvents).toStrictEqual(1000 - i - 1);
+    }
+  });
+
+  test('does not allow concurrent waits', async () => {
+    const queue = new EventQueue<number>();
+    queue.waitForEvent(neverAbort);
+    expect(() => queue.waitForEvent(neverAbort)).rejects.toThrow();
+  });
+
+  describe('queueBasedAsyncIterable', () => {
+    test('generates a new queue for listener', () => {
+      let createdQueues = 0;
+      const iterable = EventQueue.queueBasedAsyncIterable((queue) => {
+        createdQueues++;
+      });
+
+      for (let i = 0; i < 1000; i++) {
+        iterable[Symbol.asyncIterator]();
+      }
+
+      expect(createdQueues).toStrictEqual(1000);
+    });
+
+    test('delivers events pushed by run callback', async () => {
+      const iterable = EventQueue.queueBasedAsyncIterable<number>((queue) => {
+        queue.notify(1);
+        queue.notify(2);
+        queue.notify(3);
+      });
+
+      const iterator = iterable[Symbol.asyncIterator]();
+      expect(await iterator.next()).toStrictEqual({ done: false, value: 1 });
+      expect(await iterator.next()).toStrictEqual({ done: false, value: 2 });
+      expect(await iterator.next()).toStrictEqual({ done: false, value: 3 });
+    });
+
+    test('return() aborts the signal passed to run', async () => {
+      let capturedSignal!: AbortSignal;
+
+      const iterable = EventQueue.queueBasedAsyncIterable<number>((queue, signal) => {
+        capturedSignal = signal;
+      });
+
+      const iterator = iterable[Symbol.asyncIterator]();
+      expect(capturedSignal.aborted).toBe(false);
+
+      await iterator.return!();
+
+      expect(capturedSignal.aborted).toBe(true);
+    });
+
+    test('breaking out of for-await-of aborts the run signal', async () => {
+      let capturedSignal!: AbortSignal;
+
+      const iterable = EventQueue.queueBasedAsyncIterable<number>((queue, signal) => {
+        capturedSignal = signal;
+        queue.notify(1);
+      });
+
+      for await (const _ of iterable) {
+        break;
+      }
+
+      expect(capturedSignal.aborted).toBe(true);
+    });
+
+    test('external abort signal stops the iteration', async () => {
+      const externalAbort = new AbortController();
+
+      const iterable = EventQueue.queueBasedAsyncIterable<number>(() => {
+        // no events pushed — iterator would block indefinitely without the abort
+      }, externalAbort.signal);
+
+      const iterator = iterable[Symbol.asyncIterator]();
+      const nextPromise = iterator.next();
+
+      externalAbort.abort();
+
+      expect(await nextPromise).toStrictEqual({ done: true, value: undefined });
+    });
+
+    test('pre-aborted external signal ends iteration immediately', async () => {
+      const iterable = EventQueue.queueBasedAsyncIterable<number>((queue) => {
+        queue.notify(1);
+      }, AbortSignal.abort());
+
+      const iterator = iterable[Symbol.asyncIterator]();
+      expect(await iterator.next()).toStrictEqual({ done: true, value: undefined });
+    });
+
+    test('external abort also aborts the run signal', async () => {
+      let capturedSignal!: AbortSignal;
+      const externalAbort = new AbortController();
+
+      const iterable = EventQueue.queueBasedAsyncIterable<number>((queue, signal) => {
+        capturedSignal = signal;
+      }, externalAbort.signal);
+
+      iterable[Symbol.asyncIterator]();
+      expect(capturedSignal.aborted).toBe(false);
+
+      externalAbort.abort();
+
+      expect(capturedSignal.aborted).toBe(true);
+    });
   });
 });

--- a/packages/common/tests/utils/async.test.ts
+++ b/packages/common/tests/utils/async.test.ts
@@ -71,7 +71,33 @@ describe('event queue', () => {
   test('does not allow concurrent waits', async () => {
     const queue = new EventQueue<number>();
     queue.waitForEvent(neverAbort);
-    expect(() => queue.waitForEvent(neverAbort)).rejects.toThrow();
+    await expect(() => queue.waitForEvent(neverAbort)).rejects.toThrow();
+  });
+
+  test('calls eventDelivered after dispatching to a waiting consumer', async () => {
+    let deliveredCount = 0;
+    const queue = new EventQueue<number>({ eventDelivered: () => deliveredCount++ });
+
+    const waiter = queue.waitForEvent(neverAbort);
+    queue.notify(42);
+    await waiter;
+
+    expect(deliveredCount).toBe(1);
+  });
+
+  test('calls eventDelivered after dispatching a buffered event', async () => {
+    let deliveredCount = 0;
+    const queue = new EventQueue<number>({ eventDelivered: () => deliveredCount++ });
+
+    queue.notify(1);
+    queue.notify(2);
+    expect(deliveredCount).toBe(0); // not called until consumed
+
+    await queue.waitForEvent(neverAbort);
+    expect(deliveredCount).toBe(1);
+
+    await queue.waitForEvent(neverAbort);
+    expect(deliveredCount).toBe(2);
   });
 
   describe('queueBasedAsyncIterable', () => {

--- a/packages/node/tests/PowerSyncDatabase.test.ts
+++ b/packages/node/tests/PowerSyncDatabase.test.ts
@@ -1,9 +1,9 @@
 import * as path from 'node:path';
 import { Worker } from 'node:worker_threads';
 
-import { LockContext, Schema } from '@powersync/common';
+import { LockContext, QueryResult, Schema, WatchOnChangeEvent } from '@powersync/common';
 import { randomUUID } from 'node:crypto';
-import { expect, test, vi } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { CrudEntry, CrudTransaction, PowerSyncDatabase } from '../lib/index.js';
 import { WorkerOpener } from '../src/db/options.js';
 import { AppSchema, databaseTest, tempDirectoryTest } from './utils.js';
@@ -246,6 +246,110 @@ databaseTest('clear raw tables', async ({ database }) => {
   expect(await database.getAll('SELECT * FROM lists')).toHaveLength(1);
   await database.disconnectAndClear();
   expect(await database.getAll('SELECT * FROM lists')).toHaveLength(0);
+});
+
+describe('onChangeWithAsyncGenerator', () => {
+  databaseTest('receives change events', async ({ database }) => {
+    const changes: WatchOnChangeEvent[] = [];
+    const abort = new AbortController();
+
+    const iterating = (async () => {
+      for await (const event of database.onChangeWithAsyncGenerator({
+        tables: ['todos'],
+        throttleMs: 0,
+        signal: abort.signal
+      })) {
+        changes.push(event);
+      }
+    })();
+
+    await database.execute('INSERT INTO todos (id, content) VALUES (uuid(), ?)', ['first']);
+    await expect.poll(() => changes).toHaveLength(1);
+    expect(changes[0].changedTables).toContain('ps_data__todos');
+
+    await database.execute('INSERT INTO todos (id, content) VALUES (uuid(), ?)', ['second']);
+    await expect.poll(() => changes).toHaveLength(2);
+
+    abort.abort();
+    await iterating;
+  });
+
+  databaseTest('clears listeners after break', async ({ database }) => {
+    await database.init();
+    expect((database.database as any).listeners).toHaveLength(1);
+
+    const first = (async () => {
+      for await (const event of database.onChangeWithAsyncGenerator({ tables: ['todos'], throttleMs: 0 })) {
+        return event;
+      }
+
+      throw new Error('Expected event');
+    })();
+
+    // Added listener for onChange
+    expect((database.database as any).listeners).toHaveLength(2);
+    await database.execute('INSERT INTO todos (id, content) VALUES (uuid(), ?)', ['first']);
+    await first;
+
+    // Removed listener after aborting.
+    await Promise.resolve();
+    expect((database.database as any).listeners).toHaveLength(1);
+  });
+});
+
+describe('watchWithAsyncGenerator', () => {
+  databaseTest('yields initial result and updates', async ({ database }) => {
+    const results: QueryResult[] = [];
+    const abort = new AbortController();
+
+    const iterating = (async () => {
+      for await (const result of database.watchWithAsyncGenerator('SELECT * FROM todos', [], {
+        throttleMs: 0,
+        signal: abort.signal
+      })) {
+        results.push(result);
+      }
+    })();
+
+    await expect.poll(() => results).toHaveLength(1);
+    expect(results[0].rows?.length).toBe(0);
+
+    await database.execute('INSERT INTO todos (id, content) VALUES (uuid(), ?)', ['first']);
+    await expect.poll(() => results).toHaveLength(2);
+    expect(results[1].rows?.length).toBe(1);
+
+    abort.abort();
+    await iterating;
+  });
+
+  databaseTest('stops delivering results after break', async ({ database }) => {
+    await database.init();
+    expect((database.database as any).listeners).toHaveLength(1);
+
+    const event = (async () => {
+      let isFirst = true;
+
+      for await (const event of database.watchWithAsyncGenerator('SELECT * FROM todos', [], { throttleMs: 0 })) {
+        if (isFirst) {
+          isFirst = false;
+          continue;
+        }
+
+        return event;
+      }
+
+      throw new Error('Expected two events');
+    })();
+
+    // Added listener for onChange
+    await expect.poll(() => (database.database as any).listeners).toHaveLength(2);
+    await database.execute('INSERT INTO todos (id, content) VALUES (uuid(), ?)', ['first']);
+    await event;
+
+    // Removed listener after returning.
+    await Promise.resolve();
+    expect((database.database as any).listeners).toHaveLength(1);
+  });
 });
 
 databaseTest('execute batch', async ({ database }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,9 +407,6 @@ importers:
 
   packages/common:
     dependencies:
-      event-iterator:
-        specifier: ^2.0.0
-        version: 2.0.0
       js-logger:
         specifier: 'catalog:'
         version: 1.6.1
@@ -10793,9 +10790,6 @@ packages:
   eval@0.1.8:
     resolution: {integrity: sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==}
     engines: {node: '>= 0.8'}
-
-  event-iterator@2.0.0:
-    resolution: {integrity: sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ==}
 
   event-pubsub@4.3.0:
     resolution: {integrity: sha512-z7IyloorXvKbFx9Bpie2+vMJKKx1fH1EN5yiTfp8CiLOTptSYy1g8H4yDpGlEdshL1PBiFtBHepF2cNsqeEeFQ==}
@@ -31222,8 +31216,6 @@ snapshots:
     dependencies:
       '@types/node': 25.9.1
       require-like: 0.1.2
-
-  event-iterator@2.0.0: {}
 
   event-pubsub@4.3.0: {}
 


### PR DESCRIPTION
I'm looking at ways to reduce build complexity in the JS SDK, and getting rid of rollup to make `tsc` output the only thing we ship would help a lot. Currently, `@powersync/common` has two good reasons to apply rollup:

1. We want to bundle RSocket dependencies.
2. For compatibility with older React Native / Hermes versions, we want to replace `Symbol.asyncIterator` references with a ponyfill.

I'll look at 1 in another PR to the `v2` branch, but 2 is something we can fix without a breaking change. `event-iterator` is the only dependency using `Symbol.asyncIterator`, so we can rewrite our usages with a custom implementation of it. The package is essentially a bridge between `onEvent` callbacks and async iterators, and we already had most of that in the existing `asyncNotifier` utility.

So, this:

1. Expands `asyncNotifier` into a `EventQueue` implementation allowing more than a single outstanding event.
2. Refactors `onChangeWithAsyncGenerator` and `watchWithAsyncGenerator` to be based on the `EventQueue` utility. This actually fixes a bug, breaking out of an async iterator would not have cleaned up the inner listener before.
3. Refactors the RSocket client to use that as well. The interface is slightly simpler here, we don't need to worry about `AsyncIterator.return()`.

Disclosure: Most added tests were generated with Claude Code, I manually tweaked and verified them. I smoke-tested the RSocket client with the Node.js demo since it's not covered by automated tests.