### PR TITLE
Remove data flow status to align `SyncStatus` interface with other SDKs

### DIFF
--- a/.changeset/funny-deers-explode.md
+++ b/.changeset/funny-deers-explode.md
@@ -15,4 +15,4 @@ Rename `AbstractPowerSyncDatabase` to `CommonPowerSyncDatabase`, make it a TypeS
 
 `SyncStatus` is no longer constructable in user code.
 
-Remove `DataFlowStatus.downloading`. Use `SyncStatus.downloading` instead.
+Deprecate `DataFlowStatus`. Use fields on `SyncStatus` directly instead.

--- a/demos/example-nextjs/src/components/StatusPanel.tsx
+++ b/demos/example-nextjs/src/components/StatusPanel.tsx
@@ -39,8 +39,7 @@ function ArrowDown() {
 
 export function StatusPanel() {
   const status = useStatus();
-  const { connected, hasSynced, downloading, dataFlowStatus } = status;
-  const { uploading, uploadError, downloadError } = dataFlowStatus;
+  const { connected, hasSynced, downloading, uploading, uploadError, downloadError } = status;
 
   let label = 'Connecting…';
   let chipColor: keyof typeof chipStyles = 'warning';

--- a/demos/react-multi-client/src/components/UserComponent.tsx
+++ b/demos/react-multi-client/src/components/UserComponent.tsx
@@ -201,12 +201,12 @@ export const UserComponent: React.FC<UserComponentProps> = (props) => {
   const className = useMemo(() => {
     return [
       status.downloading ? DOWNLOADING_CSS_CLASS : '',
-      status.dataFlowStatus.uploading ? UPLOADING_CSS_CLASS : '',
+      status.uploading ? UPLOADING_CSS_CLASS : '',
       showOnline ? TOGGLE_ONLINE_CSS_CLASS : ''
     ]
       .join(' ')
       .trim();
-  }, [status.downloading, status.dataFlowStatus.uploading, showOnline]);
+  }, [status.downloading, status.uploading, showOnline]);
 
   return (
     <div className={className}>

--- a/demos/react-native-supabase-background-sync/app/(tabs)/index.tsx
+++ b/demos/react-native-supabase-background-sync/app/(tabs)/index.tsx
@@ -2,12 +2,12 @@ import { initializeBackgroundTask } from '@/library/utils';
 import { LIST_TABLE, ListRecord } from '@/powersync/AppSchema';
 import { useSystem } from '@/powersync/SystemContext';
 import { useQuery, useStatus } from '@powersync/react-native';
-import * as TaskManager from "expo-task-manager";
+import * as TaskManager from 'expo-task-manager';
 import React, { useEffect } from 'react';
 import { FlatList, SafeAreaView, Text, View } from 'react-native';
 
 TaskManager.getRegisteredTasksAsync().then((tasks) => {
-  console.log("Number of tasks registered:", tasks.length);
+  console.log('Number of tasks registered:', tasks.length);
 });
 
 // Declare a variable to store the resolver function
@@ -42,59 +42,64 @@ export default function HomeScreen() {
   return (
     <SafeAreaView style={{ flex: 1 }}>
       <View style={{ flex: 1, padding: 20 }}>
-        <Text style={{ fontSize: 24, fontWeight: 'bold', marginBottom: 20 }}>
-          Lists
-        </Text>
+        <Text style={{ fontSize: 24, fontWeight: 'bold', marginBottom: 20 }}>Lists</Text>
 
         {/* Sync Progress Indicator */}
-        {status.dataFlowStatus?.downloading && downloadProgress && (
-          <View style={{
-            marginBottom: 20,
-            padding: 15,
-            backgroundColor: '#e3f2fd',
-            borderRadius: 8,
-            borderWidth: 1,
-            borderColor: '#2196f3'
-          }}>
-            <Text style={{
-              fontSize: 16,
-              fontWeight: 'bold',
-              color: '#1976d2',
-              marginBottom: 5
+        {status?.downloading && downloadProgress && (
+          <View
+            style={{
+              marginBottom: 20,
+              padding: 15,
+              backgroundColor: '#e3f2fd',
+              borderRadius: 8,
+              borderWidth: 1,
+              borderColor: '#2196f3'
             }}>
+            <Text
+              style={{
+                fontSize: 16,
+                fontWeight: 'bold',
+                color: '#1976d2',
+                marginBottom: 5
+              }}>
               Syncing...
             </Text>
-            <Text style={{
-              fontSize: 14,
-              color: '#1976d2'
-            }}>
+            <Text
+              style={{
+                fontSize: 14,
+                color: '#1976d2'
+              }}>
               {syncPercentage !== null ? `${syncPercentage}% complete` : 'Syncing...'}
             </Text>
             {downloadProgress && (
-              <Text style={{
-                fontSize: 12,
-                color: '#1976d2',
-                marginTop: 2
-              }}>
+              <Text
+                style={{
+                  fontSize: 12,
+                  color: '#1976d2',
+                  marginTop: 2
+                }}>
                 Downloaded {downloadProgress.downloadedOperations} out of {downloadProgress.totalOperations}
               </Text>
             )}
 
             {/* Progress Bar */}
             {downloadProgress && downloadProgress.totalOperations > 0 && (
-              <View style={{
-                marginTop: 10,
-                height: 8,
-                backgroundColor: '#bbdefb',
-                borderRadius: 4,
-                overflow: 'hidden'
-              }}>
-                <View style={{
-                  height: '100%',
-                  backgroundColor: '#2196f3',
-                  width: `${(downloadProgress.downloadedOperations / downloadProgress.totalOperations) * 100}%`,
-                  borderRadius: 4
-                }} />
+              <View
+                style={{
+                  marginTop: 10,
+                  height: 8,
+                  backgroundColor: '#bbdefb',
+                  borderRadius: 4,
+                  overflow: 'hidden'
+                }}>
+                <View
+                  style={{
+                    height: '100%',
+                    backgroundColor: '#2196f3',
+                    width: `${(downloadProgress.downloadedOperations / downloadProgress.totalOperations) * 100}%`,
+                    borderRadius: 4
+                  }}
+                />
               </View>
             )}
           </View>
@@ -103,21 +108,18 @@ export default function HomeScreen() {
         <FlatList
           data={listRecords}
           keyExtractor={(item) => item.id}
-          ListEmptyComponent={
-            <Text style={{ color: '#999', fontStyle: 'italic' }}>No lists found</Text>
-          }
+          ListEmptyComponent={<Text style={{ color: '#999', fontStyle: 'italic' }}>No lists found</Text>}
           renderItem={({ item: list }) => (
-            <View style={{
-              marginBottom: 20,
-              borderWidth: 1,
-              borderColor: '#ccc',
-              borderRadius: 8,
-              padding: 15,
-              backgroundColor: '#f9f9f9'
-            }}>
-              <Text style={{ fontSize: 18, fontWeight: 'bold', color: '#333' }}>
-                {list.name}
-              </Text>
+            <View
+              style={{
+                marginBottom: 20,
+                borderWidth: 1,
+                borderColor: '#ccc',
+                borderRadius: 8,
+                padding: 15,
+                backgroundColor: '#f9f9f9'
+              }}>
+              <Text style={{ fontSize: 18, fontWeight: 'bold', color: '#333' }}>{list.name}</Text>
             </View>
           )}
         />

--- a/demos/react-native-supabase-background-sync/library/utils.ts
+++ b/demos/react-native-supabase-background-sync/library/utils.ts
@@ -1,10 +1,10 @@
-import { LIST_TABLE } from "@/powersync/AppSchema";
-import * as BackgroundTask from "expo-background-task";
-import * as TaskManager from "expo-task-manager";
-import { AppState } from "react-native";
-import { system } from "@/powersync/SystemContext";
+import { LIST_TABLE } from '@/powersync/AppSchema';
+import * as BackgroundTask from 'expo-background-task';
+import * as TaskManager from 'expo-task-manager';
+import { AppState } from 'react-native';
+import { system } from '@/powersync/SystemContext';
 
-const BACKGROUND_SYNC_TASK = "background-powersync-task";
+const BACKGROUND_SYNC_TASK = 'background-powersync-task';
 const MINIMUM_INTERVAL = 15; // Run this task every 15 minutes
 
 TaskManager.defineTask(BACKGROUND_SYNC_TASK, async () => {
@@ -20,7 +20,7 @@ TaskManager.defineTask(BACKGROUND_SYNC_TASK, async () => {
       [await system.connector.userId()]
     );
 
-    console.log("[Background Task] Initializing PowerSync");
+    console.log('[Background Task] Initializing PowerSync');
 
     // Capture the previous lastSyncedAt BEFORE init so we can detect a sync that
     // completes during this background task run. `lastSyncedAt` is process-scoped
@@ -34,28 +34,25 @@ TaskManager.defineTask(BACKGROUND_SYNC_TASK, async () => {
 
     // Wait for a sync to complete during THIS background task run
     await new Promise<void>((resolve) => {
-      console.log("[Background Task] Waiting for sync to complete");
+      console.log('[Background Task] Waiting for sync to complete');
       const unregister = system.powersync.registerListener({
         statusChanged: (status) => {
           const syncedThisRun =
-            Boolean(status.lastSyncedAt) &&
-            previousSyncAt?.getTime() !== status.lastSyncedAt?.getTime();
-          const downloading = status.dataFlowStatus?.downloading || false;
-          const uploading = status.dataFlowStatus?.uploading || false;
+            Boolean(status.lastSyncedAt) && previousSyncAt?.getTime() !== status.lastSyncedAt?.getTime();
+          const downloading = status?.downloading || false;
+          const uploading = status?.uploading || false;
 
           // Resolve when a fresh sync has completed and no transfers are in flight
           if (syncedThisRun && !downloading && !uploading) {
-            console.log(
-              "[Background Task] Download complete"
-            );
+            console.log('[Background Task] Download complete');
             resolve();
             unregister();
           }
-        },
+        }
       });
     });
   } catch (error) {
-    console.error("[Background Task] Failed to execute the background task:", error);
+    console.error('[Background Task] Failed to execute the background task:', error);
     return BackgroundTask.BackgroundTaskResult.Failed;
   }
   return BackgroundTask.BackgroundTaskResult.Success;
@@ -68,23 +65,23 @@ export const initializeBackgroundTask = async (innerAppMountedPromise: Promise<v
   // Delay registering the task until the inner app is mounted
   await innerAppMountedPromise;
   // This listener will manage task registration and unregistration
-  AppState.addEventListener("change", async (nextAppState) => {
-    console.log("App state changed:", nextAppState);
+  AppState.addEventListener('change', async (nextAppState) => {
+    console.log('App state changed:', nextAppState);
 
-    if (nextAppState === "active") {
+    if (nextAppState === 'active') {
       // App is in the foreground, kill the background task
       const isTaskRegistered = await TaskManager.isTaskRegisteredAsync(BACKGROUND_SYNC_TASK);
       if (isTaskRegistered) {
-        console.log("App is active. Unregistering background task.");
+        console.log('App is active. Unregistering background task.');
         await BackgroundTask.unregisterTaskAsync(BACKGROUND_SYNC_TASK);
       }
-    } else if (nextAppState === "background") {
+    } else if (nextAppState === 'background') {
       // App is in the background, register the task to run
       const isTaskRegistered = await TaskManager.isTaskRegisteredAsync(BACKGROUND_SYNC_TASK);
       if (!isTaskRegistered) {
-        console.log("App is in background. Registering background task.");
+        console.log('App is in background. Registering background task.');
         await BackgroundTask.registerTaskAsync(BACKGROUND_SYNC_TASK, {
-          minimumInterval: MINIMUM_INTERVAL,
+          minimumInterval: MINIMUM_INTERVAL
         });
       }
     }
@@ -92,12 +89,12 @@ export const initializeBackgroundTask = async (innerAppMountedPromise: Promise<v
 
   // Run an initial check in case the app starts in the background (e.g., from a deep link)
   const initialAppState = AppState.currentState;
-  if (initialAppState === "background") {
+  if (initialAppState === 'background') {
     (async () => {
       const isTaskRegistered = await TaskManager.isTaskRegisteredAsync(BACKGROUND_SYNC_TASK);
       if (!isTaskRegistered) {
         await BackgroundTask.registerTaskAsync(BACKGROUND_SYNC_TASK, {
-          minimumInterval: MINIMUM_INTERVAL,
+          minimumInterval: MINIMUM_INTERVAL
         });
       }
     })();

--- a/demos/react-native-supabase-background-sync/powersync/SystemContext.ts
+++ b/demos/react-native-supabase-background-sync/powersync/SystemContext.ts
@@ -36,8 +36,8 @@ export class System {
     this.powersync.registerListener({
       statusChanged: (status) => {
         const hasSynced = Boolean(status.lastSyncedAt);
-        const downloading = status.dataFlowStatus?.downloading || false;
-        const uploading = status.dataFlowStatus?.uploading || false;
+        const downloading = status?.downloading || false;
+        const uploading = status?.uploading || false;
         console.log(
           '[PowerSync] Status changed:',
           hasSynced ? '✅ Synced' : '⏳ Not yet synced',

--- a/demos/react-supabase-time-based-sync/src/app/views/layout.tsx
+++ b/demos/react-supabase-time-based-sync/src/app/views/layout.tsx
@@ -73,8 +73,8 @@ export default function ViewsLayout({ children }: { children: React.ReactNode })
           <Box sx={{ flexGrow: 1 }}>
             <Typography>{title}</Typography>
           </Box>
-          <NorthIcon sx={{ marginRight: '-10px' }} color={status?.dataFlowStatus.uploading ? 'primary' : 'inherit'} />
-          <SouthIcon color={status?.dataFlowStatus.downloading ? 'primary' : 'inherit'} />
+          <NorthIcon sx={{ marginRight: '-10px' }} color={status?.uploading ? 'primary' : 'inherit'} />
+          <SouthIcon color={status?.downloading ? 'primary' : 'inherit'} />
           <Box
             sx={{ cursor: 'pointer' }}
             onClick={(event) => {

--- a/demos/react-supabase-todolist-optional-sync/src/app/views/layout.tsx
+++ b/demos/react-supabase-todolist-optional-sync/src/app/views/layout.tsx
@@ -99,8 +99,8 @@ export default function ViewsLayout({ children }: { children: React.ReactNode })
           <Box sx={{ flexGrow: 1 }}>
             <Typography>{title}</Typography>
           </Box>
-          <NorthIcon sx={{ marginRight: '-10px' }} color={status?.dataFlowStatus.uploading ? 'primary' : 'inherit'} />
-          <SouthIcon color={status?.dataFlowStatus.downloading ? 'primary' : 'inherit'} />
+          <NorthIcon sx={{ marginRight: '-10px' }} color={status?.uploading ? 'primary' : 'inherit'} />
+          <SouthIcon color={status?.downloading ? 'primary' : 'inherit'} />
           {status?.connected ? <WifiIcon /> : <SignalWifiOffIcon />}
         </Toolbar>
       </S.TopBar>

--- a/demos/react-supabase-todolist-sync-streams/src/app/views/layout.tsx
+++ b/demos/react-supabase-todolist-sync-streams/src/app/views/layout.tsx
@@ -82,8 +82,8 @@ export default function ViewsLayout({ children }: { children: React.ReactNode })
           <Box sx={{ flexGrow: 1 }}>
             <Typography>{title}</Typography>
           </Box>
-          <NorthIcon sx={{ marginRight: '-10px' }} color={status?.dataFlowStatus.uploading ? 'primary' : 'inherit'} />
-          <SouthIcon color={status?.dataFlowStatus.downloading ? 'primary' : 'inherit'} />
+          <NorthIcon sx={{ marginRight: '-10px' }} color={status?.uploading ? 'primary' : 'inherit'} />
+          <SouthIcon color={status?.downloading ? 'primary' : 'inherit'} />
           <Box
             sx={{ cursor: 'pointer' }}
             onClick={(event) => {

--- a/demos/react-supabase-todolist-tanstackdb/src/app/views/layout.tsx
+++ b/demos/react-supabase-todolist-tanstackdb/src/app/views/layout.tsx
@@ -82,8 +82,8 @@ export default function ViewsLayout({ children }: { children: React.ReactNode })
           <Box sx={{ flexGrow: 1 }}>
             <Typography>{title}</Typography>
           </Box>
-          <NorthIcon sx={{ marginRight: '-10px' }} color={status?.dataFlowStatus.uploading ? 'primary' : 'inherit'} />
-          <SouthIcon color={status?.dataFlowStatus.downloading ? 'primary' : 'inherit'} />
+          <NorthIcon sx={{ marginRight: '-10px' }} color={status?.uploading ? 'primary' : 'inherit'} />
+          <SouthIcon color={status?.downloading ? 'primary' : 'inherit'} />
           <Box
             sx={{ cursor: 'pointer' }}
             onClick={(event) => {

--- a/demos/react-supabase-todolist/src/app/views/layout.tsx
+++ b/demos/react-supabase-todolist/src/app/views/layout.tsx
@@ -82,8 +82,8 @@ export default function ViewsLayout({ children }: { children: React.ReactNode })
           <Box sx={{ flexGrow: 1 }}>
             <Typography>{title}</Typography>
           </Box>
-          <NorthIcon sx={{ marginRight: '-10px' }} color={status?.dataFlowStatus.uploading ? 'primary' : 'inherit'} />
-          <SouthIcon color={status?.dataFlowStatus.downloading ? 'primary' : 'inherit'} />
+          <NorthIcon sx={{ marginRight: '-10px' }} color={status?.uploading ? 'primary' : 'inherit'} />
+          <SouthIcon color={status?.downloading ? 'primary' : 'inherit'} />
           <Box
             sx={{ cursor: 'pointer' }}
             onClick={(event) => {

--- a/demos/vue-supabase-todolist/src/views/layouts/Layout.vue
+++ b/demos/vue-supabase-todolist/src/views/layouts/Layout.vue
@@ -5,12 +5,12 @@
     <v-spacer />
     <div class="d-flex">
       <v-icon
-        :color="syncStatus.dataFlowStatus.uploading ? 'primary' : 'inherit'"
+        :color="syncStatus.uploading ? 'primary' : 'inherit'"
         class="mr-n2 pa-0"
         icon="mdi-arrow-up"
       />
 
-      <v-icon :color="syncStatus.dataFlowStatus.downloading ? 'primary' : 'inherit'" icon="mdi-arrow-down" />
+      <v-icon :color="syncStatus.downloading ? 'primary' : 'inherit'" icon="mdi-arrow-down" />
       <v-icon :icon="syncStatus.connected ? 'mdi-wifi' : 'mdi-wifi-strength-off'" />
     </div>
   </v-app-bar>

--- a/packages/common/etc/common.api.md
+++ b/packages/common/etc/common.api.md
@@ -776,7 +776,7 @@ export interface PowerSyncDBListener extends BaseListener {
     // (undocumented)
     schemaChanged: (schema: Schema) => void;
     // (undocumented)
-    statusChanged?: ((status: SyncStatus) => void) | undefined;
+    statusChanged?: (status: SyncStatus) => void;
 }
 
 // @public
@@ -927,12 +927,15 @@ export interface StandardWatchedQueryOptions<RowType> extends WatchedQueryOption
 // @public (undocumented)
 export type StreamingSyncRequestParameterType = JSONValue;
 
-// @public (undocumented)
-export type SyncDataFlowStatus = Partial<{
-    uploading: boolean;
+// @public @deprecated (undocumented)
+export interface SyncDataFlowStatus {
     downloadError?: Error;
+    // (undocumented)
+    downloading: boolean;
     uploadError?: Error;
-}>;
+    // (undocumented)
+    uploading: boolean;
+}
 
 // @public
 export interface SyncOptions {
@@ -965,7 +968,9 @@ export interface SyncProgress extends ProgressWithOperations {
 export interface SyncStatus {
     get connected(): boolean;
     get connecting(): boolean;
+    // @deprecated (undocumented)
     get dataFlowStatus(): SyncDataFlowStatus;
+    get downloadError(): Error | undefined;
     get downloading(): boolean;
     get downloadProgress(): SyncProgress | null;
     forStream(stream: SyncStreamDescription): SyncStreamStatus | undefined;
@@ -976,6 +981,8 @@ export interface SyncStatus {
     get priorityStatusEntries(): SyncPriorityStatus[] | undefined;
     statusForPriority(priority: number): SyncPriorityStatus | undefined;
     get syncStreams(): SyncStreamStatus[] | undefined;
+    get uploadError(): Error | undefined;
+    get uploading(): boolean;
 }
 
 // @public

--- a/packages/common/src/client/CommonPowerSyncDatabase.ts
+++ b/packages/common/src/client/CommonPowerSyncDatabase.ts
@@ -102,7 +102,7 @@ export interface WatchOnChangeHandler {
 export interface PowerSyncDBListener extends BaseListener {
   initialized: () => void;
   schemaChanged: (schema: Schema) => void;
-  statusChanged?: ((status: SyncStatus) => void) | undefined;
+  statusChanged?: (status: SyncStatus) => void;
   closing: () => Promise<void> | void;
   closed: () => Promise<void> | void;
 }

--- a/packages/common/src/db/crud/SyncStatus.ts
+++ b/packages/common/src/db/crud/SyncStatus.ts
@@ -3,11 +3,10 @@ import { ProgressWithOperations, SyncProgress } from './SyncProgress.js';
 
 /**
  * @public
+ * @deprecated All fields are available on {@link SyncStatus} directly.
  */
-export type SyncDataFlowStatus = Partial<{
-  /**
-   * true if uploading changes.
-   */
+export interface SyncDataFlowStatus {
+  downloading: boolean;
   uploading: boolean;
   /**
    * Error during downloading (including connecting).
@@ -20,7 +19,7 @@ export type SyncDataFlowStatus = Partial<{
    * Cleared on the next successful upload.
    */
   uploadError?: Error;
-}>;
+}
 
 /**
  * @public
@@ -55,6 +54,30 @@ export interface SyncStatus {
   get downloading(): boolean;
 
   /**
+   * Whether the PowerSync SDK is currently uploading local mutations through the configured
+   * {@link PowerSyncBackendConnector}.
+   */
+  get uploading(): boolean;
+
+  /**
+   * An error that occurred during downloads (including connection establishment errors).
+   *
+   * A download error will be reported on all sync status entries until the next successful sync.
+   */
+  get downloadError(): Error | undefined;
+
+  /**
+   * Error during uploading.
+   * Cleared on the next successful upload.
+   */
+  get uploadError(): Error | undefined;
+
+  /**
+   * @deprecated All fields on {@link SyncDataFlowStatus} are available on {@link SyncStatus} directly.
+   */
+  get dataFlowStatus(): SyncDataFlowStatus;
+
+  /**
    * Time that a last sync has fully completed, if any.
    * This timestamp is reset to null after a restart of the PowerSync service.
    *
@@ -69,16 +92,6 @@ export interface SyncStatus {
    * or undefined when the state is still being loaded from the database.
    */
   get hasSynced(): boolean | undefined;
-
-  /**
-   * Provides the current data flow status regarding uploads and downloads.
-   *
-   * @returns An object containing:
-   * - downloading: True if actively downloading changes (only when connected is also true)
-   * - uploading: True if actively uploading changes
-   * Defaults to `{downloading: false, uploading: false}` if not specified.
-   */
-  get dataFlowStatus(): SyncDataFlowStatus;
 
   /**
    * All sync streams currently being tracked in teh database.
@@ -105,7 +118,7 @@ export interface SyncStatus {
    * A realtime progress report on how many operations have been downloaded and
    * how many are necessary in total to complete the next sync iteration.
    *
-   * This field is only set when {@link SyncDataFlowStatus#downloading} is also true.
+   * This field is only set when {@link SyncStatus#downloading} is also true.
    */
   get downloadProgress(): SyncProgress | null;
 

--- a/packages/node/tests/sync.test.ts
+++ b/packages/node/tests/sync.test.ts
@@ -169,7 +169,7 @@ function defineSyncTests(bson: boolean) {
     const database = await syncService.createDatabase();
     database.registerListener({
       statusChanged(status) {
-        expect(status.dataFlowStatus.uploading).toBeFalsy();
+        expect(status.uploading).toBeFalsy();
       }
     });
 
@@ -557,7 +557,7 @@ function defineSyncTests(bson: boolean) {
 
     const connector = new TestConnector();
     database.connect(connector, { ...options, retryDelayMs: 10_000, crudUploadThrottleMs: 100 });
-    await database.waitForStatus((s) => s.dataFlowStatus.downloadError != null);
+    await database.waitForStatus((s) => s.downloadError != null);
 
     // We'll never connect due to the error, but we should still try to upload once.
     expect(connector.uploadDataInvocations).toStrictEqual(1);
@@ -593,11 +593,11 @@ function defineSyncTests(bson: boolean) {
       },
       { ...options, retryDelayMs: 100, crudUploadThrottleMs: 100 }
     );
-    await database.waitForStatus((s) => s.dataFlowStatus.downloadError != null);
+    await database.waitForStatus((s) => s.downloadError != null);
 
     // Because we start a crud upload on connect, there should have been a call.
     expect(attemptedUploads).toStrictEqual(1);
-    expect(database.currentStatus.dataFlowStatus.uploadError).toMatchObject({ name: 'Error' });
+    expect(database.currentStatus.uploadError).toMatchObject({ name: 'Error' });
 
     // Currently, we don't retry crud uploads if we're not connected. We might revisit that in the future, but either
     // way we definitely want to retry if there's a new CRUD entry.
@@ -1048,8 +1048,8 @@ async function waitForProgress(
   forPriorities: [number, [number, number]][] = []
 ) {
   await waitForSyncStatus(database, (status) => {
-    if (status.dataFlowStatus.downloadError != null) {
-      throw `Unexpected sync error: ${status.dataFlowStatus.downloadError}`;
+    if (status.downloadError != null) {
+      throw `Unexpected sync error: ${status.downloadError}`;
     }
 
     const progress = status.downloadProgress;

--- a/packages/nuxt/src/runtime/components/SyncStatusTab.vue
+++ b/packages/nuxt/src/runtime/components/SyncStatusTab.vue
@@ -54,7 +54,7 @@
           <div flex="~ col gap-2">
             <span text="sm gray-500">Upload Progress</span>
             <div flex="~ items-center gap-2">
-              <span v-if="syncStatus?.dataFlowStatus.uploading">upload in progress...</span>
+              <span v-if="syncStatus?.uploading">upload in progress...</span>
               <span v-else text="sm gray-400">No active upload</span>
             </div>
           </div>

--- a/packages/nuxt/src/runtime/composables/usePowerSyncInspectorDiagnostics.ts
+++ b/packages/nuxt/src/runtime/composables/usePowerSyncInspectorDiagnostics.ts
@@ -249,10 +249,10 @@ export function usePowerSyncInspectorDiagnostics(): UsePowerSyncInspectorDiagnos
   const isConnected = ref(syncStatus.value?.connected || false);
   const isSyncing = ref(false);
   const isDownloading = ref(syncStatus.value?.downloading || false);
-  const isUploading = ref(syncStatus.value?.dataFlowStatus.uploading || false);
+  const isUploading = ref(syncStatus.value?.uploading || false);
   const lastSyncedAt = ref<Date | null>(syncStatus.value?.lastSyncedAt || null);
-  const uploadError = ref(syncStatus.value?.dataFlowStatus.uploadError || null);
-  const downloadError = ref(syncStatus.value?.dataFlowStatus.downloadError || null);
+  const uploadError = ref(syncStatus.value?.uploadError || null);
+  const downloadError = ref(syncStatus.value?.downloadError || null);
   const downloadProgressDetails = ref(syncStatus.value?.downloadProgress || null);
   const bucketRows = ref<null | BucketRow[]>(null);
   const tableRows = ref<null | TableRow[]>(null);
@@ -344,10 +344,10 @@ export function usePowerSyncInspectorDiagnostics(): UsePowerSyncInspectorDiagnos
         hasSynced.value = !!newStatus.hasSynced;
         isConnected.value = !!newStatus.connected;
         isDownloading.value = !!newStatus.downloading;
-        isUploading.value = !!newStatus.dataFlowStatus.uploading;
+        isUploading.value = !!newStatus.uploading;
         lastSyncedAt.value = newStatus.lastSyncedAt || null;
-        uploadError.value = newStatus.dataFlowStatus.uploadError || null;
-        downloadError.value = newStatus.dataFlowStatus.downloadError || null;
+        uploadError.value = newStatus.uploadError || null;
+        downloadError.value = newStatus.downloadError || null;
         downloadProgressDetails.value = newStatus.downloadProgress || null;
 
         if (
@@ -357,7 +357,7 @@ export function usePowerSyncInspectorDiagnostics(): UsePowerSyncInspectorDiagnos
           hasSynced.value = newStatus?.priorityStatusEntries.every((entry) => entry.hasSynced) ?? false;
         }
 
-        if (newStatus?.downloading || newStatus?.dataFlowStatus.uploading) {
+        if (newStatus?.downloading || newStatus?.uploading) {
           isSyncing.value = true;
         } else {
           isSyncing.value = false;

--- a/packages/nuxt/tests/composables/usePowerSyncInspectorDiagnostics.test.ts
+++ b/packages/nuxt/tests/composables/usePowerSyncInspectorDiagnostics.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { usePowerSyncInspectorDiagnostics } from '../../src/runtime/composables/usePowerSyncInspectorDiagnostics';
 import { withPowerSyncSetup, openPowerSync } from '../utils';
+import { SyncStatus } from '@powersync/common';
 
 describe('usePowerSyncInspectorDiagnostics', () => {
   let powersync: ReturnType<typeof openPowerSync>;
@@ -15,39 +16,37 @@ describe('usePowerSyncInspectorDiagnostics', () => {
   });
 
   it('should update reactive state when sync status changes', async () => {
-    let statusChangedCallback: ((status: any) => void) | null = null;
-    
+    let statusChangedCallback: ((status: SyncStatus) => void) | undefined;
+
     vi.spyOn(powersync, 'registerListener').mockImplementation((listener) => {
       statusChangedCallback = listener.statusChanged;
       return () => {}; // Return unregister function
     });
-    
+
     const [result] = withPowerSyncSetup(() => usePowerSyncInspectorDiagnostics(), powersync);
-    
+
     await vi.waitFor(
       () => {
         expect(statusChangedCallback).not.toBeNull();
       },
       { timeout: 1000 }
     );
-    
+
     // Simulate status change
     const testDate = new Date();
     if (statusChangedCallback) {
       statusChangedCallback({
         hasSynced: true,
         connected: true,
-        dataFlowStatus: {
-          downloading: false,
-          uploading: false,
-          downloadError: null,
-          uploadError: null,
-          downloadProgress: null
-        },
+        downloading: false,
+        uploading: false,
+        downloadError: undefined,
+        uploadError: undefined,
+        downloadProgress: null,
         lastSyncedAt: testDate
-      });
+      } satisfies Partial<SyncStatus> as SyncStatus);
     }
-    
+
     await vi.waitFor(
       () => {
         expect(result.hasSynced.value).toBe(true);
@@ -64,9 +63,9 @@ describe('usePowerSyncInspectorDiagnostics', () => {
   it('should call refreshState on mount and query database', async () => {
     const getSpy = vi.spyOn(powersync, 'get');
     const getAllSpy = vi.spyOn(powersync, 'getAll');
-    
+
     const [result] = withPowerSyncSetup(() => usePowerSyncInspectorDiagnostics(), powersync);
-    
+
     // Wait for onMounted to execute and refreshState to run
     await vi.waitFor(
       () => {
@@ -75,12 +74,10 @@ describe('usePowerSyncInspectorDiagnostics', () => {
       },
       { timeout: 1000 }
     );
-    
+
     // Verify refreshState was called (it queries synced_at and bucket data)
     const getCalls = getSpy.mock.calls;
-    const hasSyncedAtQuery = getCalls.some(call => 
-      call[0]?.includes('powersync_last_synced_at')
-    );
+    const hasSyncedAtQuery = getCalls.some((call) => call[0]?.includes('powersync_last_synced_at'));
     expect(hasSyncedAtQuery).toBe(true);
   });
 
@@ -88,20 +85,11 @@ describe('usePowerSyncInspectorDiagnostics', () => {
     const diagnosticsDb = openPowerSync(true);
     const [result] = withPowerSyncSetup(() => usePowerSyncInspectorDiagnostics(), diagnosticsDb);
 
-    await vi.waitFor(
-      () => expect(result.uploadQueueStats.value).not.toBeNull(),
-      { timeout: 2000 }
-    );
+    await vi.waitFor(() => expect(result.uploadQueueStats.value).not.toBeNull(), { timeout: 2000 });
 
-    await diagnosticsDb.execute('INSERT INTO lists(id, name) VALUES (?, ?)', [
-      'onchange-test-1',
-      'OnChange',
-    ]);
+    await diagnosticsDb.execute('INSERT INTO lists(id, name) VALUES (?, ?)', ['onchange-test-1', 'OnChange']);
 
-    await vi.waitFor(
-      () => expect(result.uploadQueueCount.value).toBeGreaterThan(0),
-      { timeout: 2000 }
-    );
+    await vi.waitFor(() => expect(result.uploadQueueCount.value).toBeGreaterThan(0), { timeout: 2000 });
   });
 
   it('should compute totals from bucketRows correctly', async () => {
@@ -110,7 +98,7 @@ describe('usePowerSyncInspectorDiagnostics', () => {
     const diagnosticsDb = openPowerSync(true);
     const [result] = withPowerSyncSetup(() => usePowerSyncInspectorDiagnostics(), diagnosticsDb);
 
-    await new Promise(resolve => setTimeout(resolve, 300));
+    await new Promise((resolve) => setTimeout(resolve, 300));
 
     expect(result.totals.value.buckets).toBe(0);
     expect(result.totals.value.row_count).toBe(0);
@@ -121,15 +109,9 @@ describe('usePowerSyncInspectorDiagnostics', () => {
     const diagnosticsDb = openPowerSync(true);
     const [result] = withPowerSyncSetup(() => usePowerSyncInspectorDiagnostics(), diagnosticsDb);
 
-    await vi.waitFor(
-      () => expect(result.uploadQueueStats.value).not.toBeNull(),
-      { timeout: 2000 }
-    );
+    await vi.waitFor(() => expect(result.uploadQueueStats.value).not.toBeNull(), { timeout: 2000 });
 
-    await diagnosticsDb.execute('INSERT INTO lists(id, name) VALUES (?, ?)', [
-      'upload-test-1',
-      'Upload Test',
-    ]);
+    await diagnosticsDb.execute('INSERT INTO lists(id, name) VALUES (?, ?)', ['upload-test-1', 'Upload Test']);
 
     await vi.waitFor(
       () => {
@@ -144,12 +126,10 @@ describe('usePowerSyncInspectorDiagnostics', () => {
   });
 
   it('should handle error when diagnostic schema is not set up', async () => {
-    const getSpy = vi.spyOn(powersync, 'get').mockRejectedValue(
-      new Error('no such table: local_bucket_data')
-    );
-    
+    const getSpy = vi.spyOn(powersync, 'get').mockRejectedValue(new Error('no such table: local_bucket_data'));
+
     const [result] = withPowerSyncSetup(() => usePowerSyncInspectorDiagnostics(), powersync);
-    
+
     await vi.waitFor(
       () => {
         expect(result.isDiagnosticSchemaSetup.value).toBe(false);
@@ -160,7 +140,7 @@ describe('usePowerSyncInspectorDiagnostics', () => {
 
   it('should format bytes correctly', () => {
     const [result] = withPowerSyncSetup(() => usePowerSyncInspectorDiagnostics(), powersync);
-    
+
     expect(result.formatBytes(0)).toBe('0 Bytes');
     expect(result.formatBytes(1024)).toBe('1 KiB');
     expect(result.formatBytes(1024 * 1024)).toBe('1 MiB');

--- a/packages/nuxt/tests/composables/usePowerSyncInspectorDiagnostics.test.ts
+++ b/packages/nuxt/tests/composables/usePowerSyncInspectorDiagnostics.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { usePowerSyncInspectorDiagnostics } from '../../src/runtime/composables/usePowerSyncInspectorDiagnostics';
 import { withPowerSyncSetup, openPowerSync } from '../utils';
-import { SyncStatus } from '@powersync/common';
+import { type SyncStatus } from '@powersync/common';
 
 describe('usePowerSyncInspectorDiagnostics', () => {
   let powersync: ReturnType<typeof openPowerSync>;

--- a/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
+++ b/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
@@ -166,9 +166,9 @@ export abstract class BasePowerSyncDatabase<Options extends BasePowerSyncDatabas
         return this.runExclusive(async () => {
           const sync = this.generateSyncStreamImplementation(connector, options);
           const onDispose = sync.registerListener({
-            statusChanged: (status, dataFlow) => {
-              this.currentStatus = new SyncStatusSnapshot(status, dataFlow);
-              this.iterateListeners((cb) => cb.statusChanged?.(this.currentStatus));
+            statusChanged: (snapshot) => {
+              this.currentStatus = snapshot;
+              this.iterateListeners((cb) => cb.statusChanged?.(snapshot));
             }
           });
           await sync.waitForReady();

--- a/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
+++ b/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
@@ -334,7 +334,7 @@ export abstract class BasePowerSyncDatabase<Options extends BasePowerSyncDatabas
     const result = await this.database.get<{ r: string }>('SELECT powersync_offline_sync_status() as r');
     const parsed = JSON.parse(result.r) as CoreSyncStatus;
 
-    const updatedStatus = new SyncStatusSnapshot(parsed, this.currentStatus.dataFlowStatus);
+    const updatedStatus = new SyncStatusSnapshot(parsed, this.currentStatus.jsState);
 
     if (!updatedStatus.isEqual(this.currentStatus)) {
       this.currentStatus = updatedStatus;

--- a/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -285,7 +285,7 @@ The next upload iteration will be delayed.`
     // Return a promise that resolves when the connection status is updated to indicate that we're connected. We do this
     // by waiting for connecting to be true and then false again.
     return new Promise<void>((resolve) => {
-      var sawStartOfConnection = false;
+      let sawStartOfConnection = false;
 
       const disposer = this.registerListener({
         statusChanged: (snapshot) => {

--- a/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -76,7 +76,7 @@ export interface StreamingSyncImplementationListener extends BaseListener {
   /**
    * Triggers whenever the status' members have changed in value
    */
-  statusChanged?: ((core: CoreSyncStatus | null, jsState: JavaScriptSyncState) => void) | undefined;
+  statusChanged?: ((status: SyncStatusSnapshot) => void) | undefined;
 }
 
 /**
@@ -282,16 +282,23 @@ The next upload iteration will be delayed.`
       this.streamingSync(controller.signal, options)
     ]);
 
-    // Return a promise that resolves when the connection status is updated to indicate that we're connected.
+    // Return a promise that resolves when the connection status is updated to indicate that we're connected. We do this
+    // by waiting for connecting to be true and then false again.
     return new Promise<void>((resolve) => {
+      var sawStartOfConnection = false;
+
       const disposer = this.registerListener({
-        statusChanged: (status, dataFlow) => {
-          if (dataFlow.downloadError != null) {
+        statusChanged: (snapshot) => {
+          if (snapshot.connecting) {
+            sawStartOfConnection = true;
+          }
+
+          if (snapshot.downloadError != null) {
             this.logger.log({
               level: LogLevels.warn,
               message: 'Initial connect attempt did not successfully connect to server'
             });
-          } else if (status && status.connecting) {
+          } else if (!sawStartOfConnection || snapshot.connecting) {
             // Still connecting.
             return;
           }
@@ -740,7 +747,7 @@ The next upload iteration will be delayed.`
     if (!this.syncStatus.isEqual(updated)) {
       this.syncStatus = updated;
       // Only trigger this is there was a change
-      this.iterateListeners((cb) => cb.statusChanged?.(core, updated.jsState));
+      this.iterateListeners((cb) => cb.statusChanged?.(updated));
     }
   }
 

--- a/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -7,7 +7,6 @@ import {
   PowerSyncLogger,
   SyncStreamConnectionMethod,
   SyncStatus,
-  SyncDataFlowStatus,
   BaseObserver
 } from '@powersync/common';
 
@@ -28,7 +27,7 @@ import {
   valueResult
 } from '../../../utils/stream_transform.js';
 import { asyncNotifier } from '../../../utils/async.js';
-import { SyncStatusSnapshot } from '../../../db/crud/SyncStatus.js';
+import { JavaScriptSyncState, SyncStatusJson, SyncStatusSnapshot } from '../../../db/crud/SyncStatus.js';
 import { ResolvedSyncOptions } from '../options.js';
 
 /**
@@ -77,7 +76,7 @@ export interface StreamingSyncImplementationListener extends BaseListener {
   /**
    * Triggers whenever the status' members have changed in value
    */
-  statusChanged?: ((core: CoreSyncStatus | null, dataFlow: SyncDataFlowStatus) => void) | undefined;
+  statusChanged?: ((core: CoreSyncStatus | null, jsState: JavaScriptSyncState) => void) | undefined;
 }
 
 /**
@@ -220,7 +219,7 @@ export abstract class AbstractStreamingSyncImplementation
              */
             const nextCrudItem = await this.options.adapter.nextCrudItem();
             if (nextCrudItem) {
-              this.updateDataFlowStatus({ uploading: true });
+              this.updateJsSyncState({ uploading: true });
 
               if (nextCrudItem.clientId == checkedCrudItem?.clientId) {
                 // This will force a higher log level than exceptions which are caught here.
@@ -236,7 +235,7 @@ The next upload iteration will be delayed.`
 
               checkedCrudItem = nextCrudItem;
               await this.options.uploadCrud();
-              this.updateDataFlowStatus({ uploadError: undefined });
+              this.updateJsSyncState({ uploadError: undefined });
             } else {
               // Uploading is completed
               const neededUpdate = await this.options.adapter.updateLocalTarget(() => this.getWriteCheckpoint());
@@ -250,7 +249,7 @@ The next upload iteration will be delayed.`
             }
           } catch (ex) {
             checkedCrudItem = undefined;
-            this.updateDataFlowStatus({ uploading: false, uploadError: ex as Error });
+            this.updateJsSyncState({ uploading: false, uploadError: ex as Error });
             await this.delayRetry(signal, options.retryDelayMs);
             if (!this.isConnected) {
               // Exit the upload loop if the sync stream is no longer connected
@@ -262,7 +261,7 @@ The next upload iteration will be delayed.`
               error: ex
             });
           } finally {
-            this.updateDataFlowStatus({ uploading: false });
+            this.updateJsSyncState({ uploading: false });
           }
         }
       }
@@ -405,7 +404,7 @@ The next upload iteration will be delayed.`
           this.logger.log({ level: LogLevels.error, message: 'Sync error', error: ex });
         }
 
-        this.updateDataFlowStatus({ downloadError: ex as Error });
+        this.updateJsSyncState({ downloadError: ex as Error });
       } finally {
         this.notifyCompletedUploads = undefined;
 
@@ -646,7 +645,7 @@ The next upload iteration will be delayed.`
       } else if ('FlushFileSystem' in instruction) {
         // Not necessary on JS platforms.
       } else if ('DidCompleteSync' in instruction) {
-        syncImplementation.updateDataFlowStatus({ downloadError: undefined });
+        syncImplementation.updateJsSyncState({ downloadError: undefined });
       }
     }
 
@@ -732,21 +731,21 @@ The next upload iteration will be delayed.`
     return { immediateRestart: hideDisconnectOnRestart };
   }
 
-  protected updateSyncStatus(core: CoreSyncStatus | null, dataFlow?: SyncDataFlowStatus) {
+  protected updateSyncStatus(core: CoreSyncStatus | null, jsState?: JavaScriptSyncState) {
     const updated = new SyncStatusSnapshot(core, {
-      ...this.syncStatus.dataFlowStatus,
-      ...dataFlow
+      ...this.syncStatus.jsState,
+      ...jsState
     });
 
     if (!this.syncStatus.isEqual(updated)) {
       this.syncStatus = updated;
       // Only trigger this is there was a change
-      this.iterateListeners((cb) => cb.statusChanged?.(updated.core, updated.dataFlowStatus));
+      this.iterateListeners((cb) => cb.statusChanged?.(core, updated.jsState));
     }
   }
 
-  protected updateDataFlowStatus(dataFlow: SyncDataFlowStatus) {
-    this.updateSyncStatus(this.syncStatus.core, dataFlow);
+  protected updateJsSyncState(state: JavaScriptSyncState) {
+    this.updateSyncStatus(this.syncStatus.core, state);
   }
 
   private async delayRetry(signal: AbortSignal, delay: number): Promise<void> {

--- a/packages/shared-internals/src/db/crud/SyncStatus.ts
+++ b/packages/shared-internals/src/db/crud/SyncStatus.ts
@@ -164,7 +164,7 @@ export class SyncStatusSnapshot implements SyncStatus {
    * Not all errors are serializable over a MessagePort. E.g. some `DomExceptions` fail to be passed across workers.
    * This explicitly serializes errors in the SyncStatus.
    */
-  protected serializeError(error?: Error) {
+  serializeError(error?: Error) {
     if (typeof error == 'undefined') {
       return undefined;
     }

--- a/packages/shared-internals/src/db/crud/SyncStatus.ts
+++ b/packages/shared-internals/src/db/crud/SyncStatus.ts
@@ -12,18 +12,22 @@ import { SyncPriorityStatus as CoreSyncPriorityStatus } from '../../client/sync/
 import { SyncProgressImpl } from './SyncProgress.js';
 import { FULL_SYNC_PRIORITY } from '../../constants.js';
 
-export class SyncStatusSnapshot implements SyncStatus {
-  readonly dataFlowStatus: SyncDataFlowStatus;
+/**
+ * The {@link SyncStatus} subset not managed b the Rust client in {@link CoreSyncStatus}.
+ *
+ * This includes the upload state and JS errors.
+ */
+export interface JavaScriptSyncState {
+  uploading?: boolean;
+  downloadError?: Error;
+  uploadError?: Error;
+}
 
+export class SyncStatusSnapshot implements SyncStatus {
   constructor(
     readonly core: CoreSyncStatus | null,
-    dataFlow: SyncDataFlowStatus
-  ) {
-    this.dataFlowStatus = {
-      uploading: false,
-      ...dataFlow
-    };
-  }
+    readonly jsState: JavaScriptSyncState
+  ) {}
 
   get connected(): boolean {
     return this.core?.connected ?? false;
@@ -35,6 +39,27 @@ export class SyncStatusSnapshot implements SyncStatus {
 
   get downloading(): boolean {
     return this.core?.downloading != null;
+  }
+
+  get uploading(): boolean {
+    return this.jsState.uploading ?? false;
+  }
+
+  get downloadError(): Error | undefined {
+    return this.jsState.downloadError;
+  }
+
+  get uploadError(): Error | undefined {
+    return this.jsState.uploadError;
+  }
+
+  get dataFlowStatus(): SyncDataFlowStatus {
+    return {
+      downloading: this.downloading,
+      uploading: this.uploading,
+      downloadError: this.downloadError,
+      uploadError: this.uploadError
+    };
   }
 
   get lastSyncedAt(): Date | undefined {
@@ -105,19 +130,18 @@ export class SyncStatusSnapshot implements SyncStatus {
       return value;
     };
 
-    const options = { core: this.core, dataFlow: this.dataFlowStatus };
+    const options = { core: this.core, jsState: this.jsState };
     const otherStatus = status as unknown as SyncStatusSnapshot;
     const otherOptions = {
       core: otherStatus.core,
-      dataFlow: otherStatus.dataFlowStatus
+      jsState: otherStatus.jsState
     };
 
     return JSON.stringify(options, replacer) == JSON.stringify(otherOptions, replacer);
   }
 
   getMessage() {
-    const dataFlow = this.dataFlowStatus;
-    return `SyncStatus<connected: ${this.connected} connecting: ${this.connecting} lastSyncedAt: ${this.lastSyncedAt} hasSynced: ${this.hasSynced}. Downloading: ${this.downloading}. Uploading: ${dataFlow.uploading}. UploadError: ${dataFlow.uploadError}, DownloadError?: ${dataFlow.downloadError}>`;
+    return `SyncStatus<connected: ${this.connected} connecting: ${this.connecting} lastSyncedAt: ${this.lastSyncedAt} hasSynced: ${this.hasSynced}. Downloading: ${this.downloading}. Uploading: ${this.uploading}. UploadError: ${this.uploadError}, DownloadError?: ${this.downloadError}>`;
   }
 
   /**
@@ -129,9 +153,9 @@ export class SyncStatusSnapshot implements SyncStatus {
     return {
       core: this.core,
       dataFlow: {
-        ...this.dataFlowStatus,
-        uploadError: this.serializeError(this.dataFlowStatus.uploadError),
-        downloadError: this.serializeError(this.dataFlowStatus.downloadError)
+        uploading: this.uploading,
+        uploadError: this.serializeError(this.uploadError),
+        downloadError: this.serializeError(this.downloadError)
       }
     };
   }
@@ -165,8 +189,9 @@ function priorityToJs(status: CoreSyncPriorityStatus): SyncPriorityStatus {
 }
 
 export interface SyncStatusJson {
+  // Note: When updating this, also update packages/tauri/src/database.rs
   core: CoreSyncStatus | null;
-  dataFlow: SyncDataFlowStatus;
+  dataFlow: JavaScriptSyncState;
 }
 
 class SyncStreamStatusView implements SyncStreamStatus {

--- a/packages/shared-internals/src/db/crud/SyncStatus.ts
+++ b/packages/shared-internals/src/db/crud/SyncStatus.ts
@@ -13,7 +13,7 @@ import { SyncProgressImpl } from './SyncProgress.js';
 import { FULL_SYNC_PRIORITY } from '../../constants.js';
 
 /**
- * The {@link SyncStatus} subset not managed b the Rust client in {@link CoreSyncStatus}.
+ * The {@link SyncStatus} subset not managed by the Rust client in {@link CoreSyncStatus}.
  *
  * This includes the upload state and JS errors.
  */

--- a/packages/tauri/src/database.rs
+++ b/packages/tauri/src/database.rs
@@ -139,8 +139,8 @@ impl Serialize for SerializableDataFlowStatus<'_> {
         S: Serializer,
     {
         let status = self.0;
-        // Note: This must match SyncDataFlowStatus in common/src/db/crud/SyncStatus.ts
-        let mut inner = serializer.serialize_struct("DataFlowOptions", 3)?;
+        // Note: This must match JavaScriptSyncState in common/src/db/crud/SyncStatus.ts
+        let mut inner = serializer.serialize_struct("JavaScriptSyncState", 3)?;
         inner.serialize_field("uploading", &status.is_uploading())?;
         inner.serialize_field(
             "downloadError",

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -246,8 +246,8 @@ const status = useStatus();
   <div v-if="!status.hasSynced">Waiting for initial sync to complete.</div>
   <div v-else>
     <div>Connected: {{ status.connected }}, last synced at: {{ status.lastSyncedAt }}</div>
-    <div v-if="status.dataFlowStatus.uploading">Uploading...</div>
-    <div v-if="status.dataFlowStatus.downloading">Downloading...</div>
+    <div v-if="status.uploading">Uploading...</div>
+    <div v-if="status.downloading">Downloading...</div>
   </div>
 </template>
 ```

--- a/packages/web/src/worker/sync/SharedSyncImplementation.ts
+++ b/packages/web/src/worker/sync/SharedSyncImplementation.ts
@@ -149,8 +149,7 @@ export class SharedSyncImplementation extends BaseObserver<SharedSyncImplementat
 
         const sync = this.generateStreamingImplementation();
         const onDispose = sync.registerListener({
-          statusChanged: (status, dataFlow) => {
-            const snapshot = new SyncStatusSnapshot(status, dataFlow);
+          statusChanged: (snapshot) => {
             this.syncStatus = snapshot;
             const json = snapshot.toJSON();
             this.ports.forEach((p) => p.clientProvider.statusChanged(json));

--- a/packages/web/tests/error_serialization.test.ts
+++ b/packages/web/tests/error_serialization.test.ts
@@ -34,10 +34,10 @@ describe('Error Serialization through MessagePorts', { sequential: true }, () =>
         }
       );
 
-      expect(database.currentStatus.dataFlowStatus?.downloadError).toBeDefined();
-      expect(database.currentStatus.dataFlowStatus?.downloadError?.name).toBe('Error');
-      expect(database.currentStatus.dataFlowStatus?.downloadError?.message).toBe('HTTP : "Unauthorized"\n');
-      expect(database.currentStatus.dataFlowStatus?.downloadError?.stack).toBeDefined();
+      expect(database.currentStatus?.downloadError).toBeDefined();
+      expect(database.currentStatus?.downloadError?.name).toBe('Error');
+      expect(database.currentStatus?.downloadError?.message).toBe('HTTP : "Unauthorized"\n');
+      expect(database.currentStatus?.downloadError?.stack).toBeDefined();
     }
   );
 });

--- a/packages/web/tests/sync_status.test.ts
+++ b/packages/web/tests/sync_status.test.ts
@@ -35,7 +35,7 @@ function describeSyncStatusStreamingTests(createConnectedDatabase: () => Promise
 
       powersync.registerListener({
         statusChanged: (status) => {
-          if (status.dataFlowStatus.downloadError) {
+          if (status.downloadError) {
             resolveDownloadError();
             receivedUploadError = true;
           }
@@ -75,7 +75,7 @@ function describeSyncStatusStreamingTests(createConnectedDatabase: () => Promise
 
       powersync.registerListener({
         statusChanged: (status) => {
-          if (status.dataFlowStatus.uploadError) {
+          if (status.uploadError) {
             resolveUploadError();
             receivedUploadError = true;
           } else if (receivedUploadError) {

--- a/tools/diagnostics-app/src/library/powersync/ConnectionManager.ts
+++ b/tools/diagnostics-app/src/library/powersync/ConnectionManager.ts
@@ -201,8 +201,8 @@ export function useSyncStatus() {
 
     setCurrent(sync.syncStatus);
     const l = sync.registerListener({
-      statusChanged: (core, dataFlow) => {
-        setCurrent(new SyncStatusSnapshot(core, dataFlow));
+      statusChanged: (snapshot) => {
+        setCurrent(snapshot);
       }
     });
     return () => l?.();

--- a/tools/diagnostics-app/src/library/powersync/ConnectionManager.ts
+++ b/tools/diagnostics-app/src/library/powersync/ConnectionManager.ts
@@ -209,15 +209,8 @@ export function useSyncStatus() {
   }, [current]); // Re-run when current changes (triggered by sync recreation)
 
   // Return status with persisted error if available
-  if (current && lastConnectionError && !current.dataFlowStatus?.downloadError) {
-    // Use type assertion to preserve the full SyncStatus type after spread
-    return {
-      ...current,
-      dataFlowStatus: {
-        ...current.dataFlowStatus,
-        downloadError: lastConnectionError
-      }
-    } as typeof current;
+  if (current && lastConnectionError && !current.downloadError) {
+    return new SyncStatusSnapshot(current.core, { ...current.jsState, downloadError: lastConnectionError });
   }
 
   return current;

--- a/tools/diagnostics-app/src/routes/_authenticated.tsx
+++ b/tools/diagnostics-app/src/routes/_authenticated.tsx
@@ -146,7 +146,7 @@ function AppSidebar() {
 
 function AuthenticatedLayout() {
   const syncStatus = useSyncStatus();
-  const syncError = useMemo(() => syncStatus?.dataFlowStatus?.downloadError, [syncStatus]);
+  const syncError = useMemo(() => syncStatus?.downloadError, [syncStatus]);
   const { title } = useNavigationPanel();
 
   return (
@@ -162,10 +162,7 @@ function AuthenticatedLayout() {
             </div>
             <div className="flex items-center gap-2 flex-shrink-0">
               <ArrowUp
-                className={cn(
-                  'h-5 w-5 -mr-2.5',
-                  syncStatus?.dataFlowStatus.uploading ? 'text-primary' : 'text-muted-foreground'
-                )}
+                className={cn('h-5 w-5 -mr-2.5', syncStatus?.uploading ? 'text-primary' : 'text-muted-foreground')}
               />
               <ArrowDown
                 className={cn('h-5 w-5', syncStatus?.downloading ? 'text-primary' : 'text-muted-foreground')}


### PR DESCRIPTION
The `dataFlowStatus` getter on `SyncStatus` only exists in the JavaScript SDKs. On every other PowerSync SDK, its fields (`uploading`, `downloading`, `uploadError` and `downloadError`) are part of the main `SyncStatus` class.

In https://github.com/powersync-ja/powersync-js/pull/993, `downloading` was moved from the data flow status to the main `SyncStatus` class. Christiaan pointed out that having `downloading` and `uploading` on separate interfaces isn't great, so this PR completes the migration by moving everything to the main `SyncStatus` interface.

To not make upgrading to v2 harder than it needs to be, I've kept `SyncDataFlowStatus` getters around as deprecated members. Internally, we also need to track these fields separately because they're not managed by the sync status from the core extension. This uses `JavaScriptSyncState` to refer to these values, but that type is only relevant internally.

I patched the demos manually by grepping for `dataFlowStatus`.  I have manually tested the `react-supabase-todolist` demo.