### PR TITLE
[Fix] Preserve Error.cause on SyncStatus upload/download errors

### DIFF
--- a/.changeset/preserve-error-cause.md
+++ b/.changeset/preserve-error-cause.md
@@ -1,0 +1,5 @@
+---
+"@powersync/common": patch
+---
+
+[Fix] Preserve `Error.cause` when serializing sync status errors, so the full cause chain on `uploadError` and `downloadError` reaches `statusChanged` listeners.

--- a/.changeset/preserve-error-cause.md
+++ b/.changeset/preserve-error-cause.md
@@ -1,5 +1,5 @@
 ---
-"@powersync/common": patch
+"@powersync/common": minor
 ---
 
 [Fix] Preserve `Error.cause` when serializing sync status errors, so the full cause chain on `uploadError` and `downloadError` reaches `statusChanged` listeners.

--- a/packages/common/etc/common.api.md
+++ b/packages/common/etc/common.api.md
@@ -1924,11 +1924,7 @@ export class SyncStatus {
     // (undocumented)
     protected options: SyncStatusOptions;
     get priorityStatusEntries(): SyncPriorityStatus[];
-    protected serializeError(error?: Error): {
-        name: string;
-        message: string;
-        stack: string | undefined;
-    } | undefined;
+    protected serializeError(error?: Error): Error | undefined;
     statusForPriority(priority: number): SyncPriorityStatus;
     get syncStreams(): SyncStreamStatus[] | undefined;
     // Warning: (ae-incompatible-release-tags) The symbol "toJSON" is marked as @public, but its signature references "SyncStatusOptions" which is marked as @internal

--- a/packages/common/src/db/crud/SyncStatus.ts
+++ b/packages/common/src/db/crud/SyncStatus.ts
@@ -277,21 +277,20 @@ export class SyncStatus {
    * Not all errors are serializable over a MessagePort. E.g. some `DomExceptions` fail to be passed across workers.
    * This explicitly serializes errors in the SyncStatus.
    */
-  protected serializeError(error?: Error) {
+  protected serializeError(error?: Error): Error | undefined {
     if (typeof error == 'undefined') {
       return undefined;
     }
-    const serialized: { name: string; message: string; stack?: string; cause?: unknown } = {
+    const serialized: Error = {
       name: error.name,
       message: error.message,
       stack: error.stack
     };
     // `Error.cause` can be any value (the spec types it as unknown). Preserve it
     // so consumers reading uploadError/downloadError keep the failure context.
-    // Recurse for Error causes so the whole chain is flattened the same way
-    const cause = (error as { cause?: unknown }).cause;
-    if (typeof cause != 'undefined') {
-      serialized.cause = cause instanceof Error ? this.serializeError(cause) : cause;
+    // Recurse for Error causes so the whole chain is flattened the same way.
+    if (typeof error.cause != 'undefined') {
+      serialized.cause = error.cause instanceof Error ? this.serializeError(error.cause) : error.cause;
     }
     return serialized;
   }

--- a/packages/common/src/db/crud/SyncStatus.ts
+++ b/packages/common/src/db/crud/SyncStatus.ts
@@ -234,11 +234,7 @@ export class SyncStatus {
      */
     const replacer = (_: string, value: any) => {
       if (value instanceof Error) {
-        return {
-          name: value.name,
-          message: value.message,
-          stack: value.stack
-        };
+        return this.serializeError(value);
       }
       return value;
     };
@@ -285,11 +281,19 @@ export class SyncStatus {
     if (typeof error == 'undefined') {
       return undefined;
     }
-    return {
+    const serialized: { name: string; message: string; stack?: string; cause?: unknown } = {
       name: error.name,
       message: error.message,
       stack: error.stack
     };
+    // `Error.cause` can be any value (the spec types it as unknown). Preserve it
+    // so consumers reading uploadError/downloadError keep the failure context.
+    // Recurse for Error causes so the whole chain is flattened the same way
+    const cause = (error as { cause?: unknown }).cause;
+    if (typeof cause != 'undefined') {
+      serialized.cause = cause instanceof Error ? this.serializeError(cause) : cause;
+    }
+    return serialized;
   }
 
   private static comparePriorities(a: SyncPriorityStatus, b: SyncPriorityStatus) {


### PR DESCRIPTION
`SyncStatus` flattens `uploadError` and `downloadError` into plain objects before they reach `statusChanged` listeners. The flattening only kept `name`, `message`, and `stack`, so `Error.cause` was dropped. 

## Change

- `serializeError` now includes `cause`. It recurses for `Error` causes so the entire chain is preserved, and passes non-`Error` causes through unchanged (`Error.cause` can be any value).

There is no API change, and the existing `name`, `message`, and `stack` behaviour is unchanged.

## Testing

Reproduced in a React Native app by throwing `new Error('Test Error', { cause: new Error('Cause Error', { cause: new Error('Deep Error') }) })` from the connector's `uploadData`, then logging `uploadError` from a `statusChanged` listener.

- Before the fix, the listener received only `Test Error` and its `cause` was `undefined`.
- After the fix, the listener received the full chain: `Test Error`, caused by `Cause Error`, caused by `Deep Error`.

## Note

Claude Opus 4.8 helped research where the cause was being lost. I reproduced the issue and tested the fix myself.
