### PR TITLE
Load RSocket libraries dynamically

### DIFF
--- a/.changeset/real-mugs-appear.md
+++ b/.changeset/real-mugs-appear.md
@@ -1,0 +1,7 @@
+---
+'@powersync/react-native': minor
+'@powersync/node': minor
+'@powersync/web': minor
+---
+
+Internal: Refactor remote to load WebSocket support lazily, reducing the size of the main PowerSync SDK.

--- a/packages/common/src/client/sync/options.ts
+++ b/packages/common/src/client/sync/options.ts
@@ -48,9 +48,6 @@ export interface SyncOptions {
   crudUploadThrottleMs?: number;
 }
 
-// TODO: This should not be part of SyncOptions. Remove the WebSocket options from @powersync/common into a separate
-// package and make this an option only available when creating a custom remote.
-
 /**
  * @public
  */

--- a/packages/node/src/db/PowerSyncDatabase.ts
+++ b/packages/node/src/db/PowerSyncDatabase.ts
@@ -26,7 +26,7 @@ export type NodePowerSyncDatabaseOptions = BasePowerSyncDatabaseOptions &
     /**
      * Options to override how the SDK will connect to the sync service.
      */
-    remoteOptions?: Partial<NodeRemoteOptions>;
+    remoteOptions?: NodeRemoteOptions;
   };
 
 class NodePowerSyncDatabase extends BasePowerSyncDatabase<NodePowerSyncDatabaseOptions> {

--- a/packages/node/src/sync/stream/NodeRemote.ts
+++ b/packages/node/src/sync/stream/NodeRemote.ts
@@ -36,9 +36,11 @@ export class NodeRemote extends AbstractRemote {
     this.fetchImpl =
       options?.customFetch ??
       ((resource, init) => {
+        const dispatcher = options?.dispatcher ?? defaultFetchDispatcher();
+
         return fetch(resource, {
           // @ts-expect-error
-          dispatcher: fetchDispatcher,
+          dispatcher,
           ...init
         });
       });

--- a/packages/node/src/sync/stream/NodeRemote.ts
+++ b/packages/node/src/sync/stream/NodeRemote.ts
@@ -1,24 +1,17 @@
 import * as os from 'node:os';
 
-import {
-  AbstractRemote,
-  AbstractRemoteOptions,
-  FetchImplementation,
-  FetchImplementationProvider,
-  RemoteConnector
-} from '@powersync/shared-internals';
+import { AbstractRemote, FetchOptions, RemoteConnector } from '@powersync/shared-internals';
 import { Dispatcher, EnvHttpProxyAgent, getGlobalDispatcher, ProxyAgent, WebSocket as UndiciWebSocket } from 'undici';
 import { PowerSyncLogger } from '@powersync/common';
 
 export const STREAMING_POST_TIMEOUT_MS = 30_000;
 
-class NodeFetchProvider extends FetchImplementationProvider {
-  getFetch(): FetchImplementation {
-    return fetch.bind(globalThis);
-  }
-}
+export interface NodeRemoteOptions {
+  /**
+   * @internal Only meant to be used for tests.
+   */
+  customFetch: typeof fetch;
 
-export interface NodeRemoteOptions extends AbstractRemoteOptions {
   /**
    * Optional custom dispatcher for HTTP or WEB_SOCKET connections.
    *
@@ -30,23 +23,30 @@ export interface NodeRemoteOptions extends AbstractRemoteOptions {
 
 export class NodeRemote extends AbstractRemote {
   private wsDispatcher: Dispatcher | undefined;
+  private fetchImpl: typeof fetch;
 
   constructor(
     protected connector: RemoteConnector,
-    protected logger: PowerSyncLogger,
-    options?: Partial<NodeRemoteOptions>
+    logger: PowerSyncLogger,
+    options?: NodeRemoteOptions
   ) {
-    const fetchDispatcher = options?.dispatcher ?? defaultFetchDispatcher();
+    super(connector, logger);
 
-    super(connector, logger, {
-      fetchImplementation: options?.fetchImplementation ?? new NodeFetchProvider(),
-      fetchOptions: {
-        dispatcher: fetchDispatcher
-      },
-      ...(options ?? {})
-    });
+    this.fetchImpl =
+      options?.customFetch ??
+      ((resource, init) => {
+        return fetch(resource, {
+          // @ts-expect-error
+          dispatcher: fetchDispatcher,
+          ...init
+        });
+      });
 
     this.wsDispatcher = options?.dispatcher;
+  }
+
+  protected fetch({ resource, request }: FetchOptions): Promise<Response> {
+    return this.fetchImpl(resource, request);
   }
 
   protected createSocket(url: string): globalThis.WebSocket {

--- a/packages/node/src/sync/stream/NodeRemote.ts
+++ b/packages/node/src/sync/stream/NodeRemote.ts
@@ -3,6 +3,7 @@ import * as os from 'node:os';
 import { AbstractRemote, FetchOptions, RemoteConnector } from '@powersync/shared-internals';
 import { Dispatcher, EnvHttpProxyAgent, getGlobalDispatcher, ProxyAgent, WebSocket as UndiciWebSocket } from 'undici';
 import { PowerSyncLogger } from '@powersync/common';
+import type { WebSocketSyncStreamPlatform, WebSocketSupport } from '@powersync/shared-internals/websockets';
 
 export const STREAMING_POST_TIMEOUT_MS = 30_000;
 
@@ -49,7 +50,17 @@ export class NodeRemote extends AbstractRemote {
     return this.fetchImpl(resource, request);
   }
 
-  protected createSocket(url: string): globalThis.WebSocket {
+  protected async loadWebSocketSupport(platform: WebSocketSyncStreamPlatform): Promise<WebSocketSupport> {
+    if (!websockets) {
+      websockets = import('@powersync/shared-internals/websockets').then(
+        (module) => new module.WebSocketSupport(platform)
+      );
+    }
+
+    return await websockets;
+  }
+
+  createSocket(url: string): globalThis.WebSocket {
     // Create dedicated dispatcher for this WebSocket
     const baseDispatcher = this.getWebsocketDispatcher(url);
 
@@ -105,3 +116,5 @@ function getProxyForProtocol(protocol: string): string | undefined {
     process.env[`ALL_PROXY`]
   );
 }
+
+let websockets: Promise<WebSocketSupport> | undefined;

--- a/packages/node/src/sync/stream/NodeRemote.ts
+++ b/packages/node/src/sync/stream/NodeRemote.ts
@@ -11,7 +11,7 @@ export interface NodeRemoteOptions {
   /**
    * @internal Only meant to be used for tests.
    */
-  customFetch: typeof fetch;
+  customFetch?: typeof fetch;
 
   /**
    * Optional custom dispatcher for HTTP or WEB_SOCKET connections.
@@ -54,12 +54,12 @@ export class NodeRemote extends AbstractRemote {
 
   protected async loadWebSocketSupport(platform: WebSocketSyncStreamPlatform): Promise<WebSocketSupport> {
     if (!websockets) {
-      websockets = import('@powersync/shared-internals/websockets').then(
-        (module) => new module.WebSocketSupport(platform)
-      );
+      // loadWebSocketSupport being called concurrently is safe, the import resolves to the same module in that case.
+      const module = await import('@powersync/shared-internals/websockets');
+      websockets = new module.WebSocketSupport(platform);
     }
 
-    return await websockets;
+    return websockets;
   }
 
   createSocket(url: string): globalThis.WebSocket {
@@ -119,4 +119,4 @@ function getProxyForProtocol(protocol: string): string | undefined {
   );
 }
 
-let websockets: Promise<WebSocketSupport> | undefined;
+let websockets: WebSocketSupport | undefined;

--- a/packages/node/tests/utils.ts
+++ b/packages/node/tests/utils.ts
@@ -172,7 +172,7 @@ export function createMockSyncServiceTest(bson: boolean) {
           ...options,
           database: dbOptions,
           remoteOptions: {
-            fetchImplementation: inMemoryFetch
+            customFetch: inMemoryFetch
           }
         });
 

--- a/packages/react-native/src/sync/stream/ReactNativeRemote.ts
+++ b/packages/react-native/src/sync/stream/ReactNativeRemote.ts
@@ -6,6 +6,7 @@ import { TextDecoder } from 'text-encoding';
 
 // @ts-expect-error
 import { fetch } from 'react-native-fetch-api';
+import { WebSocketSupport, WebSocketSyncStreamPlatform } from '@powersync/shared-internals/websockets';
 
 export const STREAMING_POST_TIMEOUT_MS = 30_000;
 
@@ -52,6 +53,10 @@ export class ReactNativeRemote extends AbstractRemote {
     }
   }
 
+  protected loadWebSocketSupport(platform: WebSocketSyncStreamPlatform): Promise<WebSocketSupport> {
+    return Promise.resolve((websockets ??= new WebSocketSupport(platform)));
+  }
+
   getUserAgent(): string {
     return [
       super.getUserAgent(),
@@ -70,3 +75,5 @@ export class ReactNativeRemote extends AbstractRemote {
     return false;
   }
 }
+
+let websockets: WebSocketSupport | undefined;

--- a/packages/react-native/src/sync/stream/ReactNativeRemote.ts
+++ b/packages/react-native/src/sync/stream/ReactNativeRemote.ts
@@ -10,10 +10,15 @@ import { WebSocketSupport, WebSocketSyncStreamPlatform } from '@powersync/shared
 
 export const STREAMING_POST_TIMEOUT_MS = 30_000;
 
+export interface ReactNativeRemoteOptions {
+  fetchImplementation?: typeof fetch;
+}
+
 export class ReactNativeRemote extends AbstractRemote {
   constructor(
     protected connector: RemoteConnector,
-    logger: PowerSyncLogger
+    logger: PowerSyncLogger,
+    readonly options?: ReactNativeRemoteOptions
   ) {
     super(connector, logger);
   }
@@ -47,6 +52,10 @@ export class ReactNativeRemote extends AbstractRemote {
     try {
       // Directly import the fetch implementation from react-native-fetch-api. This removes the requirement for the
       // global `fetch` to be overridden by a polyfill.
+      if (this.options?.fetchImplementation) {
+        return await this.options.fetchImplementation(options.resource, options.request);
+      }
+
       return await fetch(options.resource, options.request);
     } finally {
       clearTimeout(timeout as any);

--- a/packages/react-native/src/sync/stream/ReactNativeRemote.ts
+++ b/packages/react-native/src/sync/stream/ReactNativeRemote.ts
@@ -1,12 +1,5 @@
 import { LogLevels, PowerSyncLogger } from '@powersync/common';
-import {
-  AbstractRemote,
-  AbstractRemoteOptions,
-  FetchImplementation,
-  FetchImplementationProvider,
-  RemoteConnector,
-  SyncStreamOptions
-} from '@powersync/shared-internals';
+import { AbstractRemote, FetchOptions, RemoteConnector } from '@powersync/shared-internals';
 import { Platform } from 'react-native';
 // @ts-expect-error
 import { TextDecoder } from 'text-encoding';
@@ -16,46 +9,47 @@ import { fetch } from 'react-native-fetch-api';
 
 export const STREAMING_POST_TIMEOUT_MS = 30_000;
 
-type ReactNativeFetchOptions = RequestInit & {
-  reactNative?: Record<string, unknown>;
-};
-
-/**
- * Directly imports fetch implementation from react-native-fetch-api.
- * This removes the requirement for the global `fetch` to be overridden by
- * a polyfill.
- */
-class ReactNativeFetchProvider extends FetchImplementationProvider {
-  getFetch(): FetchImplementation {
-    return fetch.bind(globalThis);
-  }
-}
-
 export class ReactNativeRemote extends AbstractRemote {
   constructor(
     protected connector: RemoteConnector,
-    protected logger: PowerSyncLogger,
-    options?: Partial<AbstractRemoteOptions>
+    logger: PowerSyncLogger
   ) {
-    super(connector, logger, {
-      ...(options ?? {}),
-      fetchImplementation: options?.fetchImplementation ?? new ReactNativeFetchProvider()
-    });
+    super(connector, logger);
   }
 
-  get fetch(): FetchImplementation {
-    const fetchImplementation = super.fetch;
-    return ((input, init) => {
-      const options = (init ?? {}) as ReactNativeFetchOptions;
+  protected async fetch(options: FetchOptions): Promise<Response> {
+    let timeout: unknown;
+    if (options.expectStreamingResponse) {
+      // @ts-expect-error https://github.com/react-native-community/fetch#enable-text-streaming
+      options.request.reactNative = {
+        /**
+         * The `react-native-fetch-api` polyfill provides streaming support via
+         * this non-standard flag
+         * https://github.com/react-native-community/fetch#enable-text-streaming
+         */
+        textStreaming: true
+      };
 
-      return fetchImplementation(input, {
-        ...options,
-        reactNative: {
-          ...(options.reactNative ?? {}),
-          textStreaming: true
-        }
-      } as RequestInit);
-    }) as FetchImplementation;
+      timeout =
+        Platform.OS == 'android'
+          ? setTimeout(() => {
+              this.logger.log({
+                level: LogLevels.warn,
+                message: `HTTP Streaming POST is taking longer than ${Math.ceil(
+                  STREAMING_POST_TIMEOUT_MS / 1000
+                )} seconds to resolve. If using a debug build, please ensure Flipper Network plugin is disabled.`
+              });
+            }, STREAMING_POST_TIMEOUT_MS)
+          : null;
+    }
+
+    try {
+      // Directly import the fetch implementation from react-native-fetch-api. This removes the requirement for the
+      // global `fetch` to be overridden by a polyfill.
+      return await fetch(options.resource, options.request);
+    } finally {
+      clearTimeout(timeout as any);
+    }
   }
 
   getUserAgent(): string {
@@ -74,39 +68,5 @@ export class ReactNativeRemote extends AbstractRemote {
   protected get supportsStreamingBinaryResponses(): boolean {
     // We have to pass textStreaming: true to get streamed responses at all, and those don't support binary data.
     return false;
-  }
-
-  protected async fetchStreamRaw(options: SyncStreamOptions) {
-    const timeout =
-      Platform.OS == 'android'
-        ? setTimeout(() => {
-            this.logger.log({
-              level: LogLevels.warn,
-              message: `HTTP Streaming POST is taking longer than ${Math.ceil(
-                STREAMING_POST_TIMEOUT_MS / 1000
-              )} seconds to resolve. If using a debug build, please ensure Flipper Network plugin is disabled.`
-            });
-          }, STREAMING_POST_TIMEOUT_MS)
-        : null;
-
-    try {
-      return await super.fetchStreamRaw({
-        ...options,
-        fetchOptions: {
-          ...options.fetchOptions,
-          /**
-           * The `react-native-fetch-api` polyfill provides streaming support via
-           * this non-standard flag
-           * https://github.com/react-native-community/fetch#enable-text-streaming
-           */
-          // @ts-expect-error https://github.com/react-native-community/fetch#enable-text-streaming
-          reactNative: { textStreaming: true }
-        }
-      });
-    } finally {
-      if (timeout) {
-        clearTimeout(timeout);
-      }
-    }
   }
 }

--- a/packages/react-native/src/sync/stream/ReactNativeRemote.ts
+++ b/packages/react-native/src/sync/stream/ReactNativeRemote.ts
@@ -24,7 +24,7 @@ export class ReactNativeRemote extends AbstractRemote {
   }
 
   protected async fetch(options: FetchOptions): Promise<Response> {
-    let timeout: unknown;
+    let timeout: ReturnType<typeof setTimeout> | null = null;
     if (options.expectStreamingResponse) {
       // @ts-expect-error https://github.com/react-native-community/fetch#enable-text-streaming
       options.request.reactNative = {
@@ -58,7 +58,7 @@ export class ReactNativeRemote extends AbstractRemote {
 
       return await fetch(options.resource, options.request);
     } finally {
-      clearTimeout(timeout as any);
+      if (timeout != null) clearTimeout(timeout);
     }
   }
 

--- a/packages/react-native/tests/sync/ReactNativeRemote.test.ts
+++ b/packages/react-native/tests/sync/ReactNativeRemote.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { ReactNativeRemote } from '../../src/sync/stream/ReactNativeRemote';
+import { createConsoleLogger } from '@powersync/common';
 
 const connector = {
   fetchCredentials: async () => ({
@@ -19,32 +20,39 @@ function jsonResponse(body: unknown): Response {
   } as Response;
 }
 
+const logger = createConsoleLogger();
+
 describe('ReactNativeRemote', () => {
-  it('uses text streaming for non-streaming GET requests', async () => {
+  it('does not use streaming for non-streaming GET requests', async () => {
     const fetchImplementation = vi.fn(async () => jsonResponse({ ok: true }));
-    const remote = new ReactNativeRemote(connector, undefined, { fetchImplementation });
+    const remote = new ReactNativeRemote(connector, logger, { fetchImplementation });
 
     await remote.get('/write-checkpoint2.json');
 
     expect(fetchImplementation).toHaveBeenCalledWith(
       'https://example.com/write-checkpoint2.json',
       expect.objectContaining({
-        method: 'GET',
-        reactNative: expect.objectContaining({
-          textStreaming: true
-        })
+        method: 'GET'
       })
     );
   });
 
   it('uses text streaming for non-streaming POST requests', async () => {
     const fetchImplementation = vi.fn(async () => jsonResponse({ ok: true }));
-    const remote = new ReactNativeRemote(connector, undefined, { fetchImplementation });
+    const remote = new ReactNativeRemote(connector, logger, { fetchImplementation });
 
-    await remote.post('/crud', { op: 'put' });
+    try {
+      await remote.fetchStream({
+        path: '/sync/stream',
+        data: {},
+        abortSignal: new AbortController().signal
+      });
+    } catch {
+      // This fails because the mock is incomplete, ignore.
+    }
 
     expect(fetchImplementation).toHaveBeenCalledWith(
-      'https://example.com/crud',
+      'https://example.com/sync/stream',
       expect.objectContaining({
         method: 'POST',
         reactNative: expect.objectContaining({

--- a/packages/shared-internals/package.json
+++ b/packages/shared-internals/package.json
@@ -9,24 +9,13 @@
   "type": "module",
   "exports": {
     ".": {
-      "node": {
-        "import": {
-          "types": "./lib/index.d.ts",
-          "default": "./dist/bundle.node.mjs"
-        },
-        "require": {
-          "types": "./dist/index.d.cts",
-          "require": "./dist/bundle.node.cjs"
-        }
-      },
-      "import": {
-        "types": "./lib/index.d.ts",
-        "default": "./dist/bundle.mjs"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "require": "./dist/bundle.cjs"
-      }
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    },
+    "./websockets": {
+      "types": "./lib/client/sync/stream/WebSocketSupport.d.ts",
+      "node": "./dist/websockets.node.mjs",
+      "default": "./dist/websockets.mjs"
     },
     "./internal/sync_protocol": {
       "types": "./legacy/sync_protocol.d.ts"
@@ -53,7 +42,8 @@
     "build:prod": "tsc -b && rollup -c rollup.config.mjs",
     "clean": "rm -rf lib dist tsconfig.tsbuildinfo",
     "test": "vitest",
-    "test:exports": "attw --pack . --profile node16 --exclude-entrypoints internal/sync_protocol"
+    "test:exports": "attw --pack . --profile node16 --exclude-entrypoints internal/sync_protocol",
+    "postversion": "node tool/update_version.js"
   },
   "devDependencies": {
     "@powersync/common": "workspace:*",

--- a/packages/shared-internals/package.json
+++ b/packages/shared-internals/package.json
@@ -42,7 +42,7 @@
     "build:prod": "tsc -b && rollup -c rollup.config.mjs",
     "clean": "rm -rf lib dist tsconfig.tsbuildinfo",
     "test": "vitest",
-    "test:exports": "attw --pack . --profile node16 --exclude-entrypoints internal/sync_protocol",
+    "test:exports": "attw --pack . --profile node16 --exclude-entrypoints internal/sync_protocol --ignore-rules cjs-resolves-to-esm",
     "postversion": "node tool/update_version.js"
   },
   "devDependencies": {

--- a/packages/shared-internals/rollup.config.mjs
+++ b/packages/shared-internals/rollup.config.mjs
@@ -6,33 +6,26 @@ import { dts } from 'rollup-plugin-dts';
 import MagicString from 'magic-string';
 import { walk } from 'estree-walker';
 
-function defineBuild(isNode) {
+function defineWebSocketBuild(isNode) {
   const suffix = isNode ? '.node' : '';
   const plugins = [
     [
       json(),
       nodeResolve({ preferBuiltins: false, browser: true }),
       commonjs({}),
+      checkNoIllegalAsyncIteratorUse(),
       inject({
         Buffer: isNode ? ['node:buffer', 'Buffer'] : ['buffer/', 'Buffer']
       })
     ]
   ];
-  if (!isNode) {
-    plugins.push(checkNoIllegalAsyncIteratorUse());
-  }
 
   return {
-    input: 'lib/index.js',
+    input: 'lib/client/sync/stream/WebSocketSupport.js',
     output: [
       {
-        file: `dist/bundle${suffix}.mjs`,
+        file: `dist/websockets${suffix}.mjs`,
         format: 'esm',
-        sourcemap: true
-      },
-      {
-        file: `dist/bundle${suffix}.cjs`,
-        format: 'cjs',
         sourcemap: true
       }
     ],
@@ -45,12 +38,20 @@ function defineBuild(isNode) {
  */
 export default () => {
   return [
-    defineBuild(false),
-    defineBuild(true),
+    defineWebSocketBuild(false),
+    defineWebSocketBuild(true),
+    // Run a no-emit build to verify we're not using Symbol.asyncIterator without fallbacks in our sources and
+    // dependencies.
     {
-      input: './lib/index.d.ts',
-      output: [{ file: 'dist/index.d.cts', format: 'cjs' }],
-      plugins: [dts()]
+      input: 'lib/index.js',
+      output: [
+        {
+          file: `dist/unused.js`,
+          format: 'esm'
+        }
+      ],
+      plugins: [checkNoIllegalAsyncIteratorUse(), noEmit()],
+      external: ['@powersync/common']
     }
   ];
 };
@@ -63,6 +64,17 @@ function checkNoIllegalAsyncIteratorUse() {
 
       if (code.includes('Symbol.asyncIterator')) {
         throw new Error(`${id} is not allowed to use Symbol.asyncIterator. Import compatibility.ts instead.`);
+      }
+    }
+  };
+}
+
+function noEmit() {
+  return {
+    name: 'noEmit',
+    generateBundle(_, bundle) {
+      for (const file in bundle) {
+        delete bundle[file];
       }
     }
   };

--- a/packages/shared-internals/rollup.config.mjs
+++ b/packages/shared-internals/rollup.config.mjs
@@ -38,6 +38,9 @@ function defineWebSocketBuild(isNode) {
  */
 export default () => {
   return [
+    // RSocket only contains CJS builds for Node.js. To support ESM and to ensure we support Web/React Native as well,
+    // we bundle and transform parts of the SDK using RSocket. The rest of the SDK consists of unbundled direct tsc
+    // outputs.
     defineWebSocketBuild(false),
     defineWebSocketBuild(true),
     // Run a no-emit build to verify we're not using Symbol.asyncIterator without fallbacks in our sources and

--- a/packages/shared-internals/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/shared-internals/src/client/sync/stream/AbstractRemote.ts
@@ -1,5 +1,4 @@
 import { type fetch } from 'cross-fetch';
-import PACKAGE from '../../../../package.json' with { type: 'json' };
 import { FetchStrategy, PowerSyncCredentials, LogLevels, PowerSyncLogger } from '@powersync/common';
 
 import { AbortOperation } from '../../../utils/AbortOperation.js';
@@ -7,10 +6,10 @@ import {
   doneResult,
   extractBsonObjects,
   extractJsonLines,
-  SimpleAsyncIterator,
-  valueResult
+  SimpleAsyncIterator
 } from '../../../utils/stream_transform.js';
-import { webSocketSyncStream } from './WebSocketSupport.js';
+import { WebSocketSupport, WebSocketSyncStreamPlatform } from './WebSocketSupport.js';
+import { EventQueue } from '../../../utils/async.js';
 
 /**
  * @internal
@@ -21,7 +20,14 @@ export type RemoteConnector = {
 };
 
 const POWERSYNC_TRAILING_SLASH_MATCH = /\/+$/;
-const POWERSYNC_JS_VERSION = PACKAGE.version;
+// Note: A postversion script will make Changesets keep this constant up-to-date.
+const POWERSYNC_JS_VERSION = 'unset';
+
+const webSocketPlatform: WebSocketSyncStreamPlatform = {
+  LogLevels,
+  EventQueue,
+  AbortOperation
+};
 
 /**
  * @internal
@@ -66,6 +72,7 @@ export interface PreparedRequest {
   url: string;
   headers: Record<string, string>;
   userAgent: string;
+  path: string;
 }
 
 /**
@@ -162,7 +169,8 @@ export abstract class AbstractRemote {
         Authorization: `Token ${credentials.token}`,
         'x-user-agent': userAgent
       },
-      userAgent
+      userAgent,
+      path
     };
   }
 
@@ -204,12 +212,34 @@ export abstract class AbstractRemote {
   }
 
   /**
+   * Loads `@powersync/shared-internals/websockets`.
+   *
+   * We prefer to load that as a lazy module with a dynamic `import()` expressions on most platforms. An exception is
+   * React Native, where WebSocket support is preferred and we want to load this directly.
+   */
+  protected abstract loadWebSocketSupport(platform: WebSocketSyncStreamPlatform): Promise<WebSocketSupport>;
+
+  /**
    * Returns a data stream of sync line data, fetched via RSocket-over-WebSocket.
    *
    * The only mechanism to abort the returned stream is to use the abort signal in {@link SocketSyncStreamOptions}.
    */
   async socketStreamRaw(options: SocketSyncStreamOptions): Promise<SimpleAsyncIterator<Uint8Array>> {
-    return await webSocketSyncStream(this, options, await this.buildRequest(options.path));
+    const support = await this.loadWebSocketSupport(webSocketPlatform);
+
+    const request = await this.buildRequest(options.path);
+    request.url = request.url.replace(/^https?:\/\//, function (match) {
+      return match === 'https://' ? 'wss://' : 'ws://';
+    });
+    const { fetchStrategy = FetchStrategy.Buffered, abortSignal, data } = options;
+
+    return await support.webSocketSyncStream({
+      remote: this,
+      buffered: fetchStrategy == FetchStrategy.Buffered,
+      abortSignal,
+      requestPayload: data,
+      request
+    });
   }
 
   /**

--- a/packages/shared-internals/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/shared-internals/src/client/sync/stream/AbstractRemote.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../utils/stream_transform.js';
 import { WebSocketSupport, WebSocketSyncStreamPlatform } from './WebSocketSupport.js';
 import { EventQueue } from '../../../utils/async.js';
+import { POWERSYNC_JS_VERSION } from '../../../version.js';
 
 /**
  * @internal
@@ -20,8 +21,6 @@ export type RemoteConnector = {
 };
 
 const POWERSYNC_TRAILING_SLASH_MATCH = /\/+$/;
-// Note: A postversion script will make Changesets keep this constant up to date with the version in package.json.
-const POWERSYNC_JS_VERSION = 'unset before initial release';
 
 const webSocketPlatform: WebSocketSyncStreamPlatform = {
   LogLevels,

--- a/packages/shared-internals/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/shared-internals/src/client/sync/stream/AbstractRemote.ts
@@ -1,10 +1,8 @@
 import { type fetch } from 'cross-fetch';
-import { Requestable, RSocket, RSocketConnector } from 'rsocket-core';
 import PACKAGE from '../../../../package.json' with { type: 'json' };
 import { FetchStrategy, PowerSyncCredentials, LogLevels, PowerSyncLogger } from '@powersync/common';
 
 import { AbortOperation } from '../../../utils/AbortOperation.js';
-import { WebsocketClientTransport } from './WebsocketClientTransport.js';
 import {
   doneResult,
   extractBsonObjects,
@@ -12,7 +10,7 @@ import {
   SimpleAsyncIterator,
   valueResult
 } from '../../../utils/stream_transform.js';
-import { EventQueue } from '../../../utils/async.js';
+import { webSocketSyncStream } from './WebSocketSupport.js';
 
 /**
  * @internal
@@ -25,29 +23,13 @@ export type RemoteConnector = {
 const POWERSYNC_TRAILING_SLASH_MATCH = /\/+$/;
 const POWERSYNC_JS_VERSION = PACKAGE.version;
 
-const SYNC_QUEUE_REQUEST_HIGH_WATER = 10;
-const SYNC_QUEUE_REQUEST_LOW_WATER = 5;
-
-// Keep alive message is sent every period
-const KEEP_ALIVE_MS = 20_000;
-
-// One message of any type must be received in this period.
-const SOCKET_TIMEOUT_MS = 30_000;
-
-// One keepalive message must be received in this period.
-// If there is a backlog of messages (for example on slow connections), keepalive messages could be delayed
-// significantly. Therefore this is longer than the socket timeout.
-const KEEP_ALIVE_LIFETIME_MS = 90_000;
-
 /**
  * @internal
  */
 export type SyncStreamOptions = {
   path: string;
   data: unknown;
-  headers?: Record<string, string>;
   abortSignal: AbortSignal;
-  fetchOptions?: Request;
 };
 
 /**
@@ -55,46 +37,20 @@ export type SyncStreamOptions = {
  */
 export type FetchImplementation = typeof fetch;
 
-/**
- * Class wrapper for providing a fetch implementation.
- * The class wrapper is used to distinguish the fetchImplementation
- * option in [AbstractRemoteOptions] from the general fetch method
- * which is typeof "function"
- *
- * @internal
- */
-export class FetchImplementationProvider {
-  getFetch(): FetchImplementation {
-    throw new Error('Unspecified fetch implementation');
-  }
+export function lazyFetchImplementation(getFetch: () => FetchImplementation): FetchImplementation {
+  let resolved: FetchImplementation;
+
+  return (request) => {
+    const fetch = (resolved ??= getFetch());
+    return fetch(request);
+  };
 }
 
-/**
- * @internal
- */
-export type AbstractRemoteOptions = {
-  /**
-   * Transforms the PowerSync base URL which might contain
-   * `http(s)://` to the corresponding WebSocket variant
-   * e.g. `ws(s)://`
-   */
-  socketUrlTransformer: (url: string) => string;
-
-  /**
-   * Optionally provide the fetch implementation to use.
-   * Note that this usually needs to be bound to the global scope.
-   * Binding should be done before passing here.
-   */
-  fetchImplementation: FetchImplementation | FetchImplementationProvider;
-
-  /**
-   * Optional options to pass directly to all `fetch` calls.
-   *
-   * This can include fields such as `dispatcher` (e.g. for proxy support),
-   * `cache`, or any other fetch-compatible options.
-   */
-  fetchOptions?: {};
-};
+export interface FetchOptions {
+  resource: string;
+  request: RequestInit;
+  expectStreamingResponse: boolean;
+}
 
 /**
  * @internal
@@ -106,46 +62,27 @@ export interface SocketSyncStreamOptions {
   data: unknown;
 }
 
-/**
- * @internal
- */
-export const DEFAULT_REMOTE_OPTIONS: AbstractRemoteOptions = {
-  socketUrlTransformer: (url) =>
-    url.replace(/^https?:\/\//, function (match) {
-      return match === 'https://' ? 'wss://' : 'ws://';
-    }),
-  fetchImplementation: new FetchImplementationProvider(),
-  fetchOptions: {}
-};
+export interface PreparedRequest {
+  url: string;
+  headers: Record<string, string>;
+  userAgent: string;
+}
 
 /**
  * @internal
  */
 export abstract class AbstractRemote {
   protected credentials: PowerSyncCredentials | null = null;
-  protected options: AbstractRemoteOptions;
 
   constructor(
     protected connector: RemoteConnector,
-    protected logger: PowerSyncLogger,
-    options?: Partial<AbstractRemoteOptions>
-  ) {
-    this.options = {
-      ...DEFAULT_REMOTE_OPTIONS,
-      ...(options ?? {})
-    };
-  }
+    readonly logger: PowerSyncLogger
+  ) {}
 
   /**
-   * @returns a fetch implementation (function)
-   * which can be called to perform fetch requests
+   * Sends a request using a suitable `fetch` implementation for the current platform.
    */
-  get fetch(): FetchImplementation {
-    const { fetchImplementation } = this.options;
-    return fetchImplementation instanceof FetchImplementationProvider
-      ? fetchImplementation.getFetch()
-      : fetchImplementation;
-  }
+  protected abstract fetch(options: FetchOptions): Promise<Response>;
 
   /**
    * Get credentials currently cached, or fetch new credentials if none are
@@ -206,7 +143,7 @@ export abstract class AbstractRemote {
     return `powersync-js/${POWERSYNC_JS_VERSION}`;
   }
 
-  protected async buildRequest(path: string) {
+  protected async buildRequest(path: string): Promise<PreparedRequest> {
     const credentials = await this.getCredentials();
     if (credentials != null && (credentials.endpoint == null || credentials.endpoint == '')) {
       throw new Error('PowerSync endpoint not configured');
@@ -224,40 +161,23 @@ export abstract class AbstractRemote {
         'content-type': 'application/json',
         Authorization: `Token ${credentials.token}`,
         'x-user-agent': userAgent
-      }
-    };
-  }
-
-  async post(path: string, data: any, headers: Record<string, string> = {}): Promise<any> {
-    const request = await this.buildRequest(path);
-    const res = await this.fetch(request.url, {
-      method: 'POST',
-      headers: {
-        ...headers,
-        ...request.headers
       },
-      body: JSON.stringify(data)
-    });
-
-    if (res.status === 401) {
-      this.invalidateCredentials();
-    }
-
-    if (!res.ok) {
-      throw new Error(`Received ${res.status} - ${res.statusText} when posting to ${path}: ${await res.text()}}`);
-    }
-
-    return res.json();
+      userAgent
+    };
   }
 
   async get(path: string, headers?: Record<string, string>): Promise<any> {
     const request = await this.buildRequest(path);
-    const res = await this.fetch(request.url, {
-      method: 'GET',
-      headers: {
-        ...headers,
-        ...request.headers
-      }
+    const res = await this.fetch({
+      resource: request.url,
+      request: {
+        method: 'GET',
+        headers: {
+          ...headers,
+          ...request.headers
+        }
+      },
+      expectStreamingResponse: false
     });
 
     if (res.status === 401) {
@@ -279,7 +199,7 @@ export abstract class AbstractRemote {
     return new TextDecoder();
   }
 
-  protected createSocket(url: string): WebSocket {
+  createSocket(url: string): WebSocket {
     return new WebSocket(url);
   }
 
@@ -289,211 +209,7 @@ export abstract class AbstractRemote {
    * The only mechanism to abort the returned stream is to use the abort signal in {@link SocketSyncStreamOptions}.
    */
   async socketStreamRaw(options: SocketSyncStreamOptions): Promise<SimpleAsyncIterator<Uint8Array>> {
-    const { path, fetchStrategy = FetchStrategy.Buffered } = options;
-    const mimeType = 'application/json';
-
-    function toBuffer(js: any): Buffer {
-      return Buffer.from(JSON.stringify(js));
-    }
-
-    const syncQueueRequestSize = fetchStrategy == FetchStrategy.Buffered ? 10 : 1;
-    const request = await this.buildRequest(path);
-    const url = this.options.socketUrlTransformer(request.url);
-
-    // Add the user agent in the setup payload - we can't set custom
-    // headers with websockets on web. The browser userAgent is however added
-    // automatically as a header.
-    const userAgent = this.getUserAgent();
-
-    // While we're connecting (a process that can't be aborted in RSocket), the WebSocket instance to close if we wanted
-    // to abort the connection.
-    let pendingSocket: WebSocket | null = null;
-    let keepAliveTimeout: any;
-    let rsocket: RSocket | null = null;
-    let paused = false;
-    const queue = new EventQueue<Uint8Array | null>({
-      eventDelivered: () => {
-        if (queue.countOutstandingEvents <= SYNC_QUEUE_REQUEST_LOW_WATER) {
-          paused = false;
-          requestMore();
-        }
-      }
-    });
-    let didClose = false;
-    let connectionEstablished = false;
-    let pendingEventsCount = syncQueueRequestSize;
-    let res: Requestable | null = null;
-
-    const abortRequest = () => {
-      if (didClose) {
-        return;
-      }
-      didClose = true;
-
-      clearTimeout(keepAliveTimeout);
-
-      if (pendingSocket) {
-        pendingSocket.close();
-      }
-
-      if (rsocket) {
-        rsocket.close();
-      }
-
-      // Send a bogus event to the queue to ensure a pending listener gets woken up. We check for didClose and would
-      // return a doneEvent.
-      queue.notify(null);
-    };
-
-    function push(event: Uint8Array) {
-      queue.notify(event);
-      if (queue.countOutstandingEvents >= SYNC_QUEUE_REQUEST_HIGH_WATER) {
-        paused = true;
-      }
-    }
-
-    function requestMore() {
-      const delta = syncQueueRequestSize - pendingEventsCount;
-      if (!paused && delta > 0) {
-        res?.request(delta);
-        pendingEventsCount = syncQueueRequestSize;
-      }
-    }
-
-    // Handle upstream abort
-    if (options.abortSignal.aborted) {
-      throw new AbortOperation('Connection request aborted');
-    } else {
-      options.abortSignal.addEventListener('abort', abortRequest);
-    }
-
-    const resetTimeout = () => {
-      clearTimeout(keepAliveTimeout);
-      keepAliveTimeout = setTimeout(() => {
-        this.logger.log({
-          level: LogLevels.error,
-          message: `No data received on WebSocket in ${SOCKET_TIMEOUT_MS}ms, closing connection.`
-        });
-        abortRequest();
-      }, SOCKET_TIMEOUT_MS);
-    };
-    resetTimeout();
-
-    const connector = new RSocketConnector({
-      transport: new WebsocketClientTransport({
-        url,
-        wsCreator: (url) => {
-          const socket = (pendingSocket = this.createSocket(url));
-
-          socket.addEventListener('message', () => {
-            resetTimeout();
-          });
-          return socket;
-        }
-      }),
-      setup: {
-        keepAlive: KEEP_ALIVE_MS,
-        lifetime: KEEP_ALIVE_LIFETIME_MS,
-        dataMimeType: mimeType,
-        metadataMimeType: mimeType,
-        payload: {
-          data: null,
-          metadata: toBuffer({
-            token: request.headers.Authorization,
-            user_agent: userAgent
-          })
-        }
-      }
-    });
-
-    try {
-      rsocket = await connector.connect();
-      // The connection is established, we no longer need to monitor the initial timeout
-      pendingSocket = null;
-    } catch (ex) {
-      this.logger.log({ level: LogLevels.error, message: `Failed to connect WebSocket`, error: ex });
-      abortRequest();
-
-      throw ex;
-    }
-
-    resetTimeout();
-
-    // Helps to prevent double close scenarios
-    rsocket.onClose(() => (rsocket = null));
-
-    return await new Promise((resolve, reject) => {
-      const queueAsIterator: SimpleAsyncIterator<Uint8Array> = {
-        next: async () => {
-          if (didClose) return doneResult;
-
-          const notification = await queue.waitForEvent(options.abortSignal);
-          if (didClose) {
-            return doneResult;
-          } else {
-            return valueResult(notification!);
-          }
-        }
-      };
-
-      res = rsocket!.requestStream(
-        {
-          data: toBuffer(options.data),
-          metadata: toBuffer({
-            path
-          })
-        },
-        syncQueueRequestSize, // The initial N amount
-        {
-          onError: (e) => {
-            if (e.message.includes('PSYNC_')) {
-              if (e.message.includes('PSYNC_S21')) {
-                this.invalidateCredentials();
-              }
-            } else {
-              // Possible that connection is with an older service, always invalidate to be safe
-              if (e.message !== 'Closed. ') {
-                this.invalidateCredentials();
-              }
-            }
-
-            // Don't log closed as an error
-            if (e.message !== 'Closed. ') {
-              this.logger.log({ level: LogLevels.error, message: 'RSocket error', error: e });
-            }
-            // RSocket will close the RSocket stream automatically
-            // Close the downstream stream as well - this will close the RSocket connection and WebSocket
-            abortRequest();
-            // Handles cases where the connection failed e.g. auth error or connection error
-            if (!connectionEstablished) {
-              reject(e);
-            }
-          },
-          onNext: (payload) => {
-            // The connection is active
-            if (!connectionEstablished) {
-              connectionEstablished = true;
-              resolve(queueAsIterator);
-            }
-            const { data } = payload;
-
-            if (data) {
-              push(data);
-            }
-
-            // Less events are now pending
-            pendingEventsCount--;
-
-            // Request another event (unless the downstream consumer is paused).
-            requestMore();
-          },
-          onComplete: () => {
-            abortRequest(); // this will also emit a done event
-          },
-          onExtension: () => {}
-        }
-      );
-    });
+    return await webSocketSyncStream(this, options, await this.buildRequest(options.path));
   }
 
   /**
@@ -515,7 +231,7 @@ export abstract class AbstractRemote {
   protected async fetchStreamRaw(
     options: SyncStreamOptions
   ): Promise<{ isBson: boolean; stream: SimpleAsyncIterator<Uint8Array> }> {
-    const { data, path, headers, abortSignal } = options;
+    const { data, path, abortSignal } = options;
     const request = await this.buildRequest(path);
 
     /**
@@ -555,18 +271,19 @@ export abstract class AbstractRemote {
       const ndJson = 'application/x-ndjson';
       const bson = 'application/vnd.powersync.bson-stream';
 
-      res = await this.fetch(request.url, {
-        method: 'POST',
-        headers: {
-          ...headers,
-          ...request.headers,
-          accept: this.supportsStreamingBinaryResponses ? `${bson};q=0.9,${ndJson};q=0.8` : ndJson
+      res = await this.fetch({
+        resource: request.url,
+        request: {
+          method: 'POST',
+          headers: {
+            ...request.headers,
+            accept: this.supportsStreamingBinaryResponses ? `${bson};q=0.9,${ndJson};q=0.8` : ndJson
+          },
+          body: JSON.stringify(data),
+          signal: controller.signal,
+          cache: 'no-store'
         },
-        body: JSON.stringify(data),
-        signal: controller.signal,
-        cache: 'no-store',
-        ...(this.options.fetchOptions ?? {}),
-        ...options.fetchOptions
+        expectStreamingResponse: true
       });
 
       if (!res.ok || !res.body) {

--- a/packages/shared-internals/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/shared-internals/src/client/sync/stream/AbstractRemote.ts
@@ -20,8 +20,8 @@ export type RemoteConnector = {
 };
 
 const POWERSYNC_TRAILING_SLASH_MATCH = /\/+$/;
-// Note: A postversion script will make Changesets keep this constant up-to-date.
-const POWERSYNC_JS_VERSION = 'unset';
+// Note: A postversion script will make Changesets keep this constant up to date with the version in package.json.
+const POWERSYNC_JS_VERSION = 'unset before initial release';
 
 const webSocketPlatform: WebSocketSyncStreamPlatform = {
   LogLevels,

--- a/packages/shared-internals/src/client/sync/stream/WebSocketSupport.ts
+++ b/packages/shared-internals/src/client/sync/stream/WebSocketSupport.ts
@@ -65,9 +65,6 @@ export class WebSocketSupport {
     }
 
     const syncQueueRequestSize = buffered ? 10 : 1;
-    const url = request.url.replace(/^https?:\/\//, function (match) {
-      return match === 'https://' ? 'wss://' : 'ws://';
-    });
 
     // While we're connecting (a process that can't be aborted in RSocket), the WebSocket instance to close if we wanted
     // to abort the connection.
@@ -145,7 +142,7 @@ export class WebSocketSupport {
 
     const connector = new RSocketConnector({
       transport: new WebsocketClientTransport({
-        url,
+        url: request.url,
         wsCreator: (url) => {
           const socket = (pendingSocket = remote.createSocket(url));
 

--- a/packages/shared-internals/src/client/sync/stream/WebSocketSupport.ts
+++ b/packages/shared-internals/src/client/sync/stream/WebSocketSupport.ts
@@ -1,10 +1,15 @@
-import { FetchStrategy, LogLevels } from '@powersync/common';
-import { doneResult, SimpleAsyncIterator, valueResult } from '../../../utils/stream_transform.js';
-import { AbstractRemote, PreparedRequest, SocketSyncStreamOptions } from './AbstractRemote.js';
+// Note: This file gets bundled as a lazy import, along with all of its dependencies. For this reason, only use type
+// imports and let a caller provide the implementation.
+// An exception is RSocket, which we explicitly want to bundle into this file.
+import type { LogLevels } from '@powersync/common';
+import type { AbstractRemote, PreparedRequest } from './AbstractRemote.js';
+import type { EventQueue } from '../../../utils/async.js';
+import type { AbortOperation } from '../../../utils/AbortOperation.js';
+
+// doneResult and valueResult are tiny definitions we can afford to duplicate.
+import { doneResult, type SimpleAsyncIterator, valueResult } from '../../../utils/stream_transform.js';
 import { Requestable, RSocket, RSocketConnector } from 'rsocket-core';
 import { WebsocketClientTransport } from 'rsocket-websocket-client';
-import { AbortOperation } from '../../../utils/AbortOperation.js';
-import { EventQueue } from '../../../utils/async.js';
 
 const SYNC_QUEUE_REQUEST_HIGH_WATER = 10;
 const SYNC_QUEUE_REQUEST_LOW_WATER = 5;
@@ -20,211 +25,234 @@ const SOCKET_TIMEOUT_MS = 30_000;
 // significantly. Therefore this is longer than the socket timeout.
 const KEEP_ALIVE_LIFETIME_MS = 90_000;
 
-export async function webSocketSyncStream(
-  remote: AbstractRemote,
-  options: SocketSyncStreamOptions,
-  request: PreparedRequest
-): Promise<SimpleAsyncIterator<Uint8Array>> {
-  const { path, fetchStrategy = FetchStrategy.Buffered } = options;
-  const mimeType = 'application/json';
-  const userAgent = request.userAgent;
+export interface WebSocketSyncStreamPlatform {
+  LogLevels: typeof LogLevels;
+  EventQueue: typeof EventQueue;
+  AbortOperation: typeof AbortOperation;
+}
 
-  function toBuffer(js: any): Buffer {
-    return Buffer.from(JSON.stringify(js));
+export interface WebSocketSyncStreamOptions {
+  remote: AbstractRemote;
+  buffered: boolean;
+  abortSignal: AbortSignal;
+  requestPayload: unknown;
+  request: PreparedRequest;
+}
+
+export class WebSocketSupport {
+  #platform: WebSocketSyncStreamPlatform;
+
+  constructor(platform: WebSocketSyncStreamPlatform) {
+    this.#platform = platform;
   }
 
-  const syncQueueRequestSize = fetchStrategy == FetchStrategy.Buffered ? 10 : 1;
-  const url = request.url.replace(/^https?:\/\//, function (match) {
-    return match === 'https://' ? 'wss://' : 'ws://';
-  });
+  async webSocketSyncStream({
+    remote,
+    buffered,
+    request,
+    abortSignal,
+    requestPayload
+  }: WebSocketSyncStreamOptions): Promise<SimpleAsyncIterator<Uint8Array>> {
+    const mimeType = 'application/json';
+    const userAgent = request.userAgent;
 
-  // While we're connecting (a process that can't be aborted in RSocket), the WebSocket instance to close if we wanted
-  // to abort the connection.
-  let pendingSocket: WebSocket | null = null;
-  let keepAliveTimeout: any;
-  let rsocket: RSocket | null = null;
-  let paused = false;
-  const queue = new EventQueue<Uint8Array | null>({
-    eventDelivered: () => {
-      if (queue.countOutstandingEvents <= SYNC_QUEUE_REQUEST_LOW_WATER) {
-        paused = false;
-        requestMore();
-      }
-    }
-  });
-  let didClose = false;
-  let connectionEstablished = false;
-  let pendingEventsCount = syncQueueRequestSize;
-  let res: Requestable | null = null;
-
-  const abortRequest = () => {
-    if (didClose) {
-      return;
-    }
-    didClose = true;
-
-    clearTimeout(keepAliveTimeout);
-
-    if (pendingSocket) {
-      pendingSocket.close();
+    function toBuffer(js: any): Buffer {
+      return Buffer.from(JSON.stringify(js));
     }
 
-    if (rsocket) {
-      rsocket.close();
-    }
+    const syncQueueRequestSize = buffered ? 10 : 1;
+    const url = request.url.replace(/^https?:\/\//, function (match) {
+      return match === 'https://' ? 'wss://' : 'ws://';
+    });
 
-    // Send a bogus event to the queue to ensure a pending listener gets woken up. We check for didClose and would
-    // return a doneEvent.
-    queue.notify(null);
-  };
-
-  function push(event: Uint8Array) {
-    queue.notify(event);
-    if (queue.countOutstandingEvents >= SYNC_QUEUE_REQUEST_HIGH_WATER) {
-      paused = true;
-    }
-  }
-
-  function requestMore() {
-    const delta = syncQueueRequestSize - pendingEventsCount;
-    if (!paused && delta > 0) {
-      res?.request(delta);
-      pendingEventsCount = syncQueueRequestSize;
-    }
-  }
-
-  // Handle upstream abort
-  if (options.abortSignal.aborted) {
-    throw new AbortOperation('Connection request aborted');
-  } else {
-    options.abortSignal.addEventListener('abort', abortRequest);
-  }
-
-  const resetTimeout = () => {
-    clearTimeout(keepAliveTimeout);
-    keepAliveTimeout = setTimeout(() => {
-      remote.logger.log({
-        level: LogLevels.error,
-        message: `No data received on WebSocket in ${SOCKET_TIMEOUT_MS}ms, closing connection.`
-      });
-      abortRequest();
-    }, SOCKET_TIMEOUT_MS);
-  };
-  resetTimeout();
-
-  const connector = new RSocketConnector({
-    transport: new WebsocketClientTransport({
-      url,
-      wsCreator: (url) => {
-        const socket = (pendingSocket = remote.createSocket(url));
-
-        socket.addEventListener('message', () => {
-          resetTimeout();
-        });
-        return socket;
-      }
-    }),
-    setup: {
-      keepAlive: KEEP_ALIVE_MS,
-      lifetime: KEEP_ALIVE_LIFETIME_MS,
-      dataMimeType: mimeType,
-      metadataMimeType: mimeType,
-      payload: {
-        data: null,
-        metadata: toBuffer({
-          token: request.headers.Authorization,
-          user_agent: userAgent
-        })
-      }
-    }
-  });
-
-  try {
-    rsocket = await connector.connect();
-    // The connection is established, we no longer need to monitor the initial timeout
-    pendingSocket = null;
-  } catch (ex) {
-    remote.logger.log({ level: LogLevels.error, message: `Failed to connect WebSocket`, error: ex });
-    abortRequest();
-
-    throw ex;
-  }
-
-  resetTimeout();
-
-  // Helps to prevent double close scenarios
-  rsocket.onClose(() => (rsocket = null));
-
-  return await new Promise((resolve, reject) => {
-    const queueAsIterator: SimpleAsyncIterator<Uint8Array> = {
-      next: async () => {
-        if (didClose) return doneResult;
-
-        const notification = await queue.waitForEvent(options.abortSignal);
-        if (didClose) {
-          return doneResult;
-        } else {
-          return valueResult(notification!);
+    // While we're connecting (a process that can't be aborted in RSocket), the WebSocket instance to close if we wanted
+    // to abort the connection.
+    let pendingSocket: WebSocket | null = null;
+    let keepAliveTimeout: any;
+    let rsocket: RSocket | null = null;
+    let paused = false;
+    const queue = new this.#platform.EventQueue<Uint8Array | null>({
+      eventDelivered: () => {
+        if (queue.countOutstandingEvents <= SYNC_QUEUE_REQUEST_LOW_WATER) {
+          paused = false;
+          requestMore();
         }
       }
+    });
+    let didClose = false;
+    let connectionEstablished = false;
+    let pendingEventsCount = syncQueueRequestSize;
+    let res: Requestable | null = null;
+
+    const abortRequest = () => {
+      if (didClose) {
+        return;
+      }
+      didClose = true;
+
+      clearTimeout(keepAliveTimeout);
+
+      if (pendingSocket) {
+        pendingSocket.close();
+      }
+
+      if (rsocket) {
+        rsocket.close();
+      }
+
+      // Send a bogus event to the queue to ensure a pending listener gets woken up. We check for didClose and would
+      // return a doneEvent.
+      queue.notify(null);
     };
 
-    res = rsocket!.requestStream(
-      {
-        data: toBuffer(options.data),
-        metadata: toBuffer({
-          path
-        })
-      },
-      syncQueueRequestSize, // The initial N amount
-      {
-        onError: (e) => {
-          if (e.message.includes('PSYNC_')) {
-            if (e.message.includes('PSYNC_S21')) {
-              remote.invalidateCredentials();
-            }
-          } else {
-            // Possible that connection is with an older service, always invalidate to be safe
-            if (e.message !== 'Closed. ') {
-              remote.invalidateCredentials();
-            }
-          }
-
-          // Don't log closed as an error
-          if (e.message !== 'Closed. ') {
-            remote.logger.log({ level: LogLevels.error, message: 'RSocket error', error: e });
-          }
-          // RSocket will close the RSocket stream automatically
-          // Close the downstream stream as well - this will close the RSocket connection and WebSocket
-          abortRequest();
-          // Handles cases where the connection failed e.g. auth error or connection error
-          if (!connectionEstablished) {
-            reject(e);
-          }
-        },
-        onNext: (payload) => {
-          // The connection is active
-          if (!connectionEstablished) {
-            connectionEstablished = true;
-            resolve(queueAsIterator);
-          }
-          const { data } = payload;
-
-          if (data) {
-            push(data);
-          }
-
-          // Less events are now pending
-          pendingEventsCount--;
-
-          // Request another event (unless the downstream consumer is paused).
-          requestMore();
-        },
-        onComplete: () => {
-          abortRequest(); // this will also emit a done event
-        },
-        onExtension: () => {}
+    function push(event: Uint8Array) {
+      queue.notify(event);
+      if (queue.countOutstandingEvents >= SYNC_QUEUE_REQUEST_HIGH_WATER) {
+        paused = true;
       }
-    );
-  });
+    }
+
+    function requestMore() {
+      const delta = syncQueueRequestSize - pendingEventsCount;
+      if (!paused && delta > 0) {
+        res?.request(delta);
+        pendingEventsCount = syncQueueRequestSize;
+      }
+    }
+
+    // Handle upstream abort
+    if (abortSignal.aborted) {
+      throw new this.#platform.AbortOperation('Connection request aborted');
+    } else {
+      abortSignal.addEventListener('abort', abortRequest);
+    }
+
+    const resetTimeout = () => {
+      clearTimeout(keepAliveTimeout);
+      keepAliveTimeout = setTimeout(() => {
+        remote.logger.log({
+          level: this.#platform.LogLevels.error,
+          message: `No data received on WebSocket in ${SOCKET_TIMEOUT_MS}ms, closing connection.`
+        });
+        abortRequest();
+      }, SOCKET_TIMEOUT_MS);
+    };
+    resetTimeout();
+
+    const connector = new RSocketConnector({
+      transport: new WebsocketClientTransport({
+        url,
+        wsCreator: (url) => {
+          const socket = (pendingSocket = remote.createSocket(url));
+
+          socket.addEventListener('message', () => {
+            resetTimeout();
+          });
+          return socket;
+        }
+      }),
+      setup: {
+        keepAlive: KEEP_ALIVE_MS,
+        lifetime: KEEP_ALIVE_LIFETIME_MS,
+        dataMimeType: mimeType,
+        metadataMimeType: mimeType,
+        payload: {
+          data: null,
+          metadata: toBuffer({
+            token: request.headers.Authorization,
+            user_agent: userAgent
+          })
+        }
+      }
+    });
+
+    try {
+      rsocket = await connector.connect();
+      // The connection is established, we no longer need to monitor the initial timeout
+      pendingSocket = null;
+    } catch (ex) {
+      remote.logger.log({ level: this.#platform.LogLevels.error, message: `Failed to connect WebSocket`, error: ex });
+      abortRequest();
+
+      throw ex;
+    }
+
+    resetTimeout();
+
+    // Helps to prevent double close scenarios
+    rsocket.onClose(() => (rsocket = null));
+
+    return await new Promise((resolve, reject) => {
+      const queueAsIterator: SimpleAsyncIterator<Uint8Array> = {
+        next: async () => {
+          if (didClose) return doneResult;
+
+          const notification = await queue.waitForEvent(abortSignal);
+          if (didClose) {
+            return doneResult;
+          } else {
+            return valueResult(notification!);
+          }
+        }
+      };
+
+      res = rsocket!.requestStream(
+        {
+          data: toBuffer(requestPayload),
+          metadata: toBuffer({
+            path: request.path
+          })
+        },
+        syncQueueRequestSize, // The initial N amount
+        {
+          onError: (e) => {
+            if (e.message.includes('PSYNC_')) {
+              if (e.message.includes('PSYNC_S21')) {
+                remote.invalidateCredentials();
+              }
+            } else {
+              // Possible that connection is with an older service, always invalidate to be safe
+              if (e.message !== 'Closed. ') {
+                remote.invalidateCredentials();
+              }
+            }
+
+            // Don't log closed as an error
+            if (e.message !== 'Closed. ') {
+              remote.logger.log({ level: this.#platform.LogLevels.error, message: 'RSocket error', error: e });
+            }
+            // RSocket will close the RSocket stream automatically
+            // Close the downstream stream as well - this will close the RSocket connection and WebSocket
+            abortRequest();
+            // Handles cases where the connection failed e.g. auth error or connection error
+            if (!connectionEstablished) {
+              reject(e);
+            }
+          },
+          onNext: (payload) => {
+            // The connection is active
+            if (!connectionEstablished) {
+              connectionEstablished = true;
+              resolve(queueAsIterator);
+            }
+            const { data } = payload;
+
+            if (data) {
+              push(data);
+            }
+
+            // Less events are now pending
+            pendingEventsCount--;
+
+            // Request another event (unless the downstream consumer is paused).
+            requestMore();
+          },
+          onComplete: () => {
+            abortRequest(); // this will also emit a done event
+          },
+          onExtension: () => {}
+        }
+      );
+    });
+  }
 }

--- a/packages/shared-internals/src/client/sync/stream/WebSocketSupport.ts
+++ b/packages/shared-internals/src/client/sync/stream/WebSocketSupport.ts
@@ -1,0 +1,230 @@
+import { FetchStrategy, LogLevels } from '@powersync/common';
+import { doneResult, SimpleAsyncIterator, valueResult } from '../../../utils/stream_transform.js';
+import { AbstractRemote, PreparedRequest, SocketSyncStreamOptions } from './AbstractRemote.js';
+import { Requestable, RSocket, RSocketConnector } from 'rsocket-core';
+import { WebsocketClientTransport } from 'rsocket-websocket-client';
+import { AbortOperation } from '../../../utils/AbortOperation.js';
+import { EventQueue } from '../../../utils/async.js';
+
+const SYNC_QUEUE_REQUEST_HIGH_WATER = 10;
+const SYNC_QUEUE_REQUEST_LOW_WATER = 5;
+
+// Keep alive message is sent every period
+const KEEP_ALIVE_MS = 20_000;
+
+// One message of any type must be received in this period.
+const SOCKET_TIMEOUT_MS = 30_000;
+
+// One keepalive message must be received in this period.
+// If there is a backlog of messages (for example on slow connections), keepalive messages could be delayed
+// significantly. Therefore this is longer than the socket timeout.
+const KEEP_ALIVE_LIFETIME_MS = 90_000;
+
+export async function webSocketSyncStream(
+  remote: AbstractRemote,
+  options: SocketSyncStreamOptions,
+  request: PreparedRequest
+): Promise<SimpleAsyncIterator<Uint8Array>> {
+  const { path, fetchStrategy = FetchStrategy.Buffered } = options;
+  const mimeType = 'application/json';
+  const userAgent = request.userAgent;
+
+  function toBuffer(js: any): Buffer {
+    return Buffer.from(JSON.stringify(js));
+  }
+
+  const syncQueueRequestSize = fetchStrategy == FetchStrategy.Buffered ? 10 : 1;
+  const url = request.url.replace(/^https?:\/\//, function (match) {
+    return match === 'https://' ? 'wss://' : 'ws://';
+  });
+
+  // While we're connecting (a process that can't be aborted in RSocket), the WebSocket instance to close if we wanted
+  // to abort the connection.
+  let pendingSocket: WebSocket | null = null;
+  let keepAliveTimeout: any;
+  let rsocket: RSocket | null = null;
+  let paused = false;
+  const queue = new EventQueue<Uint8Array | null>({
+    eventDelivered: () => {
+      if (queue.countOutstandingEvents <= SYNC_QUEUE_REQUEST_LOW_WATER) {
+        paused = false;
+        requestMore();
+      }
+    }
+  });
+  let didClose = false;
+  let connectionEstablished = false;
+  let pendingEventsCount = syncQueueRequestSize;
+  let res: Requestable | null = null;
+
+  const abortRequest = () => {
+    if (didClose) {
+      return;
+    }
+    didClose = true;
+
+    clearTimeout(keepAliveTimeout);
+
+    if (pendingSocket) {
+      pendingSocket.close();
+    }
+
+    if (rsocket) {
+      rsocket.close();
+    }
+
+    // Send a bogus event to the queue to ensure a pending listener gets woken up. We check for didClose and would
+    // return a doneEvent.
+    queue.notify(null);
+  };
+
+  function push(event: Uint8Array) {
+    queue.notify(event);
+    if (queue.countOutstandingEvents >= SYNC_QUEUE_REQUEST_HIGH_WATER) {
+      paused = true;
+    }
+  }
+
+  function requestMore() {
+    const delta = syncQueueRequestSize - pendingEventsCount;
+    if (!paused && delta > 0) {
+      res?.request(delta);
+      pendingEventsCount = syncQueueRequestSize;
+    }
+  }
+
+  // Handle upstream abort
+  if (options.abortSignal.aborted) {
+    throw new AbortOperation('Connection request aborted');
+  } else {
+    options.abortSignal.addEventListener('abort', abortRequest);
+  }
+
+  const resetTimeout = () => {
+    clearTimeout(keepAliveTimeout);
+    keepAliveTimeout = setTimeout(() => {
+      remote.logger.log({
+        level: LogLevels.error,
+        message: `No data received on WebSocket in ${SOCKET_TIMEOUT_MS}ms, closing connection.`
+      });
+      abortRequest();
+    }, SOCKET_TIMEOUT_MS);
+  };
+  resetTimeout();
+
+  const connector = new RSocketConnector({
+    transport: new WebsocketClientTransport({
+      url,
+      wsCreator: (url) => {
+        const socket = (pendingSocket = remote.createSocket(url));
+
+        socket.addEventListener('message', () => {
+          resetTimeout();
+        });
+        return socket;
+      }
+    }),
+    setup: {
+      keepAlive: KEEP_ALIVE_MS,
+      lifetime: KEEP_ALIVE_LIFETIME_MS,
+      dataMimeType: mimeType,
+      metadataMimeType: mimeType,
+      payload: {
+        data: null,
+        metadata: toBuffer({
+          token: request.headers.Authorization,
+          user_agent: userAgent
+        })
+      }
+    }
+  });
+
+  try {
+    rsocket = await connector.connect();
+    // The connection is established, we no longer need to monitor the initial timeout
+    pendingSocket = null;
+  } catch (ex) {
+    remote.logger.log({ level: LogLevels.error, message: `Failed to connect WebSocket`, error: ex });
+    abortRequest();
+
+    throw ex;
+  }
+
+  resetTimeout();
+
+  // Helps to prevent double close scenarios
+  rsocket.onClose(() => (rsocket = null));
+
+  return await new Promise((resolve, reject) => {
+    const queueAsIterator: SimpleAsyncIterator<Uint8Array> = {
+      next: async () => {
+        if (didClose) return doneResult;
+
+        const notification = await queue.waitForEvent(options.abortSignal);
+        if (didClose) {
+          return doneResult;
+        } else {
+          return valueResult(notification!);
+        }
+      }
+    };
+
+    res = rsocket!.requestStream(
+      {
+        data: toBuffer(options.data),
+        metadata: toBuffer({
+          path
+        })
+      },
+      syncQueueRequestSize, // The initial N amount
+      {
+        onError: (e) => {
+          if (e.message.includes('PSYNC_')) {
+            if (e.message.includes('PSYNC_S21')) {
+              remote.invalidateCredentials();
+            }
+          } else {
+            // Possible that connection is with an older service, always invalidate to be safe
+            if (e.message !== 'Closed. ') {
+              remote.invalidateCredentials();
+            }
+          }
+
+          // Don't log closed as an error
+          if (e.message !== 'Closed. ') {
+            remote.logger.log({ level: LogLevels.error, message: 'RSocket error', error: e });
+          }
+          // RSocket will close the RSocket stream automatically
+          // Close the downstream stream as well - this will close the RSocket connection and WebSocket
+          abortRequest();
+          // Handles cases where the connection failed e.g. auth error or connection error
+          if (!connectionEstablished) {
+            reject(e);
+          }
+        },
+        onNext: (payload) => {
+          // The connection is active
+          if (!connectionEstablished) {
+            connectionEstablished = true;
+            resolve(queueAsIterator);
+          }
+          const { data } = payload;
+
+          if (data) {
+            push(data);
+          }
+
+          // Less events are now pending
+          pendingEventsCount--;
+
+          // Request another event (unless the downstream consumer is paused).
+          requestMore();
+        },
+        onComplete: () => {
+          abortRequest(); // this will also emit a done event
+        },
+        onExtension: () => {}
+      }
+    );
+  });
+}

--- a/packages/shared-internals/src/client/sync/stream/WebSocketSupport.ts
+++ b/packages/shared-internals/src/client/sync/stream/WebSocketSupport.ts
@@ -25,6 +25,10 @@ const SOCKET_TIMEOUT_MS = 30_000;
 // significantly. Therefore this is longer than the socket timeout.
 const KEEP_ALIVE_LIFETIME_MS = 90_000;
 
+/**
+ * Symbols from the main module used in WebSockets too. We're passing those from the main module to avoid bundling them
+ * again.
+ */
 export interface WebSocketSyncStreamPlatform {
   LogLevels: typeof LogLevels;
   EventQueue: typeof EventQueue;

--- a/packages/shared-internals/src/version.ts
+++ b/packages/shared-internals/src/version.ts
@@ -1,0 +1,3 @@
+// Note: This file gets updated by tool/update_version.js script as part of the Changesets release workflow.
+// The update happens in the changesets PR, before the package is built.
+export const POWERSYNC_JS_VERSION = 'unset before initial release';

--- a/packages/shared-internals/tool/update_version.js
+++ b/packages/shared-internals/tool/update_version.js
@@ -1,13 +1,15 @@
-import { readFileSync, writeFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import pkg from '../package.json' with { type: 'json' };
 
 const version = pkg.version;
 
-const abstractRemotePath = resolve(fileURLToPath(import.meta.url), '../../src/client/sync/stream/AbstractRemote.ts');
-let source = readFileSync(abstractRemotePath, 'utf-8');
-source = source.replace(/^const POWERSYNC_JS_VERSION = '.*'/m, `const POWERSYNC_JS_VERSION = '${version}'`);
+const versionTsPath = resolve(fileURLToPath(import.meta.url), '../../src/version.ts');
+const source = `// Note: This file gets updated by tool/update_version.js script as part of the Changesets release workflow.
+// The update happens in the changesets PR, before the package is built.
+export const POWERSYNC_JS_VERSION = '${version}';
+`;
 
-writeFileSync(abstractRemotePath, source);
+writeFileSync(versionTsPath, source);
 console.log(`Updated POWERSYNC_JS_VERSION constant to ${version}`);

--- a/packages/shared-internals/tool/update_version.js
+++ b/packages/shared-internals/tool/update_version.js
@@ -1,0 +1,13 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import pkg from '../package.json' with { type: 'json' };
+
+const version = pkg.version;
+
+const abstractRemotePath = resolve(fileURLToPath(import.meta.url), '../../src/client/sync/stream/AbstractRemote.ts');
+let source = readFileSync(abstractRemotePath, 'utf-8');
+source = source.replace(/^const POWERSYNC_JS_VERSION = '.*'/m, `const POWERSYNC_JS_VERSION = '${version}'`);
+
+writeFileSync(abstractRemotePath, source);
+console.log(`Updated POWERSYNC_JS_VERSION constant to ${version}`);

--- a/packages/web/src/db/sync/WebRemote.ts
+++ b/packages/web/src/db/sync/WebRemote.ts
@@ -1,33 +1,18 @@
 import { LogLevels, PowerSyncLogger } from '@powersync/common';
-import {
-  AbstractRemote,
-  AbstractRemoteOptions,
-  FetchImplementation,
-  FetchImplementationProvider,
-  RemoteConnector
-} from '@powersync/shared-internals';
+import { AbstractRemote, FetchOptions, RemoteConnector } from '@powersync/shared-internals';
 
 import { getUserAgentInfo } from './userAgent.js';
-
-/*
- * Depends on browser's implementation of global fetch.
- */
-class WebFetchProvider extends FetchImplementationProvider {
-  getFetch(): FetchImplementation {
-    return fetch.bind(globalThis);
-  }
-}
 
 export class WebRemote extends AbstractRemote {
   constructor(
     protected connector: RemoteConnector,
-    protected logger: PowerSyncLogger,
-    options?: Partial<AbstractRemoteOptions>
+    logger: PowerSyncLogger
   ) {
-    super(connector, logger, {
-      ...(options ?? {}),
-      fetchImplementation: options?.fetchImplementation ?? new WebFetchProvider()
-    });
+    super(connector, logger);
+  }
+
+  protected fetch({ resource, request }: FetchOptions): Promise<Response> {
+    return fetch(resource, request);
   }
 
   getUserAgent(): string {

--- a/packages/web/src/db/sync/WebRemote.ts
+++ b/packages/web/src/db/sync/WebRemote.ts
@@ -18,6 +18,7 @@ export class WebRemote extends AbstractRemote {
 
   protected async loadWebSocketSupport(platform: WebSocketSyncStreamPlatform): Promise<WebSocketSupport> {
     if (!websockets) {
+      // loadWebSocketSupport being called concurrently is safe, the import resolves to the same module in that case.
       const module = await import('@powersync/shared-internals/websockets');
       websockets = new module.WebSocketSupport(platform);
     }

--- a/packages/web/src/db/sync/WebRemote.ts
+++ b/packages/web/src/db/sync/WebRemote.ts
@@ -2,6 +2,7 @@ import { LogLevels, PowerSyncLogger } from '@powersync/common';
 import { AbstractRemote, FetchOptions, RemoteConnector } from '@powersync/shared-internals';
 
 import { getUserAgentInfo } from './userAgent.js';
+import type { WebSocketSyncStreamPlatform, WebSocketSupport } from '@powersync/shared-internals/websockets';
 
 export class WebRemote extends AbstractRemote {
   constructor(
@@ -15,6 +16,16 @@ export class WebRemote extends AbstractRemote {
     return fetch(resource, request);
   }
 
+  protected async loadWebSocketSupport(platform: WebSocketSyncStreamPlatform): Promise<WebSocketSupport> {
+    if (!websockets) {
+      websockets = import('@powersync/shared-internals/websockets').then(
+        (module) => new module.WebSocketSupport(platform)
+      );
+    }
+
+    return await websockets;
+  }
+
   getUserAgent(): string {
     let ua = [super.getUserAgent(), `powersync-web`];
     try {
@@ -25,3 +36,5 @@ export class WebRemote extends AbstractRemote {
     return ua.join(' ');
   }
 }
+
+let websockets: Promise<WebSocketSupport> | undefined;

--- a/packages/web/src/db/sync/WebRemote.ts
+++ b/packages/web/src/db/sync/WebRemote.ts
@@ -18,12 +18,11 @@ export class WebRemote extends AbstractRemote {
 
   protected async loadWebSocketSupport(platform: WebSocketSyncStreamPlatform): Promise<WebSocketSupport> {
     if (!websockets) {
-      websockets = import('@powersync/shared-internals/websockets').then(
-        (module) => new module.WebSocketSupport(platform)
-      );
+      const module = await import('@powersync/shared-internals/websockets');
+      websockets = new module.WebSocketSupport(platform);
     }
 
-    return await websockets;
+    return websockets;
   }
 
   getUserAgent(): string {
@@ -37,4 +36,4 @@ export class WebRemote extends AbstractRemote {
   }
 }
 
-let websockets: Promise<WebSocketSupport> | undefined;
+let websockets: WebSocketSupport | undefined;

--- a/packages/web/tests/mocks/MockWebRemote.ts
+++ b/packages/web/tests/mocks/MockWebRemote.ts
@@ -1,9 +1,8 @@
 import { PowerSyncLogger } from '@powersync/common';
 import {
   AbstractRemote,
-  AbstractRemoteOptions,
   FetchImplementation,
-  FetchImplementationProvider,
+  FetchOptions,
   RemoteConnector,
   SocketSyncStreamOptions
 } from '@powersync/shared-internals';
@@ -21,37 +20,33 @@ import { MockSyncService, setupMockServiceMessageHandler } from '../utils/MockSy
  * 2. Wait for a client to create a response before returning
  * 3. Set up message handler for the mock service when onconnect is called
  */
-class MockSyncServiceFetchProvider extends FetchImplementationProvider {
-  getFetch(): FetchImplementation {
-    return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-      const request = new Request(input, init);
+export async function mockFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const request = new Request(input, init);
 
-      const mockService = MockSyncService.GLOBAL_INSTANCE;
+  const mockService = MockSyncService.GLOBAL_INSTANCE;
 
-      // Read the request body (if any)
-      let body: any = null;
-      try {
-        if (request.body) {
-          const clonedRequest = request.clone();
-          body = await clonedRequest.json().catch(() => {
-            // If JSON parsing fails, try text
-            return clonedRequest.text().catch(() => null);
-          });
-        }
-      } catch (e) {
-        // Body might not be readable, that's okay
-      }
-
-      // Extract headers from the request
-      const headers: Record<string, string> = {};
-      request.headers.forEach((value, key) => {
-        headers[key] = value;
+  // Read the request body (if any)
+  let body: any = null;
+  try {
+    if (request.body) {
+      const clonedRequest = request.clone();
+      body = await clonedRequest.json().catch(() => {
+        // If JSON parsing fails, try text
+        return clonedRequest.text().catch(() => null);
       });
-
-      // Register as a pending request and wait for client to create response
-      return await mockService.registerPendingRequest(request.url, request.method, headers, body, request.signal);
-    };
+    }
+  } catch (e) {
+    // Body might not be readable, that's okay
   }
+
+  // Extract headers from the request
+  const headers: Record<string, string> = {};
+  request.headers.forEach((value, key) => {
+    headers[key] = value;
+  });
+
+  // Register as a pending request and wait for client to create response
+  return await mockService.registerPendingRequest(request.url, request.method, headers, body, request.signal);
 }
 
 /**
@@ -87,16 +82,13 @@ export class WebRemote extends AbstractRemote {
 
   constructor(
     protected connector: RemoteConnector,
-    protected logger: PowerSyncLogger,
-    options?: Partial<AbstractRemoteOptions>
+    logger: PowerSyncLogger
   ) {
-    // Use mock service fetch provider if we're in a shared worker context
-    const fetchProvider = new MockSyncServiceFetchProvider();
+    super(connector, logger);
+  }
 
-    super(connector, logger, {
-      ...(options ?? {}),
-      fetchImplementation: options?.fetchImplementation ?? fetchProvider
-    });
+  protected fetch(options: FetchOptions): Promise<Response> {
+    return mockFetch(options.resource, options.request);
   }
 
   getUserAgent(): string {

--- a/packages/web/tests/mocks/MockWebRemote.ts
+++ b/packages/web/tests/mocks/MockWebRemote.ts
@@ -1,11 +1,5 @@
 import { PowerSyncLogger } from '@powersync/common';
-import {
-  AbstractRemote,
-  FetchImplementation,
-  FetchOptions,
-  RemoteConnector,
-  SocketSyncStreamOptions
-} from '@powersync/shared-internals';
+import { AbstractRemote, FetchOptions, RemoteConnector, SocketSyncStreamOptions } from '@powersync/shared-internals';
 
 import { SimpleAsyncIterator } from '@powersync/shared-internals';
 import { type BSON } from 'bson';
@@ -102,6 +96,10 @@ export class WebRemote extends AbstractRemote {
     const { BSON } = await import('bson');
     this._bson = BSON;
     return this._bson;
+  }
+
+  protected loadWebSocketSupport(): Promise<never> {
+    throw new Error('Mocked WebRemote does not support WebSockets');
   }
 
   /**

--- a/packages/web/tests/utils/MockStreamOpenFactory.ts
+++ b/packages/web/tests/utils/MockStreamOpenFactory.ts
@@ -51,9 +51,10 @@ export class MockRemote extends AbstractRemote {
     });
   }
 
-  post(path: string, data: any, headers?: Record<string, string> | undefined): Promise<any> {
-    throw new Error('Method not implemented.');
+  protected fetch(): Promise<Response> {
+    throw new Error('Not implemented');
   }
+
   async get(path: string, headers?: Record<string, string> | undefined): Promise<any> {
     // mock a response for write checkpoint API
     if (path.includes('checkpoint')) {
@@ -62,12 +63,7 @@ export class MockRemote extends AbstractRemote {
     throw new Error('Not implemented');
   }
 
-  async postStreaming(
-    path: string,
-    data: any,
-    headers?: Record<string, string>,
-    signal?: AbortSignal
-  ): Promise<ReadableStream> {
+  async postStreaming(path: string, data: any, signal?: AbortSignal): Promise<ReadableStream> {
     const stream = new ReadableStream({
       start: (controller) => {
         this.streamController = controller;
@@ -99,7 +95,7 @@ export class MockRemote extends AbstractRemote {
   }
 
   async fetchStream(options: SyncStreamOptions): Promise<SimpleAsyncIterator<Uint8Array | string>> {
-    const mockResponse = await this.postStreaming(options.path, options.data, options.headers, options.abortSignal);
+    const mockResponse = await this.postStreaming(options.path, options.data, options.abortSignal);
     const mockReader = mockResponse.getReader();
     options.abortSignal?.addEventListener('abort', async () => {
       try {

--- a/packages/web/tests/utils/MockStreamOpenFactory.ts
+++ b/packages/web/tests/utils/MockStreamOpenFactory.ts
@@ -90,8 +90,8 @@ export class MockRemote extends AbstractRemote {
     return new Response(stream).body!;
   }
 
-  async socketStreamRaw<T>(): Promise<never> {
-    throw 'Unsupported: Socket streams are not currently supported in tests';
+  protected loadWebSocketSupport(): Promise<never> {
+    throw new Error('Mocked WebRemote does not support WebSockets');
   }
 
   async fetchStream(options: SyncStreamOptions): Promise<SimpleAsyncIterator<Uint8Array | string>> {


### PR DESCRIPTION
RSocket is a pain to import for users, and the only remaining reason we apply a bundler to our SDK. We can't avoid that entirely, but we can apply some tricks to only bundle code directly importing RSocket.

Before this PR, all of `@powersync/shared-internals` and dependencies like RSocket were bundled into a single file. Now, we:

1. Use plain tsc JavaScript modules for almost everything, except:
2. A single file providing RSocket support, written in a way to avoid any other imports.

This means that most of the SDK is now much easier to work on (more packages that can be built with `tsc -w` alone), and smaller too: The minified `WebSocketSupport` file with dependencies is 26 kB (111 kB uncompressed) that no longer need to be loaded and parsed unless WebSockets are actually used. 

This also simplifies `AbstractRemote a bit:

- Remove `AbstractRemoteOptions`! It was an implementation detail that shouldn't leak into public APIs.
  - Make `fetch` an abstract method, allowing implementations to call the global `fetch` directly (avoiding `bind(globalThis)`).
  - Avoid passing `fetchOptions` through different calls, if they are needed then an implementation should just add them before calling `fetch`.
- For the user agent, avoid importing `package.json` to get the version. Using a constant updated by changesets avoids having to bundle the entire `package.json`.

Manual testing:

- [x] Node with HTTP
- [x] Node with WebSockets
- [x] Vite-bundled app with HTTP
- [x] Vite-bundled app with WebSockets
- [x] Webpack-bundled app with HTTP
- [x] Webpack-bundled app with WebSockets
- [x] ReactNative with HTTP
- [x] ReactNative with WebSockets
