### PR TITLE
Copy relevant sections from old op-sqlite readme

### DIFF
--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -18,6 +18,82 @@ See a summary of features [here](https://docs.powersync.co/client-sdk-references
 npx expo install @powersync/react-native @op-engineering/op-sqlite
 ```
 
+## Configuration options
+
+### Encryption with SQLCipher
+
+To enable SQLCipher you need to add the following configuration option to your application's `package.json`. Note that for [monorepos](https://op-engineering.github.io/op-sqlite/docs/installation) you may have to add this configuration to the monorepo root `package.json` instead, this depends on where your package manager tool hoists modules.
+
+```json
+{
+  // your normal package.json
+  // ...
+  "op-sqlite": {
+    "sqlcipher": true
+  }
+}
+```
+
+Additionally you will need to add an [encryption key](https://www.zetetic.net/sqlcipher/sqlcipher-api/#key) to the OPSQLite factory constructor
+
+```typescript
+const db = new PowerSyncDatabase({
+  schema: new Schema(...),
+  database: {
+    dbFilename: 'sqlite.db',
+    sqliteOptions: {
+      encryptionKey: 'your-encryption-key'
+    }
+  }
+});
+```
+
+### Full-Text Search
+
+To enable the `fts5` extension, configure OP-SQLite in your (or for monorepos, the root) `package.json`:
+
+```json
+{
+  // your normal package.json
+  // ...
+  "op-sqlite": {
+    "fts5": true
+  }
+}
+```
+
+### Loading SQLite extensions
+
+To load additional SQLite extensions include the `extensions` option in `sqliteOptions` which expects an array of objects with a `path` and an `entryPoint`:
+
+```js
+sqliteOptions: {
+  extensions: [{ path: libPath, entryPoint: 'sqlite3_powersync_init' }];
+}
+```
+
+More info can be found in the [OP-SQLite docs](https://op-engineering.github.io/op-sqlite/docs/api/#loading-extensions).
+
+Example usage:
+
+```ts
+import { getDylibPath } from '@op-engineering/op-sqlite';
+
+let libPath: string;
+if (Platform.OS === 'ios') {
+  libPath = getDylibPath('co.powersync.sqlitecore', 'powersync-sqlite-core');
+} else {
+  libPath = 'libpowersync';
+}
+
+const factory = new OPSqliteOpenFactory({
+  dbFilename: 'sqlite.db',
+  sqliteOptions: {
+    extensions: [{ path: libPath, entryPoint: 'sqlite3_powersync_init' }]
+  }
+});
+```
+
 ## Install Polyfills
 
 - Polyfills are required for [watched queries](#babel-plugins-watched-queries) using the Async Iterator response format.

--- a/packages/react-native/src/db/PowerSyncDatabase.ts
+++ b/packages/react-native/src/db/PowerSyncDatabase.ts
@@ -5,7 +5,6 @@ import {
   DBAdapter,
   PowerSyncBackendConnector,
   PowerSyncDatabaseConstructor,
-  PowerSyncDatabaseOptions,
   SyncStreamConnectionMethod
 } from '@powersync/common';
 import {
@@ -86,6 +85,6 @@ class ReactNativePowerSyncDatabase extends BasePowerSyncDatabase<ReactNativeData
  * });
  * ```
  */
-export const PowerSyncDatabase: PowerSyncDatabaseConstructor<PowerSyncDatabaseOptions> = ReactNativePowerSyncDatabase;
+export const PowerSyncDatabase: PowerSyncDatabaseConstructor<ReactNativeDatabaseOptions> = ReactNativePowerSyncDatabase;
 
 export interface PowerSyncDatabase extends CommonPowerSyncDatabase {}


### PR DESCRIPTION
Features like fts5 and encryption require `package.json` changes to configure them with op-sqlite. The old readme documented those, this adds relevant sections to `@powersync/react-native` as well.