### PR TITLE
fix(ts): some types polyshing, shorten filenames in web package dist/worker folder

### DIFF
--- a/packages/common/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/common/src/client/sync/stream/AbstractRemote.ts
@@ -42,7 +42,7 @@ const KEEP_ALIVE_LIFETIME_MS = 90_000;
 /**
  * @internal
  */
-export const DEFAULT_REMOTE_LOGGER = Logger.get('PowerSyncRemote');
+export const DEFAULT_REMOTE_LOGGER: ILogger = Logger.get('PowerSyncRemote');
 
 /**
  * @internal

--- a/packages/common/src/utils/Logger.ts
+++ b/packages/common/src/utils/Logger.ts
@@ -7,7 +7,15 @@ const TypedLogger: ILogger = Logger as any;
 /**
  * @public
  */
-export const LogLevel = {
+export const LogLevel: {
+  TRACE: ILogLevel;
+  DEBUG: ILogLevel;
+  INFO: ILogLevel;
+  TIME: ILogLevel;
+  WARN: ILogLevel;
+  ERROR: ILogLevel;
+  OFF: ILogLevel;
+} = {
   TRACE: TypedLogger.TRACE,
   DEBUG: TypedLogger.DEBUG,
   INFO: TypedLogger.INFO,

--- a/packages/node/tests/sync.test.ts
+++ b/packages/node/tests/sync.test.ts
@@ -8,9 +8,9 @@ import {
   ProgressWithOperations,
   Schema,
   SyncClientImplementation,
-  SyncStreamConnectionMethod
+  SyncStreamConnectionMethod,
+  LogLevel,
 } from '@powersync/common';
-import Logger from 'js-logger';
 import {
   bucket,
   MockSyncService,
@@ -602,7 +602,7 @@ function defineSyncTests(bson: boolean) {
   });
 
   mockSyncServiceTest('handles uploads across checkpoints', async ({ syncService }) => {
-    const logger = createLogger('test', { logLevel: (Logger as any).TRACE });
+    const logger = createLogger('test', { logLevel: LogLevel.TRACE });
     const logMessages: string[] = [];
     (logger as any).invoke = (level, args) => {
       console.log(...args);
@@ -933,7 +933,7 @@ function defineSyncTests(bson: boolean) {
 
   mockSyncServiceTest('can reconnect based on query changes', async ({ syncService }) => {
     // Test for https://discord.com/channels/1138230179878154300/1399340612435710034/1399340612435710034
-    const logger = createLogger('test', { logLevel: (Logger as any).TRACE });
+    const logger = createLogger('test', { logLevel: LogLevel.TRACE });
     const logMessages: string[] = [];
     (logger as any).invoke = (level, args) => {
       console.log(...args);

--- a/packages/web/src/db/adapters/wa-sqlite/RawSqliteConnection.ts
+++ b/packages/web/src/db/adapters/wa-sqlite/RawSqliteConnection.ts
@@ -45,8 +45,8 @@ export class RawSqliteConnection {
     );
     await this.executeRaw(`PRAGMA temp_store = ${this.options.temporaryStorage};`);
     if (this.options.encryptionKey) {
-      const escapedKey = this.options.encryptionKey.replace("'", "''");
-      await this.executeRaw(`PRAGMA key = '${escapedKey}'`);
+      const escapedKey = this.options.encryptionKey.replaceAll("'", "''");
+      await this.executeRaw(`PRAGMA key = '${escapedKey}';`);
     }
     await this.executeRaw(`PRAGMA cache_size = -${this.options.cacheSizeKb};`);
 

--- a/packages/web/webpack.workers.config.js
+++ b/packages/web/webpack.workers.config.js
@@ -18,6 +18,7 @@ export default () => {
     },
     output: {
       filename: 'worker/[name].umd.js',
+      chunkFilename: 'worker/[contenthash].umd.js',
       path: path.join(__dirname, 'dist'),
       library: {
         name: 'sdk_web',


### PR DESCRIPTION
Fixed errors with skipLibCheck:false

Multiple errors as
```
TS2503: Cannot find namespace 'Logger'
    node_modules/@powersync/common/lib/utils/Logger.d.ts:11:10:
      11 │     WARN: Logger.ILogLevel;
         ╵           ~~~~~~
```

Allow to use HEX key for encryption as stated in https://utelle.github.io/SQLite3MultipleCiphers/docs/configuration/config_sql_pragmas/#pragma-key--hexkey
by replacing quotes and forcefully set ChaCha20 as cipher, because under hood it's seems not default as stated in docs