### PR TITLE
Fix dev publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
         run: |
           pnpm build:packages:prod
           pnpm changeset version --no-git-tag --snapshot dev
+          pnpm install --no-frozen-lockfile
           pnpm changeset publish --tag dev
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We have a few `workspace:<currentversion>` dependencies between packages that `changeset version` will update for us. That's a problem for dev-releases, because that requires a new lockfile (or else `pnpm install` will fail in CI). To fix dev releases, this adds adds a step for dev publishing to update the outdated lockfile.

I think the risk of this is fairly low - dev releases can only be triggered by us and there's a lockfile check before we run `build:packages:prod`. No changes are necessary for real releases as changesets updates the lockfile in versioning PRs.