### PR TITLE
fix(v2) dev release fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,3 +54,4 @@ jobs:
           pnpm changeset publish --tag dev
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_FROZEN_LOCKFILE: 'false'


### PR DESCRIPTION
Addresses https://github.com/powersync-ja/powersync-js/actions/runs/28441559689/job/84280530994

This allows outdated lockfiles for dev releases.