### PR TITLE
Fix/sync stream typo

### DIFF
--- a/packages/common/src/db/crud/SyncStatus.ts
+++ b/packages/common/src/db/crud/SyncStatus.ts
@@ -61,7 +61,7 @@ export type SyncStatusOptions = {
  * @public
  */
 export class SyncStatus {
-  constructor(protected options: SyncStatusOptions) {}
+  constructor(protected options: SyncStatusOptions) { }
 
   /**
    * Returns the used sync client implementation (either the one implemented in JavaScript or the newer Rust-based
@@ -138,7 +138,7 @@ export class SyncStatus {
   }
 
   /**
-   * All sync streams currently being tracked in teh database.
+   * All sync streams currently being tracked in the database.
    *
    * This returns null when the database is currently being opened and we don't have reliable information about all
    * included streams yet.

--- a/packages/common/src/db/crud/SyncStatus.ts
+++ b/packages/common/src/db/crud/SyncStatus.ts
@@ -61,7 +61,7 @@ export type SyncStatusOptions = {
  * @public
  */
 export class SyncStatus {
-  constructor(protected options: SyncStatusOptions) { }
+  constructor(protected options: SyncStatusOptions) {}
 
   /**
    * Returns the used sync client implementation (either the one implemented in JavaScript or the newer Rust-based


### PR DESCRIPTION
change `teh` to `the` in the `syncStream` documentation.