### PR TITLE
fix: Release/build fix for op-sqlite/bob gen

### DIFF
--- a/.changeset/honest-streams-enable.md
+++ b/.changeset/honest-streams-enable.md
@@ -1,0 +1,5 @@
+---
+'@powersync/tanstack-react-query': patch
+---
+
+Respect the user-provided `enabled` option in `useQuery` and `useQueries` instead of overriding it. Queries backed by sync streams now pause via TanStack's `skipToken` until their streams have synced, leaving `enabled` fully under the caller's control (`useSuspenseQuery` always runs, since suspense rejects `skipToken`). Also fixes a stale `streamsHaveSynced` value and a race where rows written while a query's source tables were still being resolved could be missed.

--- a/.changeset/polish-diagnostics-app.md
+++ b/.changeset/polish-diagnostics-app.md
@@ -1,0 +1,5 @@
+---
+'@powersync/diagnostics-app': patch
+---
+
+Polish UI, terminology, and documentation.

--- a/demos/react-neon-tanstack-query-notes/package.json
+++ b/demos/react-neon-tanstack-query-notes/package.json
@@ -18,7 +18,7 @@
     "@neondatabase/serverless": "^1.0.2",
     "@powersync/drizzle-driver": "^0.7.4",
     "@powersync/react": "^1.10.0",
-    "@powersync/tanstack-react-query": "^0.2.13",
+    "@powersync/tanstack-react-query": "^0.2.12",
     "@powersync/web": "^1.38.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-toggle": "^1.1.10",

--- a/packages/powersync-op-sqlite/package.json
+++ b/packages/powersync-op-sqlite/package.json
@@ -75,6 +75,7 @@
   },
   "devDependencies": {
     "@op-engineering/op-sqlite": "catalog:",
+    "@react-native-community/cli": "^20.0.0",
     "@react-native/eslint-config": "^0.83.1",
     "@types/react": "^19.1.1",
     "del-cli": "^7.0.0",

--- a/packages/tanstack-react-query/CHANGELOG.md
+++ b/packages/tanstack-react-query/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @powersync/tanstack-react-query
 
-## 0.2.13
-
-### Patch Changes
-
-- f026de6: Respect the user-provided `enabled` option in `useQuery` and `useQueries` instead of overriding it. Queries backed by sync streams now pause via TanStack's `skipToken` until their streams have synced, leaving `enabled` fully under the caller's control (`useSuspenseQuery` always runs, since suspense rejects `skipToken`). Also fixes a stale `streamsHaveSynced` value and a race where rows written while a query's source tables were still being resolved could be missed.
-
 ## 0.2.12
 
 ### Patch Changes

--- a/packages/tanstack-react-query/package.json
+++ b/packages/tanstack-react-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powersync/tanstack-react-query",
-  "version": "0.2.13",
+  "version": "0.2.12",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -671,6 +671,9 @@ importers:
       '@op-engineering/op-sqlite':
         specifier: 'catalog:'
         version: 15.2.7(react-native@0.83.1(@babel/core@7.29.7)(@react-native-community/cli@20.0.0(typescript@6.0.3))(@react-native/metro-config@0.83.1(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
+      '@react-native-community/cli':
+        specifier: ^20.0.0
+        version: 20.0.0(typescript@6.0.3)
       '@react-native/eslint-config':
         specifier: ^0.83.1
         version: 0.83.1(eslint@8.57.1)(jest@29.7.0(@types/node@24.10.13))(prettier@3.8.1)(typescript@6.0.3)
@@ -18020,17 +18023,6 @@ packages:
     resolution: {integrity: sha512-FdNA4RyH1L43TlvGG8qOMIfcEczwA5ij+zLXUy3Z83CjxhLvcV7/Q/8pk22wnCgYw7PJhtK+7lhO+qqyT4NdvQ==}
     engines: {node: '>=16.14'}
 
-  ws@6.2.3:
-    resolution: {integrity: sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@6.2.4:
     resolution: {integrity: sha512-PNIUUyLI5YpkJZj60YBzX1o0ByQ4ovvfmq9N/Kig/PAYbVlGyz4R6G0SEWrD0O9acc0sT2+IdMBVLFv8FSi0Nw==}
     peerDependencies:
@@ -25405,7 +25397,7 @@ snapshots:
       ora: 5.4.1
       semver: 7.8.1
       wcwidth: 1.0.1
-      yaml: 2.8.2
+      yaml: 2.9.0
     transitivePeerDependencies:
       - typescript
 
@@ -25440,7 +25432,7 @@ snapshots:
       open: 6.4.0
       pretty-format: 29.7.0
       serve-static: 1.16.3
-      ws: 6.2.3
+      ws: 6.2.4
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -25479,7 +25471,7 @@ snapshots:
       fs-extra: 8.1.0
       graceful-fs: 4.2.11
       prompts: 2.4.2
-      semver: 7.7.4
+      semver: 7.8.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -40906,10 +40898,6 @@ snapshots:
     dependencies:
       js-yaml: 4.2.0
       write-file-atomic: 5.0.1
-
-  ws@6.2.3:
-    dependencies:
-      async-limiter: 1.0.1
 
   ws@6.2.4:
     dependencies:

--- a/tools/diagnostics-app/CHANGELOG.md
+++ b/tools/diagnostics-app/CHANGELOG.md
@@ -1,11 +1,5 @@
 # diagnostics-app
 
-## 0.13.14
-
-### Patch Changes
-
-- 2574af8: Polish UI, terminology, and documentation.
-
 ## 0.13.13
 
 ### Patch Changes

--- a/tools/diagnostics-app/package.json
+++ b/tools/diagnostics-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@powersync/diagnostics-app",
-  "version": "0.13.14",
+  "version": "0.13.13",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Fixes failed release https://github.com/powersync-ja/powersync-js/actions/runs/28594471143/job/84786946601

Adds `@react-native-community/cli` as an explicit dev dependency (fixed the issue on my local machine).
Also reverted the version changes made from the last versions merge.