### PR TITLE
Fix tests failing on `v2` branch

### DIFF
--- a/packages/common/src/attachments/AttachmentQueue.ts
+++ b/packages/common/src/attachments/AttachmentQueue.ts
@@ -348,6 +348,7 @@ export class AttachmentQueue {
    */
   async syncStorage(): Promise<void> {
     const signal = this.syncAbortController?.signal;
+    // We have a signal from startSync() to stopSync(), so treat the absence of one like an aborted sync.
     if (signal == null || signal?.aborted) return;
 
     try {

--- a/packages/common/src/attachments/AttachmentQueue.ts
+++ b/packages/common/src/attachments/AttachmentQueue.ts
@@ -348,7 +348,7 @@ export class AttachmentQueue {
    */
   async syncStorage(): Promise<void> {
     const signal = this.syncAbortController?.signal;
-    if (signal?.aborted) return;
+    if (signal == null || signal?.aborted) return;
 
     try {
       await this.syncLoopMutex.runExclusive(async () => {
@@ -357,13 +357,13 @@ export class AttachmentQueue {
 
         await this.syncingService.processAttachments(activeAttachments, { signal });
 
-        if (signal?.aborted) return;
+        if (signal.aborted) return;
 
         await this.attachmentService.withContext((ctx) => this.syncingService.deleteArchivedAttachments(ctx));
       }, signal);
     } catch (error) {
       // A queued batch's acquire rejects when `stopSync` aborts — expected, not an error.
-      if (signal?.aborted) return;
+      if (signal.aborted) return;
       throw error;
     }
   }

--- a/packages/node/src/db/RemoteConnection.ts
+++ b/packages/node/src/db/RemoteConnection.ts
@@ -36,11 +36,11 @@ export class RemoteConnection extends LockContext {
 
     return new Promise((resolve, reject) => {
       if (controller.signal.aborted) {
-        reject(new ConnectionClosedError(`Called operation on closed remote: ${description}`));
+        reject(new ConnectionClosedError(`Called operation on closed remote: ${description()}`));
       }
 
       function handleAbort() {
-        reject(new ConnectionClosedError(`Remote peer closed with request in flight: ${description}`));
+        reject(new ConnectionClosedError(`Remote peer closed with request in flight: ${description()}`));
       }
 
       function completePromise(action: () => void) {

--- a/packages/node/src/db/RemoteConnection.ts
+++ b/packages/node/src/db/RemoteConnection.ts
@@ -29,18 +29,18 @@ export class RemoteConnection extends LockContext {
    * Runs the inner function, but appends the stack trace where this function was called. This is useful for workers
    * because stack traces from worker errors are otherwise unrelated to the application issue that has caused them.
    */
-  private withRemote<T>(description: () => string, inner: () => Promise<T>): Promise<T> {
+  private withRemote<T>(inner: () => Promise<T>): Promise<T> {
     const trace = {};
     Error.captureStackTrace(trace);
     const controller = this.notifyWorkerClosed;
 
     return new Promise((resolve, reject) => {
       if (controller.signal.aborted) {
-        reject(new ConnectionClosedError(`Called operation on closed remote: ${description()}`));
+        reject(new ConnectionClosedError('Called operation on closed remote'));
       }
 
       function handleAbort() {
-        reject(new ConnectionClosedError(`Remote peer closed with request in flight: ${description()}`));
+        reject(new ConnectionClosedError('Remote peer closed with request in flight'));
       }
 
       function completePromise(action: () => void) {
@@ -63,31 +63,22 @@ export class RemoteConnection extends LockContext {
   }
 
   execute<T = SqliteRecord>(query: string, params?: any[] | undefined): Promise<QueryResult<T>> {
-    return this.withRemote(
-      () => `execute(${query}, ${JSON.stringify(params)})`,
-      async () => {
-        const results = await this.database.execute(query, params ?? []);
-        return queryResultFromMapped(results, results.rows as T[] | undefined);
-      }
-    );
+    return this.withRemote(async () => {
+      const results = await this.database.execute(query, params ?? []);
+      return queryResultFromMapped(results, results.rows as T[] | undefined);
+    });
   }
 
   executeBatch(query: string, params: any[][] = []): Promise<QueryResult<never>> {
-    return this.withRemote(
-      () => `executeBatch(${query}, ${JSON.stringify(params)})`,
-      async () => {
-        return await this.database.executeBatch(query, params ?? []);
-      }
-    );
+    return this.withRemote(async () => {
+      return await this.database.executeBatch(query, params ?? []);
+    });
   }
 
   executeRaw(query: string, params?: any[] | undefined): Promise<RawQueryResult> {
-    return this.withRemote(
-      () => `executeRaw(${query}, ${JSON.stringify(params)})`,
-      async () => {
-        return await this.database.executeRaw(query, params ?? []);
-      }
-    );
+    return this.withRemote(async () => {
+      return await this.database.executeRaw(query, params ?? []);
+    });
   }
 
   async refreshSchema() {

--- a/packages/node/src/db/RemoteConnection.ts
+++ b/packages/node/src/db/RemoteConnection.ts
@@ -29,18 +29,18 @@ export class RemoteConnection extends LockContext {
    * Runs the inner function, but appends the stack trace where this function was called. This is useful for workers
    * because stack traces from worker errors are otherwise unrelated to the application issue that has caused them.
    */
-  private withRemote<T>(inner: () => Promise<T>): Promise<T> {
+  private withRemote<T>(description: () => string, inner: () => Promise<T>): Promise<T> {
     const trace = {};
     Error.captureStackTrace(trace);
     const controller = this.notifyWorkerClosed;
 
     return new Promise((resolve, reject) => {
       if (controller.signal.aborted) {
-        reject(new ConnectionClosedError('Called operation on closed remote'));
+        reject(new ConnectionClosedError(`Called operation on closed remote: ${description}`));
       }
 
       function handleAbort() {
-        reject(new ConnectionClosedError('Remote peer closed with request in flight'));
+        reject(new ConnectionClosedError(`Remote peer closed with request in flight: ${description}`));
       }
 
       function completePromise(action: () => void) {
@@ -63,22 +63,31 @@ export class RemoteConnection extends LockContext {
   }
 
   execute<T = SqliteRecord>(query: string, params?: any[] | undefined): Promise<QueryResult<T>> {
-    return this.withRemote(async () => {
-      const results = await this.database.execute(query, params ?? []);
-      return queryResultFromMapped(results, results.rows as T[] | undefined);
-    });
+    return this.withRemote(
+      () => `execute(${query}, ${JSON.stringify(params)})`,
+      async () => {
+        const results = await this.database.execute(query, params ?? []);
+        return queryResultFromMapped(results, results.rows as T[] | undefined);
+      }
+    );
   }
 
   executeBatch(query: string, params: any[][] = []): Promise<QueryResult<never>> {
-    return this.withRemote(async () => {
-      return await this.database.executeBatch(query, params ?? []);
-    });
+    return this.withRemote(
+      () => `executeBatch(${query}, ${JSON.stringify(params)})`,
+      async () => {
+        return await this.database.executeBatch(query, params ?? []);
+      }
+    );
   }
 
   executeRaw(query: string, params?: any[] | undefined): Promise<RawQueryResult> {
-    return this.withRemote(async () => {
-      return await this.database.executeRaw(query, params ?? []);
-    });
+    return this.withRemote(
+      () => `executeRaw(${query}, ${JSON.stringify(params)})`,
+      async () => {
+        return await this.database.executeRaw(query, params ?? []);
+      }
+    );
   }
 
   async refreshSchema() {

--- a/packages/node/tests/attachments.test.ts
+++ b/packages/node/tests/attachments.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach, afterEach, onTestFinished } from 'vitest';
 import {
   PowerSyncDatabase,
   Schema,
@@ -261,6 +261,7 @@ describe('attachment queue', () => {
         syncIntervalMs: INTERVAL_MILLISECONDS,
         archivedCacheLimit: 0
       });
+      onTestFinished(() => queue.stopSync());
 
       await queue.startSync();
 
@@ -280,8 +281,6 @@ describe('attachment queue', () => {
       const attachmentRecord = attachments.find((r) => r.id === id);
       expect(attachmentRecord?.mediaType).toBe('image/jpeg');
       expect(mockDownloadFile).toHaveBeenCalledWith(expect.objectContaining({ mediaType: 'image/jpeg' }));
-
-      await queue.stopSync();
     }
   );
 
@@ -538,6 +537,7 @@ describe('attachment queue', () => {
       syncIntervalMs: INTERVAL_MILLISECONDS,
       errorHandler
     });
+    onTestFinished(() => localeQueue.stopSync());
 
     const id = await localeQueue.generateAttachmentId();
 
@@ -578,6 +578,7 @@ describe('attachment queue', () => {
         syncIntervalMs: INTERVAL_MILLISECONDS,
         archivedCacheLimit: 0
       });
+      onTestFinished(() => slowQueue.stopSync());
 
       await slowQueue.startSync();
 
@@ -606,112 +607,103 @@ describe('attachment queue', () => {
     }
   );
 
-  it(
-    'attachments queue should commit per-attachment, not at end of batch',
-    { timeout: 10000 },
-    async () => {
-      const gates: Array<ReturnType<typeof deferred<ArrayBuffer>>> = [deferred<ArrayBuffer>(), deferred<ArrayBuffer>()];
-      const downloadIds: string[] = [];
-      const slowDownload = vi.fn().mockImplementation((attachment: AttachmentRecord) => {
-        const idx = downloadIds.length;
-        downloadIds.push(attachment.id);
-        return gates[idx]?.promise ?? Promise.resolve(createMockJpegBuffer());
-      });
+  it('attachments queue should commit per-attachment, not at end of batch', { timeout: 10000 }, async () => {
+    const gates: Array<ReturnType<typeof deferred<ArrayBuffer>>> = [deferred<ArrayBuffer>(), deferred<ArrayBuffer>()];
+    const downloadIds: string[] = [];
+    const slowDownload = vi.fn().mockImplementation((attachment: AttachmentRecord) => {
+      const idx = downloadIds.length;
+      downloadIds.push(attachment.id);
+      return gates[idx]?.promise ?? Promise.resolve(createMockJpegBuffer());
+    });
 
-      const slowQueue = new AttachmentQueue({
-        db,
-        watchAttachments,
-        remoteStorage: { downloadFile: slowDownload, uploadFile: mockUploadFile, deleteFile: mockDeleteFile },
-        localStorage: mockLocalStorage,
-        syncIntervalMs: INTERVAL_MILLISECONDS,
-        archivedCacheLimit: 0
-      });
+    const slowQueue = new AttachmentQueue({
+      db,
+      watchAttachments,
+      remoteStorage: { downloadFile: slowDownload, uploadFile: mockUploadFile, deleteFile: mockDeleteFile },
+      localStorage: mockLocalStorage,
+      syncIntervalMs: INTERVAL_MILLISECONDS,
+      archivedCacheLimit: 0
+    });
+    onTestFinished(() => slowQueue.stopSync());
 
-      await slowQueue.startSync();
+    await slowQueue.startSync();
 
-      // Queue two downloads.
-      for (let i = 0; i < 2; i++) {
-        await db.execute('INSERT INTO users (id, name, email, photo_id) VALUES (uuid(), ?, ?, uuid())', [
-          `user${i}`,
-          `user${i}@example.com`
-        ]);
-      }
-
-      // Wait until the first download is in flight.
-      await waitForMatchCondition(
-        () => watchAttachmentsTable(),
-        () => slowDownload.mock.calls.length >= 1,
-        5
-      );
-
-      // Resolve only the first download. The second is still pending.
-      gates[0].resolve(createMockJpegBuffer());
-
-      // The first attachment must transition to SYNCED while the second is still
-      // QUEUED_DOWNLOAD — i.e. the commit happened mid-batch, not at the end.
-      await waitForMatchCondition(
-        () => watchAttachmentsTable(),
-        (rows) => {
-          const first = rows.find((r) => r.id === downloadIds[0]);
-          const others = rows.filter((r) => r.id !== downloadIds[0]);
-          return (
-            first?.state === AttachmentState.SYNCED &&
-            others.some((r) => r.state === AttachmentState.QUEUED_DOWNLOAD)
-          );
-        },
-        5
-      );
-
-      // Clean up: release the second so the worker drains and stopSync finishes.
-      gates[1].resolve(createMockJpegBuffer());
-      await slowQueue.stopSync();
-    }
-  );
-
-  it(
-    'saveFile should not be blocked by an in-flight sync batch',
-    { timeout: 10000 },
-    async () => {
-      const downloadStarted = deferred();
-      const downloadGate = deferred<ArrayBuffer>();
-      const slowDownload = vi.fn().mockImplementation(() => {
-        downloadStarted.resolve();
-        return downloadGate.promise;
-      });
-
-      const slowQueue = new AttachmentQueue({
-        db,
-        watchAttachments,
-        remoteStorage: { downloadFile: slowDownload, uploadFile: mockUploadFile, deleteFile: mockDeleteFile },
-        localStorage: mockLocalStorage,
-        syncIntervalMs: INTERVAL_MILLISECONDS,
-        archivedCacheLimit: 0
-      });
-
-      await slowQueue.startSync();
-
-      // Queue a download that will hang.
+    // Queue two downloads.
+    for (let i = 0; i < 2; i++) {
       await db.execute('INSERT INTO users (id, name, email, photo_id) VALUES (uuid(), ?, ?, uuid())', [
-        'downloader',
-        'downloader@example.com'
+        `user${i}`,
+        `user${i}@example.com`
       ]);
-
-      await downloadStarted.promise;
-
-      // saveFile must complete promptly even while a download is in flight.
-      const saveStart = Date.now();
-      const saved = await slowQueue.saveFile({
-        data: new Uint8Array(10).fill(7).buffer,
-        fileExtension: 'jpg'
-      });
-      expect(Date.now() - saveStart).toBeLessThan(500);
-      expect(saved.state).toBe(AttachmentState.QUEUED_UPLOAD);
-
-      // Clean up.
-      downloadGate.resolve(createMockJpegBuffer());
-      await slowQueue.stopSync();
     }
-  );
+
+    // Wait until the first download is in flight.
+    await waitForMatchCondition(
+      () => watchAttachmentsTable(),
+      () => slowDownload.mock.calls.length >= 1,
+      5
+    );
+
+    // Resolve only the first download. The second is still pending.
+    gates[0].resolve(createMockJpegBuffer());
+
+    // The first attachment must transition to SYNCED while the second is still
+    // QUEUED_DOWNLOAD — i.e. the commit happened mid-batch, not at the end.
+    await waitForMatchCondition(
+      () => watchAttachmentsTable(),
+      (rows) => {
+        const first = rows.find((r) => r.id === downloadIds[0]);
+        const others = rows.filter((r) => r.id !== downloadIds[0]);
+        return (
+          first?.state === AttachmentState.SYNCED && others.some((r) => r.state === AttachmentState.QUEUED_DOWNLOAD)
+        );
+      },
+      5
+    );
+
+    // Clean up: release the second so the worker drains and stopSync finishes.
+    gates[1].resolve(createMockJpegBuffer());
+  });
+
+  it('saveFile should not be blocked by an in-flight sync batch', { timeout: 10000 }, async () => {
+    const downloadStarted = deferred();
+    const downloadGate = deferred<ArrayBuffer>();
+    const slowDownload = vi.fn().mockImplementation(() => {
+      downloadStarted.resolve();
+      return downloadGate.promise;
+    });
+
+    const slowQueue = new AttachmentQueue({
+      db,
+      watchAttachments,
+      remoteStorage: { downloadFile: slowDownload, uploadFile: mockUploadFile, deleteFile: mockDeleteFile },
+      localStorage: mockLocalStorage,
+      syncIntervalMs: INTERVAL_MILLISECONDS,
+      archivedCacheLimit: 0
+    });
+    onTestFinished(() => slowQueue.stopSync());
+
+    await slowQueue.startSync();
+
+    // Queue a download that will hang.
+    await db.execute('INSERT INTO users (id, name, email, photo_id) VALUES (uuid(), ?, ?, uuid())', [
+      'downloader',
+      'downloader@example.com'
+    ]);
+
+    await downloadStarted.promise;
+
+    // saveFile must complete promptly even while a download is in flight.
+    const saveStart = Date.now();
+    const saved = await slowQueue.saveFile({
+      data: new Uint8Array(10).fill(7).buffer,
+      fileExtension: 'jpg'
+    });
+    expect(Date.now() - saveStart).toBeLessThan(500);
+    expect(saved.state).toBe(AttachmentState.QUEUED_UPLOAD);
+
+    // Clean up.
+    downloadGate.resolve(createMockJpegBuffer());
+  });
 
   it(
     'stopSync should release a sync call queued behind a stalled batch instead of leaving it hanging',
@@ -733,6 +725,7 @@ describe('attachment queue', () => {
         syncIntervalMs: INTERVAL_MILLISECONDS,
         archivedCacheLimit: 0
       });
+      onTestFinished(() => slowQueue.stopSync());
 
       await slowQueue.startSync();
 

--- a/packages/node/tests/setup.ts
+++ b/packages/node/tests/setup.ts
@@ -1,0 +1,3 @@
+// In database-related test failures, worker communication takes up almost all
+// of the default stack trace (length 10). Increase this to aid in debugging failed tests.
+Error.stackTraceLimit = 50;

--- a/packages/node/vitest.config.ts
+++ b/packages/node/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     silent: false,
     // This doesn't make the tests considerably slower. It may improve reliability for GH actions.
-    fileParallelism: false
+    fileParallelism: false,
+    setupFiles: ['./tests/setup.ts']
   }
 });

--- a/packages/tanstack-react-query/tests/usePowerSyncQueries.test.tsx
+++ b/packages/tanstack-react-query/tests/usePowerSyncQueries.test.tsx
@@ -1,15 +1,15 @@
 import { cleanup, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import React from 'react';
-import { AbstractPowerSyncDatabase, SyncStatus } from '@powersync/common';
 import { PowerSyncContext } from '@powersync/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { openPowerSync } from './utils';
 import * as Tanstack from '@tanstack/react-query';
 import { usePowerSyncQueries } from '../src/hooks/usePowerSyncQueries';
+import { BasePowerSyncDatabase, SyncStatusSnapshot } from '@powersync/shared-internals';
 
 describe('usePowerSyncQueries bug fixes', () => {
-  let db: AbstractPowerSyncDatabase;
+  let db: BasePowerSyncDatabase;
   let queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -19,7 +19,7 @@ describe('usePowerSyncQueries bug fixes', () => {
   });
 
   beforeEach(() => {
-    db = openPowerSync();
+    db = openPowerSync() as BasePowerSyncDatabase;
     queryClient.clear();
     vi.clearAllMocks();
     cleanup();
@@ -32,9 +32,13 @@ describe('usePowerSyncQueries bug fixes', () => {
   );
 
   const syncedStatus = () =>
-    new SyncStatus({
-      dataFlow: {
-        internalStreamSubscriptions: [
+    new SyncStatusSnapshot(
+      {
+        connecting: false,
+        connected: true,
+        downloading: null,
+        priority_status: [],
+        streams: [
           {
             name: 'a',
             parameters: null,
@@ -47,8 +51,9 @@ describe('usePowerSyncQueries bug fixes', () => {
             priority: 1
           }
         ]
-      }
-    });
+      },
+      {}
+    );
 
   describe('usePowerSyncQueries ', () => {
     it('updated returned streamsHaveSynced once a waitForStream stream syncs', async () => {

--- a/packages/tanstack-react-query/vitest.config.ts
+++ b/packages/tanstack-react-query/vitest.config.ts
@@ -19,12 +19,12 @@ const config: ViteUserConfig = {
       shuffle: false, // Disable shuffling of test files
       concurrent: false // Run test files sequentially
     },
+    /**
+     * Starts each test in a new iFrame
+     */
+    isolate: true,
     browser: {
       enabled: true,
-      /**
-       * Starts each test in a new iFrame
-       */
-      isolate: true,
       provider: playwright(),
       headless: true,
       instances: [

--- a/packages/web/tests/utils/mockSyncServiceTest.ts
+++ b/packages/web/tests/utils/mockSyncServiceTest.ts
@@ -122,7 +122,7 @@ export const sharedMockSyncServiceTest = test.extend<{
         () => {
           expect(database.connecting).toBe(true);
         },
-        { timeout: 1000 }
+        { timeout: 1500 }
       );
 
       let _syncRequestId: string;


### PR DESCRIPTION
This fixes a few tests that started failing after rebasing the `v2` branch onto the latest changes from `main`. The three issues fixed are:

1. A new test in `tanstack-react-query` using internal APIs that have been hidden on `v2`, requiring changed imports.
2. Some attachment tests opening queues on which `stopSync()` is not called before the database is closed, which can lead to hard to debug asynchronous failures as they try to scan for attachments on a closed database. It also looks like there's a chance for `syncStorage()` to ignore abort signals when called after `stopSync()`, but this doesn't occur in our tests.
3. A web test setup requiring a bit more time to run more reliably.

AI use: I used Claude in the investigation on attachment failures, the changes here are written by hand.