### PR TITLE
Web: Support in-memory databases

### DIFF
--- a/.changeset/brown-suits-push.md
+++ b/.changeset/brown-suits-push.md
@@ -1,0 +1,5 @@
+---
+'@powersync/web': minor
+---
+
+Allow using in-memory databases with `WASQLiteVFS.InMemoryVFS`.

--- a/packages/web/src/db/adapters/wa-sqlite/RawSqliteConnection.ts
+++ b/packages/web/src/db/adapters/wa-sqlite/RawSqliteConnection.ts
@@ -1,6 +1,6 @@
 import { Factory as WaSqliteFactory, SQLITE_ROW } from '@journeyapps/wa-sqlite';
 
-import { DEFAULT_MODULE_FACTORIES, WASQLiteModuleFactory, WASQLiteVFS } from './vfs.js';
+import { loadModuleAndVfs, WASQLiteVFS } from './vfs.js';
 import { TemporaryStorageOption } from '../options.js';
 import { RawQueryResult, SqliteValue } from '@powersync/common';
 
@@ -37,11 +37,8 @@ export class RawSqliteConnection {
    * The `sqlite3*` connection pointer.
    */
   private db: number = 0;
-  private _moduleFactory: WASQLiteModuleFactory;
 
-  constructor(readonly options: RawWaSqliteDatabaseOptions) {
-    this._moduleFactory = DEFAULT_MODULE_FACTORIES[this.options.vfs];
-  }
+  constructor(readonly options: RawWaSqliteDatabaseOptions) {}
 
   get isOpen(): boolean {
     return this.db != 0;
@@ -64,10 +61,7 @@ export class RawSqliteConnection {
   }
 
   private async openSQLiteAPI(): Promise<SQLiteAPI> {
-    const { module, vfs } = await this._moduleFactory({
-      dbFileName: this.options.filename,
-      encryptionKey: this.options.encryptionKey
-    });
+    const { module, vfs } = await loadModuleAndVfs(this.options);
     const sqlite3 = WaSqliteFactory(module);
     sqlite3.vfs_register(vfs, true);
     /**

--- a/packages/web/src/db/adapters/wa-sqlite/vfs.ts
+++ b/packages/web/src/db/adapters/wa-sqlite/vfs.ts
@@ -71,10 +71,10 @@ export async function loadModuleAndVfs({
   encryptionKey
 }: RawWaSqliteDatabaseOptions): Promise<{ module: SQLiteModule; vfs: SQLiteVFS }> {
   let moduleFactory = syncModuleFactory;
-  let resolveVfs: (module: any) => Promise<any>;
+  let resolveVfs: (module: any) => Promise<SQLiteVFS>;
 
   switch (vfs) {
-    case WASQLiteVFS.IDBBatchAtomicVFS:
+    case WASQLiteVFS.IDBBatchAtomicVFS: {
       moduleFactory = asyncModuleFactory;
       const { IDBBatchAtomicVFS } = await import('@journeyapps/wa-sqlite/src/examples/IDBBatchAtomicVFS.js');
       resolveVfs = (module) => {
@@ -82,26 +82,31 @@ export async function loadModuleAndVfs({
         return IDBBatchAtomicVFS.create(filename, module, { lockPolicy: 'exclusive' });
       };
       break;
-    case WASQLiteVFS.AccessHandlePoolVFS:
+    }
+    case WASQLiteVFS.AccessHandlePoolVFS: {
       // @ts-expect-error The types for this import are missing upstream
       const { AccessHandlePoolVFS } = await import('@journeyapps/wa-sqlite/src/examples/AccessHandlePoolVFS.js');
       resolveVfs = (module) => AccessHandlePoolVFS.create(filename, module);
       break;
-    case WASQLiteVFS.OPFSCoopSyncVFS:
+    }
+    case WASQLiteVFS.OPFSCoopSyncVFS: {
       // @ts-expect-error The types for this import are missing upstream
       const { OPFSCoopSyncVFS } = await import('@journeyapps/wa-sqlite/src/examples/OPFSCoopSyncVFS.js');
       resolveVfs = (module) => OPFSCoopSyncVFS.create(filename, module);
       break;
-    case WASQLiteVFS.OPFSWriteAheadVFS:
+    }
+    case WASQLiteVFS.OPFSWriteAheadVFS: {
       // @ts-expect-error The types for this import are missing upstream
       const { OPFSWriteAheadVFS } = await import('@journeyapps/wa-sqlite/src/examples/OPFSWriteAheadVFS.js');
       resolveVfs = (module) => OPFSWriteAheadVFS.create(filename, module, {});
       break;
-    case WASQLiteVFS.InMemoryVfs:
+    }
+    case WASQLiteVFS.InMemoryVfs: {
       const { MemoryVFS } = await import('@journeyapps/wa-sqlite/src/examples/MemoryVFS.js');
       // @ts-expect-error The types for this static method are missing upstream
       resolveVfs = (module) => MemoryVFS.create(filename, module);
       break;
+    }
   }
 
   const module = await moduleFactory(encryptionKey);

--- a/packages/web/src/db/adapters/wa-sqlite/vfs.ts
+++ b/packages/web/src/db/adapters/wa-sqlite/vfs.ts
@@ -1,4 +1,5 @@
 import type * as SQLite from '@journeyapps/wa-sqlite';
+import { RawWaSqliteDatabaseOptions } from './RawSqliteConnection.js';
 
 /**
  * List of currently tested virtual filesystems
@@ -7,11 +8,28 @@ export enum WASQLiteVFS {
   IDBBatchAtomicVFS = 'IDBBatchAtomicVFS',
   OPFSCoopSyncVFS = 'OPFSCoopSyncVFS',
   AccessHandlePoolVFS = 'AccessHandlePoolVFS',
-  OPFSWriteAheadVFS = 'OPFSWriteAheadVFS'
+  OPFSWriteAheadVFS = 'OPFSWriteAheadVFS',
+  /**
+   * A virtual file system storing data in-memory only, without persistence.
+   *
+   * This file system can be used in three configurations:
+   *
+   * 1. In shared workers (the default when available): All tabs share the same in-memory database, which is cleared
+   *    once the last tab is closed.
+   * 2. In dedicated workers (used when `enableMultiTabs` is disabled). Each tab has its own in-memory database cleared
+   *    when the tab is closed. Queries are offloaded to a dedicated worker.
+   * 3. In the context of the tab itself (used when both `enableMultiTabs` and `useWebWorker` are disabled). The per-tab
+   *    database is hosted in the tab itself, and queries run synchronously. This is _a lot_ faster than any other
+   *    single-threadedVFS, but can block JavaScript for computationally-intensive queries.
+   *
+   * This VFS primarily intended for development, but it also useful for online-first deployments not syncing large
+   * amounts of data, as it is quicker to start up.
+   */
+  InMemoryVfs = 'InMemoryVFS'
 }
 
 export function vfsRequiresDedicatedWorkers(vfs: WASQLiteVFS) {
-  return vfs != WASQLiteVFS.IDBBatchAtomicVFS;
+  return vfs != WASQLiteVFS.IDBBatchAtomicVFS && vfs != WASQLiteVFS.InMemoryVfs;
 }
 
 /**
@@ -24,14 +42,7 @@ export type WASQLiteModuleFactoryOptions = { dbFileName: string; encryptionKey?:
  */
 export type SQLiteModule = Parameters<typeof SQLite.Factory>[0];
 
-/**
- * @internal
- */
-export type WASQLiteModuleFactory = (
-  options: WASQLiteModuleFactoryOptions
-) => Promise<{ module: SQLiteModule; vfs: SQLiteVFS }>;
-
-async function asyncModuleFactory(encryptionKey: unknown) {
+async function asyncModuleFactory(encryptionKey: string | undefined): Promise<SQLiteModule> {
   if (encryptionKey) {
     const { default: factory } = await import('@journeyapps/wa-sqlite/dist/mc-wa-sqlite-async.mjs');
     return factory();
@@ -41,7 +52,7 @@ async function asyncModuleFactory(encryptionKey: unknown) {
   }
 }
 
-async function syncModuleFactory(encryptionKey: unknown) {
+async function syncModuleFactory(encryptionKey: string | undefined): Promise<SQLiteModule> {
   if (encryptionKey) {
     const { default: factory } = await import('@journeyapps/wa-sqlite/dist/mc-wa-sqlite.mjs');
     return factory();
@@ -54,43 +65,45 @@ async function syncModuleFactory(encryptionKey: unknown) {
 /**
  * @internal
  */
-export const DEFAULT_MODULE_FACTORIES = {
-  [WASQLiteVFS.IDBBatchAtomicVFS]: async (options: WASQLiteModuleFactoryOptions) => {
-    const module = await asyncModuleFactory(options.encryptionKey);
-    const { IDBBatchAtomicVFS } = await import('@journeyapps/wa-sqlite/src/examples/IDBBatchAtomicVFS.js');
-    return {
-      module,
+export async function loadModuleAndVfs({
+  vfs,
+  filename,
+  encryptionKey
+}: RawWaSqliteDatabaseOptions): Promise<{ module: SQLiteModule; vfs: SQLiteVFS }> {
+  let moduleFactory = syncModuleFactory;
+  let resolveVfs: (module: any) => Promise<any>;
+
+  switch (vfs) {
+    case WASQLiteVFS.IDBBatchAtomicVFS:
+      moduleFactory = asyncModuleFactory;
+      const { IDBBatchAtomicVFS } = await import('@journeyapps/wa-sqlite/src/examples/IDBBatchAtomicVFS.js');
+      resolveVfs = (module) => {
+        // @ts-expect-error The types for this static method are missing upstream
+        return IDBBatchAtomicVFS.create(filename, module, { lockPolicy: 'exclusive' });
+      };
+      break;
+    case WASQLiteVFS.AccessHandlePoolVFS:
+      // @ts-expect-error The types for this import are missing upstream
+      const { AccessHandlePoolVFS } = await import('@journeyapps/wa-sqlite/src/examples/AccessHandlePoolVFS.js');
+      resolveVfs = (module) => AccessHandlePoolVFS.create(filename, module);
+      break;
+    case WASQLiteVFS.OPFSCoopSyncVFS:
+      // @ts-expect-error The types for this import are missing upstream
+      const { OPFSCoopSyncVFS } = await import('@journeyapps/wa-sqlite/src/examples/OPFSCoopSyncVFS.js');
+      resolveVfs = (module) => OPFSCoopSyncVFS.create(filename, module);
+      break;
+    case WASQLiteVFS.OPFSWriteAheadVFS:
+      // @ts-expect-error The types for this import are missing upstream
+      const { OPFSWriteAheadVFS } = await import('@journeyapps/wa-sqlite/src/examples/OPFSWriteAheadVFS.js');
+      resolveVfs = (module) => OPFSWriteAheadVFS.create(filename, module, {});
+      break;
+    case WASQLiteVFS.InMemoryVfs:
+      const { MemoryVFS } = await import('@journeyapps/wa-sqlite/src/examples/MemoryVFS.js');
       // @ts-expect-error The types for this static method are missing upstream
-      vfs: await IDBBatchAtomicVFS.create(options.dbFileName, module, { lockPolicy: 'exclusive' })
-    };
-  },
-  [WASQLiteVFS.AccessHandlePoolVFS]: async (options: WASQLiteModuleFactoryOptions) => {
-    const module = await syncModuleFactory(options.encryptionKey);
-    // @ts-expect-error The types for this static method are missing upstream
-    const { AccessHandlePoolVFS } = await import('@journeyapps/wa-sqlite/src/examples/AccessHandlePoolVFS.js');
-    return {
-      module,
-      vfs: await AccessHandlePoolVFS.create(options.dbFileName, module)
-    };
-  },
-  [WASQLiteVFS.OPFSCoopSyncVFS]: async (options: WASQLiteModuleFactoryOptions) => {
-    const module = await syncModuleFactory(options.encryptionKey);
-    // @ts-expect-error The types for this static method are missing upstream
-    const { OPFSCoopSyncVFS } = await import('@journeyapps/wa-sqlite/src/examples/OPFSCoopSyncVFS.js');
-    const vfs = await OPFSCoopSyncVFS.create(options.dbFileName, module);
-    return {
-      module,
-      vfs
-    };
-  },
-  [WASQLiteVFS.OPFSWriteAheadVFS]: async (options: WASQLiteModuleFactoryOptions) => {
-    const module = await syncModuleFactory(options.encryptionKey);
-    // @ts-expect-error The types for this static method are missing upstream
-    const { OPFSWriteAheadVFS } = await import('@journeyapps/wa-sqlite/src/examples/OPFSWriteAheadVFS.js');
-    const vfs = await OPFSWriteAheadVFS.create(options.dbFileName, module, {});
-    return {
-      module,
-      vfs
-    };
+      resolveVfs = (module) => MemoryVFS.create(filename, module);
+      break;
   }
-};
+
+  const module = await moduleFactory(encryptionKey);
+  return { module, vfs: await resolveVfs(module) };
+}

--- a/packages/web/src/worker/db/MultiDatabaseServer.ts
+++ b/packages/web/src/worker/db/MultiDatabaseServer.ts
@@ -4,6 +4,7 @@ import { ClientConnectionView, DatabaseServer } from '../../db/adapters/wa-sqlit
 import { getNavigatorLocks } from '../../shared/navigator.js';
 import { RawSqliteConnection, RawWaSqliteDatabaseOptions } from '../../db/adapters/wa-sqlite/RawSqliteConnection.js';
 import { ConcurrentSqliteConnection } from '../../db/adapters/wa-sqlite/ConcurrentConnection.js';
+import { WASQLiteVFS } from '../../db/adapters/wa-sqlite/vfs.js';
 
 const OPEN_DB_LOCK = 'open-wasqlite-db';
 
@@ -75,14 +76,15 @@ export class MultiDatabaseServer {
     options: RawWaSqliteDatabaseOptions
   ): Promise<DatabaseServer> {
     return getNavigatorLocks().request(OPEN_DB_LOCK, async () => {
-      const { filename } = options;
+      const { filename, readonly, vfs } = options;
 
       let server: DatabaseServer | undefined = this.activeDatabases.get(filename);
       if (server == null) {
         // We don't need navigator locks for shared workers because all queries run in this shared worker exclusively.
         // For read-only connections, we use a VFS that supports concurrent reads (so a single lock on the connection is
-        // fine).
-        const needsNavigatorLocks = !(isSharedWorker || options.readonly);
+        // fine). In-memory databases either run in a shared worker or aren't shared across tabs at all, so the internal
+        // lock is enough.
+        const needsNavigatorLocks = !(isSharedWorker || readonly || vfs == WASQLiteVFS.InMemoryVfs);
         const connection = new RawSqliteConnection(options);
         const withSafeConcurrency = new ConcurrentSqliteConnection(connection, needsNavigatorLocks);
 

--- a/packages/web/tests/main.test.ts
+++ b/packages/web/tests/main.test.ts
@@ -45,6 +45,57 @@ describe(
   )
 );
 
+describe('Basic - with in-memory', () => {
+  const defaultOptions = {
+    dbFilename: 'in-memory.db',
+    vfs: WASQLiteVFS.InMemoryVfs,
+    databaseWorkerLogLevel: defaultLogLevel
+  };
+
+  describe(
+    'in shared worker',
+    { sequential: true },
+    describeBasicTests(() =>
+      generateTestDb({
+        schema: TEST_SCHEMA,
+        logger: defaultTestLogger,
+        database: {
+          ...defaultOptions
+        }
+      })
+    )
+  );
+
+  describe(
+    'in dedicated worker',
+    describeBasicTests(() =>
+      generateTestDb({
+        schema: TEST_SCHEMA,
+        logger: defaultTestLogger,
+        database: {
+          ...defaultOptions,
+          enableMultiTabs: false
+        }
+      })
+    )
+  );
+
+  describe(
+    'in local tab',
+    describeBasicTests(() =>
+      generateTestDb({
+        schema: TEST_SCHEMA,
+        logger: defaultTestLogger,
+        database: {
+          ...defaultOptions,
+          enableMultiTabs: false,
+          useWebWorker: false
+        }
+      })
+    )
+  );
+});
+
 function describeBasicTests(generateDB: () => PowerSyncDatabase) {
   return () => {
     it('should execute a select query using getAll', async () => {


### PR DESCRIPTION
This adds an option to use the [example in-memory VFS](https://github.com/powersync-ja/wa-sqlite/blob/master/src/examples/MemoryVFS.js) from WA-SQLite with web databases.

For some online-first workloads, not using persistence at all can be an interesting option. It avoids OPFS and navigator locks (which have known issues on Safari), and is a lot faster for queries. So when there isn't a lot of data to sync, re-downloading it every time the app is opened can be more reliable and faster than using a proper file system implementation.

Without any further code changes, this VFS can be used in three configurations depending on passed flags:

1. In a shared worker (the default): Recommended, all tabs share the same database.
2. In a dedicated worker (when `enableMultiTab: false`). It's not really clear why one would want that, but it's supported.
3. Without any workers at all (`enableMultiTab: false` and `enableWebWorker: false`): By not using any message port roundtrips, this is _much_ faster than any other single-threaded VFS but runs queries synchronously which could block the UI for computationally-expensive queries.

### Multi-threaded in-memory VFS?

This uses a very simple in-memory VFS that can't be shared across workers, so it can't be used concurrently. In a way, that is a good thing because it makes concurrency control much simpler (we don't need navigator locks), but it also means that for workloads with a large amount of concurrent queries, those can't run in parallel.

There are ways to improve this setup:

1. We could use a write-ahead log to provide concurrent reads and writes, e.g. with [this implementation](https://github.com/whygee-dev/memory-write-ahead-vfs). The WAL implementation uses navigator locks though, which is something we want to avoid where possible.
2. I have ideas for a WAL VFS that doesn't use navigator locks at all, but wouldn't work across multiple tabs. But it's not clear whether this use case is common enough to optimize for it.

Fundamentally, multi-tab access to the same in-memory database will require navigator locks (either to prevent concurrent access or to coordinate readers/checkpoints). Since we want to avoid some of the pitfalls of navigator locks with this, exposing the simple in-memory VFS might be as good as it gets. If it turns out that we need parallel access after all, we can land improvements in follow-up PRs.

At this point though, I think the VFS implementation is no longer the lowest-hanging fruit for optimization. Looking into the worker protocol to reduce roundtrips would likely speed things up more, for example.