### PR TITLE
[v1]: Web: Support in-memory databases

### DIFF
--- a/.changeset/brown-suits-push.md
+++ b/.changeset/brown-suits-push.md
@@ -1,0 +1,5 @@
+---
+'@powersync/web': minor
+---
+
+Allow using in-memory databases with `WASQLiteVFS.InMemoryVFS`.

--- a/packages/web/src/db/adapters/wa-sqlite/RawSqliteConnection.ts
+++ b/packages/web/src/db/adapters/wa-sqlite/RawSqliteConnection.ts
@@ -1,6 +1,6 @@
 import { Factory as WaSqliteFactory, SQLITE_ROW } from '@journeyapps/wa-sqlite';
 
-import { DEFAULT_MODULE_FACTORIES, WASQLiteModuleFactory } from './vfs.js';
+import { loadModuleAndVfs } from './vfs.js';
 import { ResolvedWASQLiteOpenFactoryOptions } from './WASQLiteOpenFactory.js';
 
 export interface RawResultSet {
@@ -27,11 +27,8 @@ export class RawSqliteConnection {
    * The `sqlite3*` connection pointer.
    */
   private db: number = 0;
-  private _moduleFactory: WASQLiteModuleFactory;
 
-  constructor(readonly options: ResolvedWASQLiteOpenFactoryOptions) {
-    this._moduleFactory = DEFAULT_MODULE_FACTORIES[this.options.vfs];
-  }
+  constructor(readonly options: ResolvedWASQLiteOpenFactoryOptions) {}
 
   get isOpen(): boolean {
     return this.db != 0;
@@ -54,10 +51,7 @@ export class RawSqliteConnection {
   }
 
   private async openSQLiteAPI(): Promise<SQLiteAPI> {
-    const { module, vfs } = await this._moduleFactory({
-      dbFileName: this.options.dbFilename,
-      encryptionKey: this.options.encryptionKey
-    });
+    const { module, vfs } = await loadModuleAndVfs(this.options);
     const sqlite3 = WaSqliteFactory(module);
     sqlite3.vfs_register(vfs, true);
     /**

--- a/packages/web/src/db/adapters/wa-sqlite/vfs.ts
+++ b/packages/web/src/db/adapters/wa-sqlite/vfs.ts
@@ -1,4 +1,5 @@
 import type * as SQLite from '@journeyapps/wa-sqlite';
+import { ResolvedWASQLiteOpenFactoryOptions } from './WASQLiteOpenFactory.js';
 
 /**
  * List of currently tested virtual filesystems
@@ -7,31 +8,36 @@ export enum WASQLiteVFS {
   IDBBatchAtomicVFS = 'IDBBatchAtomicVFS',
   OPFSCoopSyncVFS = 'OPFSCoopSyncVFS',
   AccessHandlePoolVFS = 'AccessHandlePoolVFS',
-  OPFSWriteAheadVFS = 'OPFSWriteAheadVFS'
+  OPFSWriteAheadVFS = 'OPFSWriteAheadVFS',
+  /**
+   * A virtual file system storing data in-memory only, without persistence.
+   *
+   * This file system can be used in three configurations:
+   *
+   * 1. In shared workers (the default when available): All tabs share the same in-memory database, which is cleared
+   *    once the last tab is closed.
+   * 2. In dedicated workers (used when `enableMultiTabs` is disabled). Each tab has its own in-memory database cleared
+   *    when the tab is closed. Queries are offloaded to a dedicated worker.
+   * 3. In the context of the tab itself (used when both `enableMultiTabs` and `useWebWorker` are disabled). The per-tab
+   *    database is hosted in the tab itself, and queries run synchronously. This is _a lot_ faster than any other
+   *    single-threadedVFS, but can block JavaScript for computationally-intensive queries.
+   *
+   * This VFS primarily intended for development, but it also useful for online-first deployments not syncing large
+   * amounts of data, as it is quicker to start up.
+   */
+  InMemoryVfs = 'InMemoryVFS'
 }
 
 export function vfsRequiresDedicatedWorkers(vfs: WASQLiteVFS) {
-  return vfs != WASQLiteVFS.IDBBatchAtomicVFS;
+  return vfs != WASQLiteVFS.IDBBatchAtomicVFS && vfs != WASQLiteVFS.InMemoryVfs;
 }
-
-/**
- * @internal
- */
-export type WASQLiteModuleFactoryOptions = { dbFileName: string; encryptionKey?: string };
 
 /**
  * @internal
  */
 export type SQLiteModule = Parameters<typeof SQLite.Factory>[0];
 
-/**
- * @internal
- */
-export type WASQLiteModuleFactory = (
-  options: WASQLiteModuleFactoryOptions
-) => Promise<{ module: SQLiteModule; vfs: SQLiteVFS }>;
-
-async function asyncModuleFactory(encryptionKey: unknown) {
+async function asyncModuleFactory(encryptionKey: string | undefined): Promise<SQLiteModule> {
   if (encryptionKey) {
     const { default: factory } = await import('@journeyapps/wa-sqlite/dist/mc-wa-sqlite-async.mjs');
     return factory();
@@ -41,7 +47,7 @@ async function asyncModuleFactory(encryptionKey: unknown) {
   }
 }
 
-async function syncModuleFactory(encryptionKey: unknown) {
+async function syncModuleFactory(encryptionKey: string | undefined): Promise<SQLiteModule> {
   if (encryptionKey) {
     const { default: factory } = await import('@journeyapps/wa-sqlite/dist/mc-wa-sqlite.mjs');
     return factory();
@@ -54,43 +60,50 @@ async function syncModuleFactory(encryptionKey: unknown) {
 /**
  * @internal
  */
-export const DEFAULT_MODULE_FACTORIES = {
-  [WASQLiteVFS.IDBBatchAtomicVFS]: async (options: WASQLiteModuleFactoryOptions) => {
-    const module = await asyncModuleFactory(options.encryptionKey);
-    const { IDBBatchAtomicVFS } = await import('@journeyapps/wa-sqlite/src/examples/IDBBatchAtomicVFS.js');
-    return {
-      module,
+export async function loadModuleAndVfs({
+  vfs,
+  dbFilename,
+  encryptionKey
+}: ResolvedWASQLiteOpenFactoryOptions): Promise<{ module: SQLiteModule; vfs: SQLiteVFS }> {
+  let moduleFactory = syncModuleFactory;
+  let resolveVfs: (module: any) => Promise<SQLiteVFS>;
+
+  switch (vfs) {
+    case WASQLiteVFS.IDBBatchAtomicVFS: {
+      moduleFactory = asyncModuleFactory;
+      const { IDBBatchAtomicVFS } = await import('@journeyapps/wa-sqlite/src/examples/IDBBatchAtomicVFS.js');
+      resolveVfs = (module) => {
+        // @ts-expect-error The types for this static method are missing upstream
+        return IDBBatchAtomicVFS.create(filename, module, { lockPolicy: 'exclusive' });
+      };
+      break;
+    }
+    case WASQLiteVFS.AccessHandlePoolVFS: {
+      // @ts-expect-error The types for this import are missing upstream
+      const { AccessHandlePoolVFS } = await import('@journeyapps/wa-sqlite/src/examples/AccessHandlePoolVFS.js');
+      resolveVfs = (module) => AccessHandlePoolVFS.create(dbFilename, module);
+      break;
+    }
+    case WASQLiteVFS.OPFSCoopSyncVFS: {
+      // @ts-expect-error The types for this import are missing upstream
+      const { OPFSCoopSyncVFS } = await import('@journeyapps/wa-sqlite/src/examples/OPFSCoopSyncVFS.js');
+      resolveVfs = (module) => OPFSCoopSyncVFS.create(dbFilename, module);
+      break;
+    }
+    case WASQLiteVFS.OPFSWriteAheadVFS: {
+      // @ts-expect-error The types for this import are missing upstream
+      const { OPFSWriteAheadVFS } = await import('@journeyapps/wa-sqlite/src/examples/OPFSWriteAheadVFS.js');
+      resolveVfs = (module) => OPFSWriteAheadVFS.create(dbFilename, module, {});
+      break;
+    }
+    case WASQLiteVFS.InMemoryVfs: {
+      const { MemoryVFS } = await import('@journeyapps/wa-sqlite/src/examples/MemoryVFS.js');
       // @ts-expect-error The types for this static method are missing upstream
-      vfs: await IDBBatchAtomicVFS.create(options.dbFileName, module, { lockPolicy: 'exclusive' })
-    };
-  },
-  [WASQLiteVFS.AccessHandlePoolVFS]: async (options: WASQLiteModuleFactoryOptions) => {
-    const module = await syncModuleFactory(options.encryptionKey);
-    // @ts-expect-error The types for this static method are missing upstream
-    const { AccessHandlePoolVFS } = await import('@journeyapps/wa-sqlite/src/examples/AccessHandlePoolVFS.js');
-    return {
-      module,
-      vfs: await AccessHandlePoolVFS.create(options.dbFileName, module)
-    };
-  },
-  [WASQLiteVFS.OPFSCoopSyncVFS]: async (options: WASQLiteModuleFactoryOptions) => {
-    const module = await syncModuleFactory(options.encryptionKey);
-    // @ts-expect-error The types for this static method are missing upstream
-    const { OPFSCoopSyncVFS } = await import('@journeyapps/wa-sqlite/src/examples/OPFSCoopSyncVFS.js');
-    const vfs = await OPFSCoopSyncVFS.create(options.dbFileName, module);
-    return {
-      module,
-      vfs
-    };
-  },
-  [WASQLiteVFS.OPFSWriteAheadVFS]: async (options: WASQLiteModuleFactoryOptions) => {
-    const module = await syncModuleFactory(options.encryptionKey);
-    // @ts-expect-error The types for this static method are missing upstream
-    const { OPFSWriteAheadVFS } = await import('@journeyapps/wa-sqlite/src/examples/OPFSWriteAheadVFS.js');
-    const vfs = await OPFSWriteAheadVFS.create(options.dbFileName, module, {});
-    return {
-      module,
-      vfs
-    };
+      resolveVfs = (module) => MemoryVFS.create(filename, module);
+      break;
+    }
   }
-};
+
+  const module = await moduleFactory(encryptionKey);
+  return { module, vfs: await resolveVfs(module) };
+}

--- a/packages/web/src/db/adapters/wa-sqlite/vfs.ts
+++ b/packages/web/src/db/adapters/wa-sqlite/vfs.ts
@@ -74,7 +74,7 @@ export async function loadModuleAndVfs({
       const { IDBBatchAtomicVFS } = await import('@journeyapps/wa-sqlite/src/examples/IDBBatchAtomicVFS.js');
       resolveVfs = (module) => {
         // @ts-expect-error The types for this static method are missing upstream
-        return IDBBatchAtomicVFS.create(filename, module, { lockPolicy: 'exclusive' });
+        return IDBBatchAtomicVFS.create(dbFilename, module, { lockPolicy: 'exclusive' });
       };
       break;
     }
@@ -99,7 +99,7 @@ export async function loadModuleAndVfs({
     case WASQLiteVFS.InMemoryVfs: {
       const { MemoryVFS } = await import('@journeyapps/wa-sqlite/src/examples/MemoryVFS.js');
       // @ts-expect-error The types for this static method are missing upstream
-      resolveVfs = (module) => MemoryVFS.create(filename, module);
+      resolveVfs = (module) => MemoryVFS.create(dbFilename, module);
       break;
     }
   }

--- a/packages/web/src/worker/db/MultiDatabaseServer.ts
+++ b/packages/web/src/worker/db/MultiDatabaseServer.ts
@@ -8,6 +8,7 @@ import {
 import { getNavigatorLocks } from '../../shared/navigator.js';
 import { RawSqliteConnection } from '../../db/adapters/wa-sqlite/RawSqliteConnection.js';
 import { ConcurrentSqliteConnection } from '../../db/adapters/wa-sqlite/ConcurrentConnection.js';
+import { WASQLiteVFS } from '../../db/adapters/wa-sqlite/vfs.js';
 
 const OPEN_DB_LOCK = 'open-wasqlite-db';
 
@@ -57,14 +58,15 @@ export class MultiDatabaseServer {
 
   private async databaseOpenAttempt(options: ResolvedWASQLiteOpenFactoryOptions): Promise<DatabaseServer> {
     return getNavigatorLocks().request(OPEN_DB_LOCK, async () => {
-      const { dbFilename } = options;
+      const { dbFilename, isReadOnly, vfs } = options;
 
       let server: DatabaseServer | undefined = this.activeDatabases.get(dbFilename);
       if (server == null) {
         // We don't need navigator locks for shared workers because all queries run in this shared worker exclusively.
         // For read-only connections, we use a VFS that supports concurrent reads (so a single lock on the connection is
-        // fine).
-        const needsNavigatorLocks = !(isSharedWorker || options.isReadOnly);
+        // fine). In-memory databases either run in a shared worker or aren't shared across tabs at all, so the internal
+        // lock is enough.
+        const needsNavigatorLocks = !(isSharedWorker || isReadOnly || vfs == WASQLiteVFS.InMemoryVfs);
         const connection = new RawSqliteConnection(options);
         const withSafeConcurrency = new ConcurrentSqliteConnection(connection, needsNavigatorLocks);
 

--- a/packages/web/tests/main.test.ts
+++ b/packages/web/tests/main.test.ts
@@ -42,11 +42,12 @@ describe(
 );
 
 describe('Basic - with in-memory', () => {
-  const defaultOptions = {
-    dbFilename: 'in-memory.db',
-    vfs: WASQLiteVFS.InMemoryVfs,
-    databaseWorkerLogLevel: defaultLogLevel
-  };
+  function generateFactory() {
+    return new WASQLiteOpenFactory({
+      dbFilename: 'in-memory.db',
+      vfs: WASQLiteVFS.InMemoryVfs
+    });
+  }
 
   describe(
     'in shared worker',
@@ -54,10 +55,7 @@ describe('Basic - with in-memory', () => {
     describeBasicTests(() =>
       generateTestDb({
         schema: TEST_SCHEMA,
-        logger: defaultTestLogger,
-        database: {
-          ...defaultOptions
-        }
+        database: generateFactory()
       })
     )
   );
@@ -67,9 +65,8 @@ describe('Basic - with in-memory', () => {
     describeBasicTests(() =>
       generateTestDb({
         schema: TEST_SCHEMA,
-        logger: defaultTestLogger,
-        database: {
-          ...defaultOptions,
+        database: generateFactory(),
+        flags: {
           enableMultiTabs: false
         }
       })
@@ -81,9 +78,8 @@ describe('Basic - with in-memory', () => {
     describeBasicTests(() =>
       generateTestDb({
         schema: TEST_SCHEMA,
-        logger: defaultTestLogger,
-        database: {
-          ...defaultOptions,
+        database: generateFactory(),
+        flags: {
           enableMultiTabs: false,
           useWebWorker: false
         }

--- a/packages/web/tests/main.test.ts
+++ b/packages/web/tests/main.test.ts
@@ -41,6 +41,57 @@ describe(
   )
 );
 
+describe('Basic - with in-memory', () => {
+  const defaultOptions = {
+    dbFilename: 'in-memory.db',
+    vfs: WASQLiteVFS.InMemoryVfs,
+    databaseWorkerLogLevel: defaultLogLevel
+  };
+
+  describe(
+    'in shared worker',
+    { sequential: true },
+    describeBasicTests(() =>
+      generateTestDb({
+        schema: TEST_SCHEMA,
+        logger: defaultTestLogger,
+        database: {
+          ...defaultOptions
+        }
+      })
+    )
+  );
+
+  describe(
+    'in dedicated worker',
+    describeBasicTests(() =>
+      generateTestDb({
+        schema: TEST_SCHEMA,
+        logger: defaultTestLogger,
+        database: {
+          ...defaultOptions,
+          enableMultiTabs: false
+        }
+      })
+    )
+  );
+
+  describe(
+    'in local tab',
+    describeBasicTests(() =>
+      generateTestDb({
+        schema: TEST_SCHEMA,
+        logger: defaultTestLogger,
+        database: {
+          ...defaultOptions,
+          enableMultiTabs: false,
+          useWebWorker: false
+        }
+      })
+    )
+  );
+});
+
 function describeBasicTests(generateDB: () => PowerSyncDatabase) {
   return () => {
     it('should execute a select query using getAll', async () => {


### PR DESCRIPTION
This ports https://github.com/powersync-ja/powersync-js/pull/1029 to the v1 branch.

A dev release of this is available in `0.0.0-dev-20260708104358` of `@powersync/web`.