### PR TITLE
fix: Http clients getting stuck on 401

### DIFF
--- a/.changeset/witty-students-cross.md
+++ b/.changeset/witty-students-cross.md
@@ -1,0 +1,5 @@
+---
+'@powersync/shared-internals': patch
+---
+
+Fixed an issue where clients using the HTTP connection method could get stuck in an endless auth-error retry loop when their token expired while disconnected (e.g. after network interruptions or device sleep).

--- a/packages/node/tests/sync.test.ts
+++ b/packages/node/tests/sync.test.ts
@@ -92,6 +92,43 @@ describe('Sync', () => {
     ]);
   });
 
+  mockSyncServiceTest('refetches credentials when HTTP stream returns 401', async ({ syncService }) => {
+    // The /sync/stream 401 should invalidate the cached credentials so the retry fetches a fresh token.
+    let fetchCredentialsCount = 0;
+    const connector = new TestConnector();
+    connector.fetchCredentials = async () => {
+      fetchCredentialsCount++;
+      return {
+        endpoint: 'https://powersync.example.org',
+        token: `token-${fetchCredentialsCount}`
+      };
+    };
+
+    syncService.installRequestInterceptor(async (request) => {
+      if (request.url.endsWith('/sync/stream') && request.headers.get('Authorization') === 'Token token-1') {
+        return new Response(
+          JSON.stringify({ error: { code: 'PSYNC_S2103', description: 'Authentication required' } }),
+          {
+            status: 401,
+            headers: { 'content-type': 'application/json' }
+          }
+        );
+      }
+      return undefined;
+    });
+
+    const database = await syncService.createDatabase();
+    database.connect(connector, {
+      connectionMethod: SyncStreamConnectionMethod.HTTP,
+      retryDelayMs: 100
+    });
+
+    // The first attempt uses token-1 and gets a 401. The SDK must invalidate the cached
+    // credentials and retry with a freshly fetched token-2, which connects successfully.
+    await vi.waitFor(() => expect(fetchCredentialsCount).toBeGreaterThanOrEqual(2), { timeout: 2000 });
+    await vi.waitFor(() => expect(syncService.connectedListeners).toHaveLength(1), { timeout: 2000 });
+  });
+
   mockSyncServiceTest('reconnects immediately after changed connection', async ({ syncService }) => {
     let database = await syncService.createDatabase();
     database.connect(new TestConnector(), {

--- a/packages/node/tests/utils.ts
+++ b/packages/node/tests/utils.ts
@@ -110,11 +110,14 @@ export function createMockSyncServiceTest(bson: boolean) {
       const databaseName = `test-${crypto.randomUUID()}.db`;
 
       const listeners: Listener[] = [];
-      let requestInterceptor: (request: Request) => Promise<void> = async () => {};
+      let requestInterceptor: (request: Request) => Promise<Response | void> = async () => {};
 
       const inMemoryFetch: typeof fetch = async (info, init?) => {
         const request = new Request(info, init);
-        await requestInterceptor(request);
+        const intercepted = await requestInterceptor(request);
+        if (intercepted) {
+          return intercepted;
+        }
 
         if (request.url.endsWith('/sync/stream')) {
           const body = await request.json();
@@ -201,7 +204,7 @@ export function createMockSyncServiceTest(bson: boolean) {
 export const mockSyncServiceTest = createMockSyncServiceTest(false);
 
 export interface MockSyncService {
-  installRequestInterceptor(interceptor: (request: Request) => Promise<void>): void;
+  installRequestInterceptor(interceptor: (request: Request) => Promise<Response | void>): void;
   pushLine: (line: StreamingSyncLine) => void;
   connectedListeners: any[];
 

--- a/packages/shared-internals/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/shared-internals/src/client/sync/stream/AbstractRemote.ts
@@ -315,6 +315,11 @@ export abstract class AbstractRemote {
           message: `Could not POST streaming to ${path} - ${res.status} - ${res.statusText}: ${text}`,
           error
         });
+
+        if (res.status === 401) {
+          this.invalidateCredentials();
+        }
+
         throw error;
       }
 


### PR DESCRIPTION
Duplicate of this backport: https://github.com/powersync-ja/powersync-js/pull/1033

Originally reported internally.

Fixed an issue where clients using the HTTP connection method could get stuck in an endless auth-error retry loop when their token expired while disconnected (e.g. after network interruptions or device sleep).

Unlike the WebSocket path and other HTTP requests, the HTTP sync stream did not invalidate cached credentials when receiving a 401 response, so every reconnect attempt reused the same expired token instead of fetching a fresh one from the connector. The sync stream now invalidates cached credentials on a 401, so the next retry calls `fetchCredentials()` for a fresh token.


## AI disclosure

This PR was created with the help of Claude Fable. Help constitutes assistance in research, planning, and rough outline of implementation. Beyond having a hand in the implementation, I have also manually tested this work.