### PR TITLE
Send sync status updates over broadcast channel when shared workers are disabled

### DIFF
--- a/.changeset/mighty-dodos-prove.md
+++ b/.changeset/mighty-dodos-prove.md
@@ -1,0 +1,7 @@
+---
+'@powersync/shared-internals': patch
+'@powersync/web': minor
+---
+
+When shared sync workers are disabled, use broadcast channels to share the current sync status and
+subscriptions across tabs.

--- a/.changeset/mighty-dodos-prove.md
+++ b/.changeset/mighty-dodos-prove.md
@@ -1,5 +1,5 @@
 ---
-'@powersync/shared-internals': patch
+'@powersync/shared-internals': minor
 '@powersync/web': minor
 ---
 

--- a/packages/shared-internals/src/client/ConnectionManager.ts
+++ b/packages/shared-internals/src/client/ConnectionManager.ts
@@ -231,7 +231,10 @@ export class ConnectionManager extends BaseObserver<ConnectionManagerListener> {
         });
         this.iterateListeners((l) => l.syncStreamCreated?.(sync));
         this.syncStreamImplementation = sync;
-        this.syncDisposer = onDispose;
+        this.syncDisposer = () => {
+          onDispose();
+          sync.dispose();
+        };
         await this.syncStreamImplementation.waitForReady();
         resolve();
       } catch (error) {

--- a/packages/shared-internals/src/client/ConnectionManager.ts
+++ b/packages/shared-internals/src/client/ConnectionManager.ts
@@ -231,10 +231,7 @@ export class ConnectionManager extends BaseObserver<ConnectionManagerListener> {
         });
         this.iterateListeners((l) => l.syncStreamCreated?.(sync));
         this.syncStreamImplementation = sync;
-        this.syncDisposer = () => {
-          onDispose();
-          sync.dispose();
-        };
+        this.syncDisposer = onDispose;
         await this.syncStreamImplementation.waitForReady();
         resolve();
       } catch (error) {

--- a/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -27,7 +27,7 @@ import {
   valueResult
 } from '../../../utils/stream_transform.js';
 import { asyncNotifier } from '../../../utils/async.js';
-import { JavaScriptSyncState, SyncStatusJson, SyncStatusSnapshot } from '../../../db/crud/SyncStatus.js';
+import { JavaScriptSyncState, SyncStatusSnapshot } from '../../../db/crud/SyncStatus.js';
 import { ResolvedSyncOptions } from '../options.js';
 
 /**
@@ -122,7 +122,7 @@ export abstract class AbstractStreamingSyncImplementation
   protected crudUpdateListener?: () => void;
   protected streamingSyncPromise?: Promise<[void, void]>;
   protected logger: PowerSyncLogger;
-  private activeStreams: SubscribedStream[];
+  protected activeStreams: SubscribedStream[];
   private connectionMayHaveChanged = false;
   private crudUploadNotifier = asyncNotifier();
 

--- a/packages/web/src/db/PowerSyncDatabase.ts
+++ b/packages/web/src/db/PowerSyncDatabase.ts
@@ -26,12 +26,10 @@ import { WebSpecificOpenOptions, WebSQLOpenOptions } from './adapters/options.js
 import { SSRStreamingSyncImplementation } from './sync/SSRWebStreamingSyncImplementation.js';
 import { SharedWebStreamingSyncImplementation } from './sync/SharedWebStreamingSyncImplementation.js';
 import { WebRemote } from './sync/WebRemote.js';
-import {
-  WebStreamingSyncImplementation,
-  WebStreamingSyncImplementationOptions
-} from './sync/WebStreamingSyncImplementation.js';
+import { WebStreamingSyncImplementationOptions } from './sync/WebStreamingSyncImplementation.js';
 import { AsyncDbAdapter } from './adapters/AsyncWebAdapter.js';
 import { resolveAndValidateOptions } from './adapters/resolveAndValidateOptions.js';
+import { TabLocalStreamingSyncImplementation } from './sync/TabLocalStreamingSyncImplementation.js';
 
 export type WebPowerSyncDatabaseOptions = BasePowerSyncDatabaseOptions &
   DatabaseSource<WebSQLOpenOptions> &
@@ -193,7 +191,7 @@ export class WebPowerSyncDatabase extends BasePowerSyncDatabase<WebPowerSyncData
           enableBroadcastLogs: this.enableBroadcastLogs
         });
       default:
-        return new WebStreamingSyncImplementation(syncOptions);
+        return new TabLocalStreamingSyncImplementation(syncOptions);
     }
   }
 }

--- a/packages/web/src/db/sync/TabLocalStreamingSyncImplementation.ts
+++ b/packages/web/src/db/sync/TabLocalStreamingSyncImplementation.ts
@@ -12,15 +12,14 @@ import {
 
 /**
  * When multi-tab support is disabled and we don't use a shared worker for sync, only a single tab will be able to
- * acquire the sync navigator lock and drive the sync.
+ * acquire the sync navigator lock and start a sync iteration.
  *
- * To provide _some_ multi-tab support in that configuration, this utility:
+ * To be able to provide _some_ multi-tab support in that configuration, this utility:
  *
  * 1. Sends sync status updates from the syncing tab to others.
  * 2. Allows other tabs to send notifications when their active sync stream subscriptions update, allowing the active
  *    tab to take those subscriptions into account.
  */
-
 export class TabLocalStreamingSyncImplementation extends WebStreamingSyncImplementation {
   #statusUpdated: BroadcastChannel;
   #subscriptionsChanged: BroadcastChannel;
@@ -64,12 +63,12 @@ export class TabLocalStreamingSyncImplementation extends WebStreamingSyncImpleme
     }
   }
 
-  updateSubscriptions(subscriptions: SubscribedStream[]): void {
+  override updateSubscriptions(subscriptions: SubscribedStream[]): void {
     super.updateSubscriptions(subscriptions);
     this.#subscriptionsChanged.postMessage('');
   }
 
-  obtainLock<T>({ callback, type, signal }: LockOptions<T>): Promise<T> {
+  override obtainLock<T>({ callback, type, signal }: LockOptions<T>): Promise<T> {
     const wrappedCallback = async (): Promise<T> => {
       this.#hasSyncLock = true;
 
@@ -83,7 +82,7 @@ export class TabLocalStreamingSyncImplementation extends WebStreamingSyncImpleme
     return super.obtainLock({ callback: type == LockType.SYNC ? wrappedCallback : callback, type, signal });
   }
 
-  async dispose(): Promise<void> {
+  override async dispose(): Promise<void> {
     this.#statusUpdated.close();
     this.#subscriptionsChanged.close();
     await super.dispose();

--- a/packages/web/src/db/sync/TabLocalStreamingSyncImplementation.ts
+++ b/packages/web/src/db/sync/TabLocalStreamingSyncImplementation.ts
@@ -1,0 +1,91 @@
+import {
+  LockOptions,
+  LockType,
+  SubscribedStream,
+  SyncStatusJson,
+  SyncStatusSnapshot
+} from '@powersync/shared-internals';
+import {
+  WebStreamingSyncImplementation,
+  WebStreamingSyncImplementationOptions
+} from './WebStreamingSyncImplementation.js';
+
+/**
+ * When multi-tab support is disabled and we don't use a shared worker for sync, only a single tab will be able to
+ * acquire the sync navigator lock and drive the sync.
+ *
+ * To provide _some_ multi-tab support in that configuration, this utility:
+ *
+ * 1. Sends sync status updates from the syncing tab to others.
+ * 2. Allows other tabs to send notifications when their active sync stream subscriptions update, allowing the active
+ *    tab to take those subscriptions into account.
+ */
+
+export class TabLocalStreamingSyncImplementation extends WebStreamingSyncImplementation {
+  #statusUpdated: BroadcastChannel;
+  #subscriptionsChanged: BroadcastChannel;
+  #hasSyncLock = false;
+
+  constructor(options: WebStreamingSyncImplementationOptions) {
+    super(options);
+
+    const identifier = options.identifier;
+    this.#statusUpdated = new BroadcastChannel(`sync-status-${identifier}`);
+    this.#subscriptionsChanged = new BroadcastChannel(`subscription-change-${identifier}`);
+
+    this.#statusUpdated.onmessage = (event) => {
+      if (event.data == 'ping') {
+        this.#sendStatus(this.syncStatus);
+        return;
+      }
+
+      const { core, dataFlow } = event.data as SyncStatusJson;
+      this.updateSyncStatus(core, dataFlow);
+    };
+
+    // Request other tabs to share their sync status.
+    this.#statusUpdated.postMessage('ping');
+    this.#subscriptionsChanged.onmessage = () => {
+      // We can't update activeStreams since we don't know when another tab referencing them is closed. However,
+      // clients will update an internal table listing streams after subscribing, and updateSubscriptions() will
+      // scan that table.
+      super.updateSubscriptions(this.activeStreams);
+    };
+
+    this.registerListener({
+      statusChanged: (status) => this.#sendStatus(status)
+    });
+  }
+
+  #sendStatus(status: SyncStatusSnapshot) {
+    // Don't share sync status if this is not the tab currently syncing.
+    if (this.#hasSyncLock) {
+      this.#statusUpdated.postMessage(status.toJSON());
+    }
+  }
+
+  updateSubscriptions(subscriptions: SubscribedStream[]): void {
+    super.updateSubscriptions(subscriptions);
+    this.#subscriptionsChanged.postMessage('');
+  }
+
+  obtainLock<T>({ callback, type, signal }: LockOptions<T>): Promise<T> {
+    const wrappedCallback = async (): Promise<T> => {
+      this.#hasSyncLock = true;
+
+      try {
+        return await callback();
+      } finally {
+        this.#hasSyncLock = false;
+      }
+    };
+
+    return super.obtainLock({ callback: type == LockType.SYNC ? wrappedCallback : callback, type, signal });
+  }
+
+  async dispose(): Promise<void> {
+    this.#statusUpdated.close();
+    this.#subscriptionsChanged.close();
+    await super.dispose();
+  }
+}

--- a/packages/web/tests/multiple_instances.test.ts
+++ b/packages/web/tests/multiple_instances.test.ts
@@ -8,6 +8,8 @@ import { generateTestDb } from './utils/testDb.js';
 import { DatabaseClient, OpenWorkerConnection } from '../src/db/adapters/wa-sqlite/DatabaseClient.js';
 import { ClientConnectionView } from '../src/db/adapters/wa-sqlite/DatabaseServer.js';
 import { generateTabCloseSignal } from '../src/shared/tab_close_signal.js';
+import { PowerSyncDatabase } from '../src/index.js';
+import { MockSyncService } from './utils/MockSyncServiceWorker.js';
 
 const DB_FILENAME = 'test-multiple-instances.db';
 
@@ -345,4 +347,51 @@ describe('Multiple Instances', { sequential: true }, () => {
       await vi.waitFor(() => expect(connector.uploadData.mock.calls.length).greaterThanOrEqual(2), { timeout: 3000 });
     }
   );
+
+  describe('tab-local sync client', () => {
+    const mockService = MockSyncService.GLOBAL_INSTANCE;
+
+    it('can share status across instances', async () => {
+      const dbFilename = `${crypto.randomUUID()}.db`;
+      const a = new PowerSyncDatabase({ database: { dbFilename, enableMultiTabs: false }, schema: TEST_SCHEMA });
+      const connectPromise = a.connect(createTestConnector());
+      onTestFinished(() => a.close());
+
+      const b = new PowerSyncDatabase({ database: { dbFilename, enableMultiTabs: false }, schema: TEST_SCHEMA });
+      onTestFinished(() => b.close());
+
+      await vi.waitFor(() => {
+        const pendingRequests = mockService.getPendingRequestsSync();
+        expect(pendingRequests).toHaveLength(1);
+        const requestId = pendingRequests[0].id;
+        mockService.createResponse(requestId, 200, { 'Content-Type': 'application/json' });
+        mockService.pushBodyData(requestId, `{"token_expires_in": 10000000}\n`);
+      });
+
+      await connectPromise;
+
+      // b should mirror the status from a after connecting.
+      b.connect(createTestConnector());
+      await vi.waitFor(() => expect(b.connected).toBeTruthy());
+    });
+
+    it('can share sync subscriptions', async () => {
+      const dbFilename = `${crypto.randomUUID()}.db`;
+      const a = new PowerSyncDatabase({ database: { dbFilename, enableMultiTabs: false }, schema: TEST_SCHEMA });
+      a.connect(createTestConnector());
+      onTestFinished(() => a.close());
+
+      const b = new PowerSyncDatabase({ database: { dbFilename, enableMultiTabs: false }, schema: TEST_SCHEMA });
+      b.connect(createTestConnector());
+      onTestFinished(() => b.close());
+
+      const stream = await b.syncStream('foo').subscribe();
+      onTestFinished(() => stream.unsubscribe());
+
+      // Subscribing on b should make the stream show up on a, too.
+      await vi.waitFor(() => {
+        expect(a.currentStatus.syncStreams).toHaveLength(1);
+      });
+    });
+  });
 });

--- a/packages/web/tests/multiple_instances.test.ts
+++ b/packages/web/tests/multiple_instances.test.ts
@@ -356,6 +356,7 @@ describe('Multiple Instances', { sequential: true }, () => {
       const a = new PowerSyncDatabase({ database: { dbFilename, enableMultiTabs: false }, schema: TEST_SCHEMA });
       const connectPromise = a.connect(createTestConnector());
       onTestFinished(() => a.close());
+      await a.init();
 
       const b = new PowerSyncDatabase({ database: { dbFilename, enableMultiTabs: false }, schema: TEST_SCHEMA });
       onTestFinished(() => b.close());
@@ -380,6 +381,7 @@ describe('Multiple Instances', { sequential: true }, () => {
       const a = new PowerSyncDatabase({ database: { dbFilename, enableMultiTabs: false }, schema: TEST_SCHEMA });
       a.connect(createTestConnector());
       onTestFinished(() => a.close());
+      await a.init();
 
       const b = new PowerSyncDatabase({ database: { dbFilename, enableMultiTabs: false }, schema: TEST_SCHEMA });
       b.connect(createTestConnector());

--- a/packages/web/tests/utils/mockSyncServiceTest.ts
+++ b/packages/web/tests/utils/mockSyncServiceTest.ts
@@ -9,7 +9,7 @@ import {
   column,
   createConsoleLogger
 } from '@powersync/common';
-import { PowerSyncDatabase, WebPowerSyncDatabaseOptions } from '@powersync/web';
+import { PowerSyncDatabase } from '@powersync/web';
 import { MockedFunction, expect, onTestFinished, test, vi } from 'vitest';
 import { MockSyncService, getMockSyncServiceFromWorker } from './MockSyncServiceClient.js';
 import { GenerateConnectedDatabaseOptions, generateDefaultOptions } from './generateConnectedDatabase.js';

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -2,6 +2,8 @@ import path from 'path';
 import { defineConfig, ViteUserConfigExport } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
 
+const mockWebRemote = path.resolve(__dirname, './tests/mocks/MockWebRemote.ts');
+
 const config: ViteUserConfigExport = {
   server: {
     headers: {
@@ -19,7 +21,8 @@ const config: ViteUserConfigExport = {
        */
       '@powersync/web': path.resolve(__dirname, './lib'),
       // Mock WebRemote to throw 401 errors for all HTTP requests in tests
-      '../../db/sync/WebRemote.js': path.resolve(__dirname, './tests/mocks/MockWebRemote.ts')
+      '../../db/sync/WebRemote.js': mockWebRemote,
+      './sync/WebRemote.js': mockWebRemote
     }
   },
   worker: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,7 @@ overrides:
   shell-quote: ^1.8.4
   websocket-driver: '>=0.7.5'
   tar: '>=7.5.19'
+  seroval: '>=1.5.6'
 
 importers:
 
@@ -15489,14 +15490,10 @@ packages:
     resolution: {integrity: sha512-EAHqADIQondwRZIdeW2I636zgsODzoBDwb3PT/+7TLDWyw1Dy/Xv7iGUIEXXav7usHDE9HVhOU61irI3EnyyHA==}
     engines: {node: '>=10'}
     peerDependencies:
-      seroval: ^1.0
+      seroval: '>=1.5.6'
 
-  seroval@1.5.0:
-    resolution: {integrity: sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==}
-    engines: {node: '>=10'}
-
-  seroval@1.5.1:
-    resolution: {integrity: sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==}
+  seroval@1.5.6:
+    resolution: {integrity: sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==}
     engines: {node: '>=10'}
 
   serve-handler@6.1.7:
@@ -22851,7 +22848,7 @@ snapshots:
       pkg-types: 2.3.0
       postcss: 8.5.15
       rollup-plugin-visualizer: 6.0.11(rollup@4.59.0)
-      seroval: 1.5.1
+      seroval: 1.5.6
       std-env: 3.10.0
       ufo: 1.6.3
       unenv: 2.0.0-rc.24
@@ -26156,8 +26153,8 @@ snapshots:
       '@tanstack/history': 1.161.4
       '@tanstack/store': 0.9.1
       cookie-es: 2.0.0
-      seroval: 1.5.0
-      seroval-plugins: 1.5.0(seroval@1.5.0)
+      seroval: 1.5.6
+      seroval-plugins: 1.5.0(seroval@1.5.6)
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
@@ -36673,13 +36670,11 @@ snapshots:
 
   serialize-javascript@7.0.6: {}
 
-  seroval-plugins@1.5.0(seroval@1.5.0):
+  seroval-plugins@1.5.0(seroval@1.5.6):
     dependencies:
-      seroval: 1.5.0
+      seroval: 1.5.6
 
-  seroval@1.5.0: {}
-
-  seroval@1.5.1: {}
+  seroval@1.5.6: {}
 
   serve-handler@6.1.7:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,8 @@ overrides:
   'websocket-driver': '>=0.7.5'
   # To avoid https://github.com/advisories/GHSA-23hp-3jrh-7fpw
   'tar': '>=7.5.19'
+  # To avoid https://github.com/advisories/GHSA-mv8w-475r-vwqw
+  'seroval': '>=1.5.6'
 
 catalog:
   '@journeyapps/wa-sqlite': ^1.5.0


### PR DESCRIPTION
To coordinate the sync process across tabs, we prefer to use shared workers. Shared workers are [broken](https://bugs.webkit.org/show_bug.cgi?id=318873) and disabled by default on Safari though, we also disable them on mobile. In these cases, each tab would attempt to sync on its own, with most tabs blocked on the navigator sync lock, leaving an app stuck waiting for `hasSynced`.

As a minor improvement, this makes the connected tab send its status update through a broadcast channel that other tabs trying to connect will listen to. So download progress and fields like `hasSynced` are then shared across tabs, and it appears like all tabs make sync progress similar to the setup with shared workers. Additionally, stream subscription changes from any tab are also broadcast to update the sync client in the active tab.

This solution is not perfect, being able to rely on shared workers would definitely be better. But it's still an improvement and provides limited multi-tab support even without shared workers.