### PR TITLE
Update core extension

### DIFF
--- a/.changeset/bright-beans-dream.md
+++ b/.changeset/bright-beans-dream.md
@@ -5,3 +5,4 @@
 ---
 
 Make `@journeyapps/wa-sqlite` a regular dependency instead of a dev-dependency.
+When upgrading, you can remove that package from your dependencies if you don't import it directly in your project.

--- a/.changeset/bright-beans-dream.md
+++ b/.changeset/bright-beans-dream.md
@@ -1,0 +1,7 @@
+---
+'@powersync/capacitor': patch
+'@powersync/nuxt': patch
+'@powersync/web': patch
+---
+
+Make `@journeyapps/wa-sqlite` a regular dependency instead of a dev-dependency.

--- a/.changeset/core-extension-0-5-1.md
+++ b/.changeset/core-extension-0-5-1.md
@@ -2,6 +2,7 @@
 '@powersync/web': patch
 '@powersync/adapter-sql-js': patch
 '@powersync/node': patch
+'@powersync/react-native': patch
 '@powersync/shared-internals': patch
 ---
 

--- a/.changeset/core-extension-0-5-1.md
+++ b/.changeset/core-extension-0-5-1.md
@@ -1,6 +1,7 @@
 ---
 '@powersync/web': patch
 '@powersync/adapter-sql-js': patch
+'@powersync/node': patch
 ---
 
 Update PowerSync SQLite core extension to version 0.5.1.

--- a/.changeset/core-extension-0-5-1.md
+++ b/.changeset/core-extension-0-5-1.md
@@ -2,6 +2,7 @@
 '@powersync/web': patch
 '@powersync/adapter-sql-js': patch
 '@powersync/node': patch
+'@powersync/shared-internals': patch
 ---
 
 Update PowerSync SQLite core extension to version 0.5.1.

--- a/.changeset/core-extension-0-5-1.md
+++ b/.changeset/core-extension-0-5-1.md
@@ -1,5 +1,6 @@
 ---
 '@powersync/web': patch
+'@powersync/adapter-sql-js': patch
 ---
 
 Update PowerSync SQLite core extension to version 0.5.1.

--- a/.changeset/core-extension-0-5-2.md
+++ b/.changeset/core-extension-0-5-2.md
@@ -4,6 +4,8 @@
 '@powersync/node': patch
 '@powersync/react-native': patch
 '@powersync/shared-internals': patch
+'@powersync/tauri-plugin': patch
+'tauri-plugin-powersync': patch
 ---
 
 Update PowerSync SQLite core extension to version 0.5.2.

--- a/.changeset/core-extension-0-5-2.md
+++ b/.changeset/core-extension-0-5-2.md
@@ -6,4 +6,4 @@
 '@powersync/shared-internals': patch
 ---
 
-Update PowerSync SQLite core extension to version 0.5.1.
+Update PowerSync SQLite core extension to version 0.5.2.

--- a/.changeset/core-extension-0-5-2.md
+++ b/.changeset/core-extension-0-5-2.md
@@ -5,6 +5,7 @@
 '@powersync/react-native': patch
 '@powersync/shared-internals': patch
 '@powersync/tauri-plugin': patch
+'@powersync/nuxt': patch
 'tauri-plugin-powersync': patch
 ---
 

--- a/.changeset/wild-weeks-prove.md
+++ b/.changeset/wild-weeks-prove.md
@@ -1,0 +1,5 @@
+---
+'@powersync/web': patch
+---
+
+Update PowerSync SQLite core extension to version 0.5.1.

--- a/demos/angular-supabase-todolist/package.json
+++ b/demos/angular-supabase-todolist/package.json
@@ -23,7 +23,6 @@
     "@angular/platform-browser-dynamic": "^19.2.4",
     "@angular/router": "^19.2.4",
     "@angular/service-worker": "^19.2.4",
-    "@journeyapps/wa-sqlite": "^1.7.0",
     "@powersync/web": "^2.0.0",
     "@supabase/supabase-js": "^2.44.4",
     "rxjs": "~7.8.1",

--- a/demos/example-capacitor/package.json
+++ b/demos/example-capacitor/package.json
@@ -25,7 +25,6 @@
     "@capacitor/core": "^8.0.0",
     "@capacitor/ios": "^8.0.0",
     "@capacitor/splash-screen": "^8.0.0",
-    "@journeyapps/wa-sqlite": "^1.7.0",
     "@powersync/capacitor": "^0.8.0",
     "@powersync/react": "^2.0.0",
     "@powersync/web": "^2.0.0",

--- a/demos/example-electron/package.json
+++ b/demos/example-electron/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",
-    "@journeyapps/wa-sqlite": "^1.7.0",
     "@mui/icons-material": "^5.15.16",
     "@mui/material": "^5.15.16",
     "@mui/x-data-grid": "^6.19.11",

--- a/demos/example-nextjs/package.json
+++ b/demos/example-nextjs/package.json
@@ -14,7 +14,6 @@
     "test:build": "pnpm build"
   },
   "dependencies": {
-    "@journeyapps/wa-sqlite": "^1.7.0",
     "@powersync/react": "^2.0.0",
     "@powersync/web": "^2.0.0",
     "@tailwindcss/postcss": "^4.2.2",

--- a/demos/example-vite/package.json
+++ b/demos/example-vite/package.json
@@ -12,7 +12,6 @@
     "test:build": "pnpm build && vitest run"
   },
   "dependencies": {
-    "@journeyapps/wa-sqlite": "^1.7.0",
     "@powersync/web": "^2.0.0"
   },
   "devDependencies": {

--- a/demos/react-multi-client/package.json
+++ b/demos/react-multi-client/package.json
@@ -10,7 +10,6 @@
     "test:build": "pnpm build"
   },
   "dependencies": {
-    "@journeyapps/wa-sqlite": "^1.7.0",
     "@powersync/react": "^2.0.0",
     "@powersync/web": "^2.0.0",
     "@supabase/supabase-js": "^2.43.1",

--- a/demos/react-native-web-supabase-todolist/package.json
+++ b/demos/react-native-web-supabase-todolist/package.json
@@ -17,7 +17,6 @@
     "@dr.pogodin/react-native-fs": "2.37.0",
     "@expo/metro-runtime": "~57.0.2",
     "@expo/vector-icons": "^15.1.1",
-    "@journeyapps/wa-sqlite": "^1.7.0",
     "@op-engineering/op-sqlite": "^17.0.0",
     "@powersync/attachments-storage-react-native": "^0.0.3",
     "@powersync/common": "^2.0.0",

--- a/demos/react-neon-tanstack-query-notes/package.json
+++ b/demos/react-neon-tanstack-query-notes/package.json
@@ -13,7 +13,6 @@
     "db:generate": "drizzle-kit generate"
   },
   "dependencies": {
-    "@journeyapps/wa-sqlite": "^1.7.0",
     "@neondatabase/neon-js": "^0.1.0-alpha.6",
     "@neondatabase/serverless": "^1.0.2",
     "@powersync/drizzle-driver": "^0.8.0",

--- a/demos/react-supabase-time-based-sync/package.json
+++ b/demos/react-supabase-time-based-sync/package.json
@@ -16,7 +16,6 @@
     "@powersync/web": "^2.0.0",
     "@emotion/react": "11.11.4",
     "@emotion/styled": "11.11.5",
-    "@journeyapps/wa-sqlite": "^1.7.0",
     "@mui/icons-material": "^5.15.12",
     "@mui/material": "^5.15.12",
     "@supabase/supabase-js": "^2.39.7",

--- a/demos/react-supabase-todolist-optional-sync/package.json
+++ b/demos/react-supabase-todolist-optional-sync/package.json
@@ -13,7 +13,6 @@
     "@powersync/web": "^2.0.0",
     "@emotion/react": "11.11.4",
     "@emotion/styled": "11.11.5",
-    "@journeyapps/wa-sqlite": "^1.7.0",
     "@mui/icons-material": "^5.15.12",
     "@mui/material": "^5.15.12",
     "@mui/x-data-grid": "^6.19.6",

--- a/demos/react-supabase-todolist-sync-streams/package.json
+++ b/demos/react-supabase-todolist-sync-streams/package.json
@@ -13,7 +13,6 @@
     "@powersync/web": "^2.0.0",
     "@emotion/react": "11.11.4",
     "@emotion/styled": "11.11.5",
-    "@journeyapps/wa-sqlite": "^1.7.0",
     "@mui/icons-material": "^5.15.12",
     "@mui/material": "^5.15.12",
     "@mui/x-data-grid": "^6.19.6",

--- a/demos/react-supabase-todolist-tanstackdb/package.json
+++ b/demos/react-supabase-todolist-tanstackdb/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@emotion/react": "11.11.4",
     "@emotion/styled": "11.11.5",
-    "@journeyapps/wa-sqlite": "^1.7.0",
     "@mui/icons-material": "^5.15.12",
     "@mui/material": "^5.15.12",
     "@mui/x-data-grid": "^6.19.6",

--- a/demos/react-supabase-todolist/package.json
+++ b/demos/react-supabase-todolist/package.json
@@ -13,7 +13,6 @@
     "@powersync/web": "^2.0.0",
     "@emotion/react": "11.11.4",
     "@emotion/styled": "11.11.5",
-    "@journeyapps/wa-sqlite": "^1.7.0",
     "@mui/icons-material": "^5.15.12",
     "@mui/material": "^5.15.12",
     "@mui/x-data-grid": "^6.19.6",

--- a/demos/yjs-react-supabase-text-collab/package.json
+++ b/demos/yjs-react-supabase-text-collab/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
-    "@journeyapps/wa-sqlite": "^1.7.0",
     "@mui/material": "^5.15.12",
     "@mui/x-data-grid": "^6.19.6",
     "@powersync/react": "^2.0.0",

--- a/packages/adapter-sql-js/package.json
+++ b/packages/adapter-sql-js/package.json
@@ -36,7 +36,7 @@
     "@powersync/shared-internals": "workspace:*"
   },
   "devDependencies": {
-    "@powersync/sql-js": "0.0.9",
+    "@powersync/sql-js": "0.0.10",
     "@powersync/web": "workspace:*",
     "@rollup/plugin-alias": "catalog:",
     "@rollup/plugin-commonjs": "catalog:",

--- a/packages/adapter-sql-js/package.json
+++ b/packages/adapter-sql-js/package.json
@@ -36,7 +36,7 @@
     "@powersync/shared-internals": "workspace:*"
   },
   "devDependencies": {
-    "@powersync/sql-js": "0.0.10",
+    "@powersync/sql-js": "0.0.11",
     "@powersync/web": "workspace:*",
     "@rollup/plugin-alias": "catalog:",
     "@rollup/plugin-commonjs": "catalog:",

--- a/packages/adapter-sql-js/src/SQLJSAdapter.ts
+++ b/packages/adapter-sql-js/src/SQLJSAdapter.ts
@@ -1,6 +1,4 @@
 import {
-  BaseObserver,
-  BaseListener,
   BatchedUpdateNotification,
   createConsoleLogger,
   DBAdapter,
@@ -42,31 +40,12 @@ export class SQLJSOpenFactory implements SQLOpenFactory {
   }
 }
 
-(globalThis as any).onSqliteUpdate = (
-  dbP: number,
-  operation: string,
-  database: string,
-  table: string,
-  rowId: number
-) => {
-  SQLJSDBAdapter.sharedObserver.iterateListeners((l) => l.tablesUpdated?.(dbP, operation, database, table, rowId));
-};
-
-interface TableObserverListener extends BaseListener {
-  tablesUpdated?: (dpP: number, operation: string, database: string, table: string, rowId: number) => void;
-}
-class TableObserver extends BaseObserver<TableObserverListener> {}
-
 export class SQLJSDBAdapter extends DBAdapter {
   protected initPromise: Promise<SQLJs.Database>;
   protected _db: SQLJs.Database | null;
-  protected tableUpdateCache: Set<string>;
   protected dbP: number | null;
   protected writeScheduler: ControlledExecutor<SQLJs.Database>;
   protected options: ResolvedSQLJSOpenOptions;
-
-  static sharedObserver = new TableObserver();
-  protected disposeListener: () => void;
 
   protected mutex: Mutex;
 
@@ -83,18 +62,8 @@ export class SQLJSDBAdapter extends DBAdapter {
     this.options = this.resolveOptions(options);
     this.initPromise = this.init();
     this._db = null;
-    this.tableUpdateCache = new Set<string>();
     this.mutex = new Mutex();
     this.dbP = null;
-    this.disposeListener = SQLJSDBAdapter.sharedObserver.registerListener({
-      tablesUpdated: (dbP: number, operation: string, database: string, table: string, rowId: number) => {
-        if (this.dbP !== dbP) {
-          // Ignore updates from other databases.
-          return;
-        }
-        this.tableUpdateCache.add(table);
-      }
-    });
 
     this.writeScheduler = new ControlledExecutor(async (db: SQLJs.Database) => {
       if (!this.options.persister) {
@@ -128,12 +97,14 @@ export class SQLJSDBAdapter extends DBAdapter {
     const db = new SQL.Database(existing);
     this.dbP = (db as any)['db'] as number;
     this._db = db;
+
+    db.exec("SELECT powersync_update_hooks('install')");
+
     return db;
   }
 
   async close() {
     const db = await this.getDB();
-    this.disposeListener();
     db.close();
   }
 
@@ -147,18 +118,24 @@ export class SQLJSDBAdapter extends DBAdapter {
   writeLock<T>(fn: (tx: LockContext) => Promise<T>, options?: DBLockOptions): Promise<T> {
     return this.mutex.runExclusive(async () => {
       const db = await this.getDB();
-      const result = await fn(new SqlJsLockContext(db));
+      const context = new SqlJsLockContext(db);
+      const result = await fn(context);
 
       // No point to schedule a write if there's no persister.
       if (this.options.persister) {
         this.writeScheduler.schedule(db);
       }
 
-      const notification: BatchedUpdateNotification = {
-        tables: Array.from(this.tableUpdateCache)
-      };
-      this.tableUpdateCache.clear();
-      this.iterateListeners((l) => l.tablesUpdated?.(notification));
+      const { rawRows: rawUpdates } = await context.executeRaw("SELECT powersync_update_hooks('get')");
+      const updatedTables = JSON.parse(rawUpdates[0][0] as string);
+
+      if (updatedTables.length) {
+        const notification: BatchedUpdateNotification = {
+          tables: updatedTables
+        };
+        this.iterateListeners((l) => l.tablesUpdated?.(notification));
+      }
+
       return result;
     }, timeoutSignal(options?.timeoutMs));
   }

--- a/packages/adapter-sql-js/src/SQLJSAdapter.ts
+++ b/packages/adapter-sql-js/src/SQLJSAdapter.ts
@@ -66,11 +66,15 @@ export class SQLJSDBAdapter extends DBAdapter {
     this.dbP = null;
 
     this.writeScheduler = new ControlledExecutor(async (db: SQLJs.Database) => {
-      if (!this.options.persister) {
+      const persister = this.options.persister;
+      if (!persister) {
         return;
       }
 
-      await this.options.persister.writeFile(db.export());
+      const blob = db.export();
+      // Calling export() closes and re-opens the database, so we need to re-install update hooks.
+      this.setup(db);
+      await persister.writeFile(blob);
     });
   }
 
@@ -97,10 +101,12 @@ export class SQLJSDBAdapter extends DBAdapter {
     const db = new SQL.Database(existing);
     this.dbP = (db as any)['db'] as number;
     this._db = db;
-
-    db.exec("SELECT powersync_update_hooks('install')");
-
+    this.setup(db);
     return db;
+  }
+
+  private setup(db: SQLJs.Database) {
+    db.exec("SELECT powersync_update_hooks('install')");
   }
 
   async close() {
@@ -121,11 +127,6 @@ export class SQLJSDBAdapter extends DBAdapter {
       const context = new SqlJsLockContext(db);
       const result = await fn(context);
 
-      // No point to schedule a write if there's no persister.
-      if (this.options.persister) {
-        this.writeScheduler.schedule(db);
-      }
-
       const { rawRows: rawUpdates } = await context.executeRaw("SELECT powersync_update_hooks('get')");
       const updatedTables = JSON.parse(rawUpdates[0][0] as string);
 
@@ -134,6 +135,11 @@ export class SQLJSDBAdapter extends DBAdapter {
           tables: updatedTables
         };
         this.iterateListeners((l) => l.tablesUpdated?.(notification));
+      }
+
+      // No point to schedule a write if there's no persister.
+      if (this.options.persister) {
+        this.writeScheduler.schedule(db);
       }
 
       return result;

--- a/packages/capacitor/PowersyncCapacitor.podspec
+++ b/packages/capacitor/PowersyncCapacitor.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
   s.swift_version = '5.1'
-  s.dependency "powersync-sqlite-core", "~> 0.4.12"
+  s.dependency "powersync-sqlite-core", "~> 0.5.1"
    s.xcconfig = {
     'OTHER_CFLAGS' => '$(inherited) -DSQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION=1',
     'HEADER_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/SQLCipher"'

--- a/packages/capacitor/PowersyncCapacitor.podspec
+++ b/packages/capacitor/PowersyncCapacitor.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
   s.swift_version = '5.1'
-  s.dependency "powersync-sqlite-core", "~> 0.5.1"
+  s.dependency "powersync-sqlite-core", "~> 0.5.2"
    s.xcconfig = {
     'OTHER_CFLAGS' => '$(inherited) -DSQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION=1',
     'HEADER_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/SQLCipher"'

--- a/packages/capacitor/README.md
+++ b/packages/capacitor/README.md
@@ -27,7 +27,7 @@ This package uses `@powersync/web` as a peer dependency. For additional `@powers
 You must also install the following peer dependencies:
 
 ```bash
-npm install @capacitor-community/sqlite @powersync/web @journeyapps/wa-sqlite
+npm install @capacitor-community/sqlite
 ```
 
 See the [Capacitor Community SQLite](https://github.com/capacitor-community/sqlite?tab=readme-ov-file#installation) repository for additional instructions.

--- a/packages/capacitor/README.md
+++ b/packages/capacitor/README.md
@@ -27,7 +27,7 @@ This package uses `@powersync/web` as a peer dependency. For additional `@powers
 You must also install the following peer dependencies:
 
 ```bash
-npm install @capacitor-community/sqlite
+npm install @capacitor-community/sqlite @powersync/web
 ```
 
 See the [Capacitor Community SQLite](https://github.com/capacitor-community/sqlite?tab=readme-ov-file#installation) repository for additional instructions.

--- a/packages/capacitor/android/build.gradle
+++ b/packages/capacitor/android/build.gradle
@@ -3,7 +3,7 @@ ext {
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.7.1'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.3.0'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.7.0'
-    powerSyncCoreVersion = project.hasProperty('powerSyncCoreVersion') ? rootProject.ext.powerSyncCoreVersion : '0.5.1'
+    powerSyncCoreVersion = project.hasProperty('powerSyncCoreVersion') ? rootProject.ext.powerSyncCoreVersion : '0.5.2'
 }
 
 buildscript {

--- a/packages/capacitor/android/build.gradle
+++ b/packages/capacitor/android/build.gradle
@@ -3,7 +3,7 @@ ext {
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.7.1'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.3.0'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.7.0'
-    powerSyncCoreVersion = project.hasProperty('powerSyncCoreVersion') ? rootProject.ext.powerSyncCoreVersion : '0.4.12'
+    powerSyncCoreVersion = project.hasProperty('powerSyncCoreVersion') ? rootProject.ext.powerSyncCoreVersion : '0.5.1'
 }
 
 buildscript {

--- a/packages/node/download_core.js
+++ b/packages/node/download_core.js
@@ -5,18 +5,18 @@ import { Readable } from 'node:stream';
 import { finished } from 'node:stream/promises';
 
 // When changing this version, run node download_core.js update_hashes
-const version = '0.4.12';
+const version = '0.5.1';
 const versionHashes = {
-  'powersync_x64.dll': 'efc095c2dff5194c1dbf4943012ae8bb5349e8aaac481d18cb0d3a49fa6a1255',
-  'powersync_x86.dll': '147ef50acdab8dc27075f29ae6f86dd26fb574f373e3a186492ca7d55d0b867c',
-  'powersync_aarch64.dll': '90fbce6a22bc7fcde0ee62ed52eec821afa86b1bacff4597ddc9cea2f7203cb1',
-  'libpowersync_x86.linux.so': '89b8b7451a01e533a5736a7025d13f0bd0640c1df40025cf8a90d6d2e7e8b1ee',
-  'libpowersync_x64.linux.so': 'c15d5a069200c823c95435bbad38a9dc12743deca42b30b0c40557b2bc32ac5d',
-  'libpowersync_aarch64.linux.so': 'acbf2a1b27f413d8a83e5efc91f0531c6989519203eaf2814c52942f1a445649',
-  'libpowersync_armv7.linux.so': 'e262fcf4c1509d96a692f159af572a09fad781d4cc3ba885d3de276926526432',
-  'libpowersync_riscv64gc.linux.so': '46101c885b4ff23e4a7059a5eb9f3fc697762455e6d296815a8ccece8eeacd41',
-  'libpowersync_x64.macos.dylib': 'e0b2402702bd744d65a2c8aba4d7242f5cefd67c33926d92567ee4e02b13e20d',
-  'libpowersync_aarch64.macos.dylib': 'cfbfa86a0b8203619059be4bf4cf3078f122866dcc4896b07f7b412a41628abe'
+  'powersync_x64.dll': 'c219af1591907c6cbd0258caab194ce70ef0a0fde30194e4a8f2835d50fd985e',
+  'powersync_x86.dll': '91b47afcb6054b7252d1350290c5d6aa53ea3b5028e30703387837c792161fcc',
+  'powersync_aarch64.dll': 'd735968bf8e42fc7e0cb1e2ce584b1f09aaa52c48919d121906cbc1caec5ed2d',
+  'libpowersync_x86.linux.so': '077d6128bfa7fab7fc4a11f7a64abacef8e0863a1ac545a28dc7a91c2bfbd69a',
+  'libpowersync_x64.linux.so': '3b999bf954525d24ec44d5cb716092af2e74df7a9ffcfad87c3a78dcc66ee9fd',
+  'libpowersync_aarch64.linux.so': 'f0d6c10090d41c9f4c6b09f3b424dacd07bd5b95bd383e6c7f3789dc9e0cf6ed',
+  'libpowersync_armv7.linux.so': 'a30fd521f08e1e1c883765b137a2b47e294c827cc5a6bdab1fe7133203078cbb',
+  'libpowersync_riscv64gc.linux.so': '9ae819f50fa2682fb3ec9afcb6046ab33a112b55234b05ecd3fc599add9fb920',
+  'libpowersync_x64.macos.dylib': '5d5a83092aa40b4604d653080ad727a32c2d2f098d2f7f51984221991676bda3',
+  'libpowersync_aarch64.macos.dylib': 'b0e4752c0f39e36e5b9896ddb81640fac9e694a6f1014a83746cdb63e696e89c'
 };
 
 const assets = Object.keys(versionHashes);

--- a/packages/node/download_core.js
+++ b/packages/node/download_core.js
@@ -5,18 +5,18 @@ import { Readable } from 'node:stream';
 import { finished } from 'node:stream/promises';
 
 // When changing this version, run node download_core.js update_hashes
-const version = '0.5.1';
+const version = '0.5.2';
 const versionHashes = {
-  'powersync_x64.dll': 'c219af1591907c6cbd0258caab194ce70ef0a0fde30194e4a8f2835d50fd985e',
-  'powersync_x86.dll': '91b47afcb6054b7252d1350290c5d6aa53ea3b5028e30703387837c792161fcc',
-  'powersync_aarch64.dll': 'd735968bf8e42fc7e0cb1e2ce584b1f09aaa52c48919d121906cbc1caec5ed2d',
-  'libpowersync_x86.linux.so': '077d6128bfa7fab7fc4a11f7a64abacef8e0863a1ac545a28dc7a91c2bfbd69a',
-  'libpowersync_x64.linux.so': '3b999bf954525d24ec44d5cb716092af2e74df7a9ffcfad87c3a78dcc66ee9fd',
-  'libpowersync_aarch64.linux.so': 'f0d6c10090d41c9f4c6b09f3b424dacd07bd5b95bd383e6c7f3789dc9e0cf6ed',
-  'libpowersync_armv7.linux.so': 'a30fd521f08e1e1c883765b137a2b47e294c827cc5a6bdab1fe7133203078cbb',
-  'libpowersync_riscv64gc.linux.so': '9ae819f50fa2682fb3ec9afcb6046ab33a112b55234b05ecd3fc599add9fb920',
-  'libpowersync_x64.macos.dylib': '5d5a83092aa40b4604d653080ad727a32c2d2f098d2f7f51984221991676bda3',
-  'libpowersync_aarch64.macos.dylib': 'b0e4752c0f39e36e5b9896ddb81640fac9e694a6f1014a83746cdb63e696e89c'
+  'powersync_x64.dll': '95b1aa81b5307793fcf5ef4d0982f38076e14cdd7b97ea1a84faa545af0b74db',
+  'powersync_x86.dll': '215d4aa2a08972dea7cbc91c316c111c2968ec47bd40865a78237b649d8d2e9a',
+  'powersync_aarch64.dll': '42a66fff06b2c927c60c78941ff8c069ad878761a46802a13dc33b9d503f6589',
+  'libpowersync_x86.linux.so': '3be78268b546796c5e8983d37b3c4b28e2c6d2a5c4ec21757164c0d6b7bc11f8',
+  'libpowersync_x64.linux.so': 'e3288d3e1e2bfc5ccee4fb66d5afb9c691e7da7010b3a561892857a922659819',
+  'libpowersync_aarch64.linux.so': '50817891679aa5598009119aa6cf00561e28c04078c6045c109281cf32bcf747',
+  'libpowersync_armv7.linux.so': 'c0028d3536fdd8684c6be20988d7edf91eb290da0b53a6f3b6752c3f0462daa7',
+  'libpowersync_riscv64gc.linux.so': 'c636d46f0e591953e37e306efd8c055b44216fb019733cbdae718d70387b6042',
+  'libpowersync_x64.macos.dylib': '53359ad66f31160795cf2728b1125567593bb00bd62197372fca8e461040abce',
+  'libpowersync_aarch64.macos.dylib': 'a3a37b9f346a7d12717149209f01c5f580a2ee3471b37bcdfa59a324834fd698'
 };
 
 const assets = Object.keys(versionHashes);

--- a/packages/node/tests/sync.test.ts
+++ b/packages/node/tests/sync.test.ts
@@ -144,7 +144,7 @@ describe('Sync', () => {
 
     // Replicate what we'd see on the web when switching connections in the shared sync worker: The sync client would
     // suddenly see a database without an active sync iteration.
-    await database.execute('SELECT powersync_control(?, null)', ['stop']);
+    await database.writeTransaction((tx) => tx.execute('SELECT powersync_control(?, null)', ['stop']));
     (database as BasePowerSyncDatabase).syncStreamImplementation!.markConnectionMayHaveChanged();
     await database.waitForStatus((s) => !s.connected);
     await vi.waitFor(() => expect(syncService.connectedListeners).toHaveLength(1));

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -64,7 +64,6 @@
     "bson": "catalog:"
   },
   "peerDependencies": {
-    "@journeyapps/wa-sqlite": "^1.7.0",
     "@powersync/kysely-driver": "workspace:^2.0.0",
     "@powersync/vue": "workspace:^0.6.0",
     "@powersync/web": "workspace:^2.0.0",

--- a/packages/nuxt/src/runtime/composables/usePowerSyncInspectorDiagnostics.ts
+++ b/packages/nuxt/src/runtime/composables/usePowerSyncInspectorDiagnostics.ts
@@ -11,6 +11,7 @@ import { ref, computed, readonly, onMounted, onUnmounted } from 'vue';
 import { computedAsync } from '@vueuse/core';
 import { usePowerSyncInspector } from './usePowerSyncInspector';
 import type { NuxtDatabaseImplementation } from '../utils/NuxtPowerSyncDatabase';
+import { SyncStatusSnapshot } from '@powersync/shared-internals';
 
 // queries
 const BUCKETS_QUERY = `
@@ -308,17 +309,21 @@ export function usePowerSyncInspectorDiagnostics(): UsePowerSyncInspectorDiagnos
 
   async function refreshState() {
     if (db.value) {
-      const { synced_at } = await db.value.get<{ synced_at: string | null }>(
-        'SELECT powersync_last_synced_at() as synced_at'
+      // FIXME: This relies on internal core extension APIs, why can't this use the
+      // current sync status?
+      const { status: rawStatus } = await db.value.get<{ status: string }>(
+        'SELECT powersync_offline_sync_status() as status'
       );
+      const status = new SyncStatusSnapshot(JSON.parse(rawStatus), null);
+      const hasSyned = status.hasSynced;
 
-      uploadQueueStats.value = await db.value?.getUploadQueueStats(true);
+      uploadQueueStats.value = await db.value.getUploadQueueStats(true);
 
-      if (synced_at != null && !syncStatus.value?.downloading) {
+      if (hasSyned && !syncStatus.value.downloading) {
         // These are potentially expensive queries - do not run during initial sync
         bucketRows.value = await db.value.getAll(BUCKETS_QUERY);
         tableRows.value = await db.value.getAll(TABLES_QUERY);
-      } else if (synced_at != null) {
+      } else if (hasSyned) {
         // Busy downloading, but have already synced once
         bucketRows.value = await db.value.getAll(BUCKETS_QUERY_FAST);
         // Load tables if we haven't yet

--- a/packages/nuxt/tests/composables/usePowerSyncInspectorDiagnostics.test.ts
+++ b/packages/nuxt/tests/composables/usePowerSyncInspectorDiagnostics.test.ts
@@ -77,8 +77,8 @@ describe('usePowerSyncInspectorDiagnostics', () => {
 
     // Verify refreshState was called (it queries synced_at and bucket data)
     const getCalls = getSpy.mock.calls;
-    const hasSyncedAtQuery = getCalls.some((call) => call[0]?.includes('powersync_last_synced_at'));
-    expect(hasSyncedAtQuery).toBe(true);
+    const hasStatusQuery = getCalls.some((call) => call[0]?.includes('powersync_offline_sync_status'));
+    expect(hasStatusQuery).toBe(true);
   });
 
   it('should trigger refreshState when onChangeWithCallback fires', async () => {

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -81,7 +81,7 @@ repositories {
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
-  implementation 'com.powersync:powersync-sqlite-core:0.5.1'
+  implementation 'com.powersync:powersync-sqlite-core:0.5.2'
   // For < 0.71, this will be from the local maven repo
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -81,7 +81,7 @@ repositories {
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
-  implementation 'com.powersync:powersync-sqlite-core:0.4.12'
+  implementation 'com.powersync:powersync-sqlite-core:0.5.1'
   // For < 0.71, this will be from the local maven repo
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion

--- a/packages/react-native/powersync-react-native.podspec
+++ b/packages/react-native/powersync-react-native.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React-callinvoker"
   s.dependency "React"
-  s.dependency "powersync-sqlite-core", "~> 0.5.1"
+  s.dependency "powersync-sqlite-core", "~> 0.5.2"
   if defined?(install_modules_dependencies())
     install_modules_dependencies(s)
   else

--- a/packages/react-native/powersync-react-native.podspec
+++ b/packages/react-native/powersync-react-native.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React-callinvoker"
   s.dependency "React"
-  s.dependency "powersync-sqlite-core", "~> 0.4.12"
+  s.dependency "powersync-sqlite-core", "~> 0.5.1"
   if defined?(install_modules_dependencies())
     install_modules_dependencies(s)
   else

--- a/packages/react-native/src/db/adapters/op-sqlite/OPSqliteAdapter.ts
+++ b/packages/react-native/src/db/adapters/op-sqlite/OPSqliteAdapter.ts
@@ -98,6 +98,8 @@ export class OPSQLiteDBAdapter extends DBAdapter {
     this.loadAdditionalExtensions(DB);
     this.loadPowerSyncExtension(DB);
 
+    await DB.execute('SELECT powersync_init()');
+
     return new OPSQLiteConnection({
       baseDB: DB
     });

--- a/packages/react-native/src/db/adapters/op-sqlite/OPSqliteAdapter.ts
+++ b/packages/react-native/src/db/adapters/op-sqlite/OPSqliteAdapter.ts
@@ -98,8 +98,6 @@ export class OPSQLiteDBAdapter extends DBAdapter {
     this.loadAdditionalExtensions(DB);
     this.loadPowerSyncExtension(DB);
 
-    await DB.execute('SELECT powersync_init()');
-
     return new OPSQLiteConnection({
       baseDB: DB
     });

--- a/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
+++ b/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
@@ -341,7 +341,7 @@ export abstract class BasePowerSyncDatabase<Options extends BasePowerSyncDatabas
         .map((n) => parseInt(n));
     } catch (e: any) {
       throw new Error(
-        `Unsupported powersync extension version. Need >=0.5.1 <1.6.0, got: ${this.sdkVersion}. Details: ${e.message}`
+        `Unsupported powersync extension version. Need >=0.5.1 <0.6.0, got: ${this.sdkVersion}. Details: ${e.message}`
       );
     }
 

--- a/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
+++ b/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
@@ -34,7 +34,11 @@ import {
   SqliteRecord,
   SyncStreamConnectionMethod
 } from '@powersync/common';
-import { BucketStorageAdapter, PSInternalTable } from './sync/bucket/BucketStorageAdapter.js';
+import {
+  BucketStorageAdapter,
+  PSInternalTable,
+  targetCheckpointRequestId
+} from './sync/bucket/BucketStorageAdapter.js';
 import { SyncStatusSnapshot } from '../db/crud/SyncStatus.js';
 import {
   ConnectionManager,
@@ -53,6 +57,7 @@ import { DEFAULT_WATCH_THROTTLE_MS } from './watched/WatchedQuery.js';
 import { CustomQuery } from './CustomQuery.js';
 import { MEMORY_TRIGGER_CLAIM_MANAGER } from './triggers/MemoryTriggerClaimManager.js';
 import { symbolAsyncIterator } from '../utils/compatibility.js';
+import { MAX_OP_ID } from '../constants.js';
 
 const POWERSYNC_TABLE_MATCH = /(^ps_data__|^ps_data_local__)/;
 
@@ -313,7 +318,6 @@ export abstract class BasePowerSyncDatabase<Options extends BasePowerSyncDatabas
    */
   protected async initialize() {
     await this._initialize();
-    await this.bucketStorageAdapter.init();
     await this.loadVersion();
     await this.updateSchema(this.options.schema);
     await this.resolveOfflineSyncStatus();
@@ -330,20 +334,20 @@ export abstract class BasePowerSyncDatabase<Options extends BasePowerSyncDatabas
     } catch (e: any) {
       throw new Error(`The powersync extension is not loaded correctly. Details: ${e.message}`);
     }
-    let versionInts: number[];
+    let major: number, minor: number, patch: number;
     try {
-      versionInts = this.sdkVersion!.split(/[.\/]/)
+      [major, minor, patch] = this.sdkVersion!.split(/[.\/]/)
         .slice(0, 3)
         .map((n) => parseInt(n));
     } catch (e: any) {
       throw new Error(
-        `Unsupported powersync extension version. Need >=0.4.10 <1.0.0, got: ${this.sdkVersion}. Details: ${e.message}`
+        `Unsupported powersync extension version. Need >=0.5.1 <1.6.0, got: ${this.sdkVersion}. Details: ${e.message}`
       );
     }
 
-    // Validate >=0.4.10 <1.0.0
-    if (versionInts[0] != 0 || versionInts[1] < 4 || (versionInts[1] == 4 && versionInts[2] < 10)) {
-      throw new Error(`Unsupported powersync extension version. Need >=0.4.10 <1.0.0, got: ${this.sdkVersion}`);
+    // Validate >=0.5.1 <0.6.0
+    if (major != 0 || minor != 5 || patch < 1) {
+      throw new Error(`Unsupported powersync extension version. Need >=0.5.1 <0.6.0, got: ${this.sdkVersion}`);
     }
   }
 
@@ -482,7 +486,7 @@ export abstract class BasePowerSyncDatabase<Options extends BasePowerSyncDatabas
 
     const last = all[all.length - 1];
     return new CrudBatch(all, haveMore, async (writeCheckpoint?: string) =>
-      this.handleCrudCheckpoint(last.clientId, writeCheckpoint)
+      this.bucketStorageAdapter.handleCrudCheckpoint(last.clientId, writeCheckpoint)
     );
   }
 
@@ -522,7 +526,8 @@ SELECT * FROM crud_entries;
               done: false,
               value: new CrudTransaction(
                 items,
-                async (writeCheckpoint?: string) => this.handleCrudCheckpoint(last.clientId, writeCheckpoint),
+                async (writeCheckpoint?: string) =>
+                  this.bucketStorageAdapter.handleCrudCheckpoint(last.clientId, writeCheckpoint),
                 txId
               )
             };
@@ -534,24 +539,6 @@ SELECT * FROM crud_entries;
 
   async getClientId(): Promise<string> {
     return this.bucketStorageAdapter.getClientId();
-  }
-
-  private async handleCrudCheckpoint(lastClientId: number, writeCheckpoint?: string) {
-    return this.writeTransaction(async (tx) => {
-      await tx.execute(`DELETE FROM ${PSInternalTable.CRUD} WHERE id <= ?`, [lastClientId]);
-      if (writeCheckpoint) {
-        const check = await tx.execute(`SELECT 1 FROM ${PSInternalTable.CRUD} LIMIT 1`);
-        if (!check.rows?.length) {
-          await tx.execute(`UPDATE ${PSInternalTable.BUCKETS} SET target_op = CAST(? as INTEGER) WHERE name='$local'`, [
-            writeCheckpoint
-          ]);
-        }
-      } else {
-        await tx.execute(`UPDATE ${PSInternalTable.BUCKETS} SET target_op = CAST(? as INTEGER) WHERE name='$local'`, [
-          this.bucketStorageAdapter.getMaxOpId()
-        ]);
-      }
-    });
   }
 
   async execute<T = SqliteRecord>(sql: string, parameters?: any[]) {

--- a/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
+++ b/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
@@ -341,13 +341,13 @@ export abstract class BasePowerSyncDatabase<Options extends BasePowerSyncDatabas
         .map((n) => parseInt(n));
     } catch (e: any) {
       throw new Error(
-        `Unsupported powersync extension version. Need >=0.5.1 <0.6.0, got: ${this.sdkVersion}. Details: ${e.message}`
+        `Unsupported powersync extension version. Need >=0.5.2 <0.6.0, got: ${this.sdkVersion}. Details: ${e.message}`
       );
     }
 
-    // Validate >=0.5.1 <0.6.0
-    if (major != 0 || minor != 5 || patch < 1) {
-      throw new Error(`Unsupported powersync extension version. Need >=0.5.1 <0.6.0, got: ${this.sdkVersion}`);
+    // Validate >=0.5.2 <0.6.0
+    if (major != 0 || minor != 5 || patch < 2) {
+      throw new Error(`Unsupported powersync extension version. Need >=0.5.2 <0.6.0, got: ${this.sdkVersion}`);
     }
   }
 

--- a/packages/shared-internals/src/client/sync/bucket/BucketStorageAdapter.ts
+++ b/packages/shared-internals/src/client/sync/bucket/BucketStorageAdapter.ts
@@ -61,6 +61,9 @@ export interface BucketStorageAdapter extends BaseObserverInterface<BucketStorag
  * Invokes `powersync_control` from the core extension, casting the result to text.
  */
 export async function rawPowerSyncControl(tx: Transaction, op: string, payload: SqliteValue): Promise<string | null> {
+  // For some calls, notably on target_checkpoint_request_id, powersync_control returns a 64-bit integer we want to
+  // represent as text. Instead of dealing with bigints which may or may not be supported across different sqlite
+  // libraries, play it safe and cast to text before mapping to JavaScript.
   const { rawRows } = await tx.executeRaw('SELECT CAST(powersync_control(?, ?) AS TEXT)', [op, payload]);
   return rawRows[0][0] as string | null;
 }

--- a/packages/shared-internals/src/client/sync/bucket/BucketStorageAdapter.ts
+++ b/packages/shared-internals/src/client/sync/bucket/BucketStorageAdapter.ts
@@ -1,4 +1,13 @@
-import { BaseListener, BaseObserverInterface, Disposable, CrudBatch, CrudEntry } from '@powersync/common';
+import {
+  BaseListener,
+  BaseObserverInterface,
+  Disposable,
+  CrudBatch,
+  CrudEntry,
+  Transaction,
+  SqliteValue
+} from '@powersync/common';
+import { MAX_OP_ID } from '../../../constants.js';
 
 export enum PSInternalTable {
   DATA = 'ps_data',
@@ -27,8 +36,6 @@ export interface BucketStorageListener extends BaseListener {
 }
 
 export interface BucketStorageAdapter extends BaseObserverInterface<BucketStorageListener>, Disposable {
-  init(): Promise<void>;
-
   hasMigratedSubkeys(): Promise<boolean>;
   migrateToFixedSubkeys(): Promise<void>;
 
@@ -37,7 +44,7 @@ export interface BucketStorageAdapter extends BaseObserverInterface<BucketStorag
   getCrudBatch(limit?: number): Promise<CrudBatch | null>;
 
   updateLocalTarget(cb: () => Promise<string>): Promise<boolean>;
-  getMaxOpId(): string;
+  handleCrudCheckpoint(lastClientId: number, writeCheckpoint?: string): Promise<void>;
 
   /**
    * Get an unique client id.
@@ -48,4 +55,27 @@ export interface BucketStorageAdapter extends BaseObserverInterface<BucketStorag
    * Invokes the `powersync_control` function for the sync client.
    */
   control(op: PowerSyncControlCommand, payload: string | Uint8Array | null): Promise<string>;
+}
+
+/**
+ * Invokes `powersync_control` from the core extension, casting the result to text.
+ */
+export async function rawPowerSyncControl(tx: Transaction, op: string, payload: SqliteValue): Promise<string | null> {
+  const { rawRows } = await tx.executeRaw('SELECT CAST(powersync_control(?, ?) AS TEXT)', [op, payload]);
+  return rawRows[0][0] as string | null;
+}
+
+/**
+ * Reads the current target checkpoint request id, or updates it when the update parameter is set.
+ *
+ * After requesting a checkpoint, the service needs to include that checkpoint id (or a subsequent one) in a
+ * `checkpoint_complete` message before we apply any subsequent sync lines. This guards against uploaded changes that
+ * have not yet been synced to flicker if we apply an intermediate checkpoint.
+ *
+ * @param update An optional value to update the stored target checkpoint request. {@link MAX_OP_ID} can be used as a
+ * sentinel for pending changes that have been uploaded, but for which no checkpoint request has been created yet.
+ * @returns The previous checkpoint request.
+ */
+export function targetCheckpointRequestId(tx: Transaction, update: string | null = null): Promise<string | null> {
+  return rawPowerSyncControl(tx, 'target_checkpoint_request_id', update);
 }

--- a/packages/shared-internals/src/client/sync/bucket/SqliteBucketStorage.ts
+++ b/packages/shared-internals/src/client/sync/bucket/SqliteBucketStorage.ts
@@ -5,14 +5,17 @@ import {
   DBAdapter,
   Transaction,
   CrudEntry,
-  CrudBatch
+  CrudBatch,
+  SqliteValue
 } from '@powersync/common';
 
 import {
   BucketStorageAdapter,
   BucketStorageListener,
   PowerSyncControlCommand,
-  PSInternalTable
+  PSInternalTable,
+  rawPowerSyncControl,
+  targetCheckpointRequestId
 } from './BucketStorageAdapter.js';
 import { CrudEntryImpl, CrudEntryJSON } from './CrudEntry.js';
 import { MAX_OP_ID } from '../../../constants.js';
@@ -21,7 +24,6 @@ import { MAX_OP_ID } from '../../../constants.js';
  * @internal
  */
 export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> implements BucketStorageAdapter {
-  public tableNames: Set<string>;
   private updateListener: () => void;
   private _clientId?: Promise<string>;
 
@@ -30,7 +32,6 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
     private logger: PowerSyncLogger
   ) {
     super();
-    this.tableNames = new Set();
     this.updateListener = db.registerListener({
       tablesUpdated: ({ tables }) => {
         if (tables.includes(PSInternalTable.CRUD)) {
@@ -38,15 +39,6 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
         }
       }
     });
-  }
-
-  async init() {
-    const existingTableRows = await this.db.getAll<{ name: string }>(
-      `SELECT name FROM sqlite_master WHERE type='table' AND name GLOB 'ps_data_*'`
-    );
-    for (const row of existingTableRows ?? []) {
-      this.tableNames.add(row.name);
-    }
   }
 
   async dispose() {
@@ -65,28 +57,19 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
     return this._clientId!;
   }
 
-  getMaxOpId() {
-    return MAX_OP_ID;
-  }
-
   async updateLocalTarget(cb: () => Promise<string>): Promise<boolean> {
-    const rs1 = await this.db.getAll(
-      "SELECT target_op FROM ps_buckets WHERE name = '$local' AND target_op = CAST(? as INTEGER)",
-      [MAX_OP_ID]
-    );
-    if (!rs1.length) {
-      // Nothing to update
-      return false;
-    }
-    const rs = await this.db.getOptional<{ seq: number }>(
-      "SELECT seq FROM main.sqlite_sequence WHERE name = 'ps_crud'"
-    );
-    if (!rs) {
-      // Nothing to update
-      return false;
-    }
+    const sequenceBefore = await this.db.readTransaction(async (tx): Promise<number | undefined> => {
+      const currentCheckpoint = await targetCheckpointRequestId(tx);
+      if (currentCheckpoint != MAX_OP_ID) return;
 
-    const seqBefore = rs.seq;
+      const rs = await tx.getOptional<{ seq: number }>("SELECT seq FROM main.sqlite_sequence WHERE name = 'ps_crud'");
+      return rs?.seq;
+    });
+
+    if (sequenceBefore == null) {
+      // Nothing to update
+      return false;
+    }
 
     const opId = await cb();
 
@@ -105,7 +88,7 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
         "SELECT seq FROM main.sqlite_sequence WHERE name = 'ps_crud'"
       );
 
-      if (seqAfter != seqBefore) {
+      if (seqAfter != sequenceBefore) {
         this.logger.log({
           level: LogLevels.debug,
           message: `New data uploaded since write checpoint ${opId} - need new write checkpoint (sequence updated)`
@@ -119,7 +102,7 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
         level: LogLevels.debug,
         message: `Updating target write checkpoint to ${opId}`
       });
-      await tx.execute("UPDATE ps_buckets SET target_op = CAST(? as INTEGER) WHERE name='$local'", [opId]);
+      await targetCheckpointRequestId(tx, opId);
       return true;
     });
   }
@@ -162,23 +145,23 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
       crud: all,
       haveMore: true,
       complete: async (writeCheckpoint?: string) => {
-        return this.writeTransaction(async (tx) => {
-          await tx.execute('DELETE FROM ps_crud WHERE id <= ?', [last.clientId]);
-          if (writeCheckpoint) {
-            const crudResult = await tx.execute('SELECT 1 FROM ps_crud LIMIT 1');
-            if (crudResult.rows?.length) {
-              await tx.execute("UPDATE ps_buckets SET target_op = CAST(? as INTEGER) WHERE name='$local'", [
-                writeCheckpoint
-              ]);
-            }
-          } else {
-            await tx.execute("UPDATE ps_buckets SET target_op = CAST(? as INTEGER) WHERE name='$local'", [
-              this.getMaxOpId()
-            ]);
-          }
-        });
+        return this.handleCrudCheckpoint(last.clientId, writeCheckpoint);
       }
     };
+  }
+
+  handleCrudCheckpoint(lastClientId: number, writeCheckpoint?: string): Promise<void> {
+    return this.writeTransaction(async (tx) => {
+      await tx.execute('DELETE FROM ps_crud WHERE id <= ?', [lastClientId]);
+      if (writeCheckpoint) {
+        const crudResult = await tx.execute('SELECT 1 FROM ps_crud LIMIT 1');
+        if (crudResult.rows?.length) {
+          await targetCheckpointRequestId(tx, writeCheckpoint);
+        }
+      } else {
+        await targetCheckpointRequestId(tx, MAX_OP_ID);
+      }
+    });
   }
 
   async writeTransaction<T>(callback: (tx: Transaction) => Promise<T>, options?: { timeoutMs: number }): Promise<T> {
@@ -187,8 +170,7 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
 
   async control(op: PowerSyncControlCommand, payload: string | Uint8Array | ArrayBuffer | null): Promise<string> {
     return await this.writeTransaction(async (tx) => {
-      const { rawRows } = await tx.executeRaw('SELECT powersync_control(?, ?)', [op, payload]);
-      return rawRows[0][0] as string;
+      return (await rawPowerSyncControl(tx, op, payload as SqliteValue))!;
     });
   }
 

--- a/packages/shared-internals/src/db/crud/SyncStatus.ts
+++ b/packages/shared-internals/src/db/crud/SyncStatus.ts
@@ -180,7 +180,7 @@ export class SyncStatusSnapshot implements SyncStatus {
 }
 
 function coreTimestampToDate(time: number | null): Date | undefined {
-  return time == null ? undefined : new Date(time * 1000);
+  return time == null ? undefined : new Date(time / 1000);
 }
 
 function priorityToJs(status: CoreSyncPriorityStatus): SyncPriorityStatus {

--- a/packages/tauri/Cargo.toml
+++ b/packages/tauri/Cargo.toml
@@ -18,7 +18,7 @@ tauri = { version = "2.10.3" }
 serde = "1"
 serde_json = { version = "1", features = ["raw_value"] }
 thiserror = "2"
-powersync = { version = "0.0.5", features = ["tokio", "reqwest"] }
+powersync = { version = "0.0.7", features = ["tokio", "reqwest"] }
 reqwest = "0.13.2"
 http-client = { version = "6.5.3", default-features = false }
 rusqlite = { version = "0.39.0", features = ["bundled"] }

--- a/packages/tauri/guest-js/database.ts
+++ b/packages/tauri/guest-js/database.ts
@@ -88,9 +88,7 @@ export class PowerSyncTauriDatabase extends BasePowerSyncDatabase<TauriPowerSync
 
   protected generateBucketStorageAdapter(): BucketStorageAdapter {
     return new Proxy<Partial<BucketStorageAdapter>>(
-      {
-        async init() {}
-      },
+      {},
       {
         get(target, symbol) {
           if (symbol in target) {

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -18,16 +18,6 @@ See a summary of features [here](https://docs.powersync.com/client-sdk-reference
 npm install @powersync/web
 ```
 
-## Install Peer Dependency: WA-SQLite
-
-This SDK currently requires `@journeyapps/wa-sqlite` as a peer dependency.
-
-Install it in your app with:
-
-```bash
-npm install @journeyapps/wa-sqlite
-```
-
 ### Encryption with Multiple Ciphers
 
 To enable encryption you need to specify an encryption key when instantiating the PowerSync database.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -56,18 +56,17 @@
   "author": "PowerSync",
   "license": "Apache-2.0",
   "peerDependencies": {
-    "@journeyapps/wa-sqlite": "catalog:",
     "@powersync/common": "workspace:^2.0.0",
     "@powersync/shared-internals": "workspace:^1.0.1"
   },
   "dependencies": {
     "@powersync/common": "workspace:*",
     "@powersync/shared-internals": "workspace:*",
+    "@journeyapps/wa-sqlite": "catalog:",
     "comlink": "catalog:",
     "commander": "^12.1.0"
   },
   "devDependencies": {
-    "@journeyapps/wa-sqlite": "^1.7.0",
     "@types/uuid": "catalog:",
     "bson": "catalog:",
     "glob": "catalog:",

--- a/packages/web/src/db/adapters/wa-sqlite/DatabaseServer.ts
+++ b/packages/web/src/db/adapters/wa-sqlite/DatabaseServer.ts
@@ -172,7 +172,10 @@ export class DatabaseServer {
   }
 
   async forceClose() {
-    this.#logger.log({ level: LogLevels.debug, message: `Closing connection to ${this.#inner.options}.` });
+    this.#logger.log({
+      level: LogLevels.debug,
+      message: `Closing connection to ${JSON.stringify(this.#inner.options)}.`
+    });
     const connection = this.#inner;
     this.#options.onClose();
     this.#updateBroadcastChannel.close();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,8 +250,8 @@ importers:
         version: link:../shared-internals
     devDependencies:
       '@powersync/sql-js':
-        specifier: 0.0.10
-        version: 0.0.10
+        specifier: 0.0.11
+        version: 0.0.11
       '@powersync/web':
         specifier: workspace:*
         version: link:../web
@@ -5513,8 +5513,8 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
-  '@powersync/sql-js@0.0.10':
-    resolution: {integrity: sha512-1sakDvham2yxcQ08VWxSvyUuUaEQARc2zNDzRlCvBgLM25l2sO81HxobLwCh8ixhz+Uqv1mxbi/OeDr7JMsUIw==}
+  '@powersync/sql-js@0.0.11':
+    resolution: {integrity: sha512-m3wlVMgYlmyaBD9Aii5x91OBFtxi2/YKS56fEP8MTEKW41leClO1pbGC6Dj88pGU9cj05EB3pbBeXgrTAFfqLg==}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -24294,7 +24294,7 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@powersync/sql-js@0.0.10': {}
+  '@powersync/sql-js@0.0.11': {}
 
   '@quansync/fs@1.0.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,8 +250,8 @@ importers:
         version: link:../shared-internals
     devDependencies:
       '@powersync/sql-js':
-        specifier: 0.0.9
-        version: 0.0.9
+        specifier: 0.0.10
+        version: 0.0.10
       '@powersync/web':
         specifier: workspace:*
         version: link:../web
@@ -5513,8 +5513,8 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
-  '@powersync/sql-js@0.0.9':
-    resolution: {integrity: sha512-HX78DscTAD5TRsjT+xEYky3sg0JSKw+B697qyJRK/iZ0Pni/VwbKCQuo9Hk4Tc0PjIQIDMajrvqrpfZz2sbhdQ==}
+  '@powersync/sql-js@0.0.10':
+    resolution: {integrity: sha512-1sakDvham2yxcQ08VWxSvyUuUaEQARc2zNDzRlCvBgLM25l2sO81HxobLwCh8ixhz+Uqv1mxbi/OeDr7JMsUIw==}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -24294,7 +24294,7 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@powersync/sql-js@0.0.9': {}
+  '@powersync/sql-js@0.0.10': {}
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -25040,7 +25040,7 @@ snapshots:
       eslint: 8.57.1
       eslint-config-prettier: 8.10.2(eslint@8.57.1)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.1)
-      eslint-plugin-ft-flow: 2.0.3(@babel/eslint-parser@7.28.6(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-ft-flow: 2.0.3(@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jest: 29.15.0(@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(jest@29.7.0(@types/node@24.10.13))(typescript@6.0.3)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 7.0.1(eslint@8.57.1)
@@ -29986,7 +29986,7 @@ snapshots:
       eslint: 8.57.1
       ignore: 5.3.2
 
-  eslint-plugin-ft-flow@2.0.3(@babel/eslint-parser@7.28.6(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-ft-flow@2.0.3(@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@babel/eslint-parser': 7.28.6(@babel/core@7.29.7)(eslint@8.57.1)
       eslint: 8.57.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@journeyapps/wa-sqlite':
-      specifier: 2.0.0
-      version: 2.0.0
+      specifier: 2.0.1
+      version: 2.0.1
     '@microsoft/api-extractor':
       specifier: ^7.58.7
       version: 7.58.7
@@ -410,7 +410,7 @@ importers:
     devDependencies:
       '@journeyapps/wa-sqlite':
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 2.0.1
       '@powersync/web':
         specifier: workspace:*
         version: link:../web
@@ -435,7 +435,7 @@ importers:
     devDependencies:
       '@journeyapps/wa-sqlite':
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 2.0.1
       '@powersync/web':
         specifier: workspace:*
         version: link:../web
@@ -539,7 +539,7 @@ importers:
     devDependencies:
       '@journeyapps/wa-sqlite':
         specifier: ^1.7.0
-        version: 1.7.0
+        version: 1.7.2
       '@nuxt/module-builder':
         specifier: ^1.0.2
         version: 1.0.2(@nuxt/cli@3.34.0(@nuxt/schema@4.3.1)(cac@6.7.14)(commander@13.1.0)(magicast@0.5.2))(@vue/compiler-core@3.5.35)(esbuild@0.27.3)(typescript@6.0.3)(vue-tsc@3.2.5(typescript@6.0.3))(vue@3.5.30(typescript@6.0.3))
@@ -785,7 +785,7 @@ importers:
     dependencies:
       '@journeyapps/wa-sqlite':
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 2.0.1
       '@powersync/common':
         specifier: workspace:*
         version: link:../common
@@ -840,7 +840,7 @@ importers:
     dependencies:
       '@journeyapps/wa-sqlite':
         specifier: 'catalog:'
-        version: 2.0.0
+        version: 2.0.1
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3991,11 +3991,11 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  '@journeyapps/wa-sqlite@1.7.0':
-    resolution: {integrity: sha512-xQZ670aKDo4FWxIFpLqY0AGDpURr09aYIO08UkLdWvFw8C018nCiqY0ILJudGRhRdXORhv7K2xD2OXZ2QxU39w==}
+  '@journeyapps/wa-sqlite@1.7.2':
+    resolution: {integrity: sha512-EVRMzqHtHgJBFcTGOgQ5/YlxrYFSXLFFztC5yo6+jQx2mqFR+a1kkLV4IirquiBzIonjmYXfBtvZ26fmI8r9Nw==}
 
-  '@journeyapps/wa-sqlite@2.0.0':
-    resolution: {integrity: sha512-rRvA568ybaop0vFmKLv3eUzG9Cwf04G3S16bKibrKzpcq6loBQxgVcJgbN6CfFAXd/4+uj3F+R3/yKhHZKYh/w==}
+  '@journeyapps/wa-sqlite@2.0.1':
+    resolution: {integrity: sha512-QhKBS9onDyFwZfXjUYH5E4UFhlRiMilMUv+M/Pba1UKYrHlLl9rjLmKPO7cBldqZGn3+Jfd1QviGDnxNipRziA==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -22125,9 +22125,9 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
-  '@journeyapps/wa-sqlite@1.7.0': {}
+  '@journeyapps/wa-sqlite@1.7.2': {}
 
-  '@journeyapps/wa-sqlite@2.0.0': {}
+  '@journeyapps/wa-sqlite@2.0.1': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -25040,7 +25040,7 @@ snapshots:
       eslint: 8.57.1
       eslint-config-prettier: 8.10.2(eslint@8.57.1)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.1)
-      eslint-plugin-ft-flow: 2.0.3(@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-ft-flow: 2.0.3(@babel/eslint-parser@7.28.6(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jest: 29.15.0(@typescript-eslint/eslint-plugin@8.57.1(@typescript-eslint/parser@8.57.1(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(jest@29.7.0(@types/node@24.10.13))(typescript@6.0.3)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 7.0.1(eslint@8.57.1)
@@ -29986,7 +29986,7 @@ snapshots:
       eslint: 8.57.1
       ignore: 5.3.2
 
-  eslint-plugin-ft-flow@2.0.3(@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-ft-flow@2.0.3(@babel/eslint-parser@7.28.6(@babel/core@7.29.7)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@babel/eslint-parser': 7.28.6(@babel/core@7.29.7)(eslint@8.57.1)
       eslint: 8.57.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@journeyapps/wa-sqlite':
-      specifier: ^1.5.0
-      version: 1.7.0
+      specifier: 2.0.0
+      version: 2.0.0
     '@microsoft/api-extractor':
       specifier: ^7.58.7
       version: 7.58.7
@@ -410,7 +410,7 @@ importers:
     devDependencies:
       '@journeyapps/wa-sqlite':
         specifier: 'catalog:'
-        version: 1.7.0
+        version: 2.0.0
       '@powersync/web':
         specifier: workspace:*
         version: link:../web
@@ -435,7 +435,7 @@ importers:
     devDependencies:
       '@journeyapps/wa-sqlite':
         specifier: 'catalog:'
-        version: 1.7.0
+        version: 2.0.0
       '@powersync/web':
         specifier: workspace:*
         version: link:../web
@@ -783,6 +783,9 @@ importers:
 
   packages/web:
     dependencies:
+      '@journeyapps/wa-sqlite':
+        specifier: 'catalog:'
+        version: 2.0.0
       '@powersync/common':
         specifier: workspace:*
         version: link:../common
@@ -796,9 +799,6 @@ importers:
         specifier: ^12.1.0
         version: 12.1.0
     devDependencies:
-      '@journeyapps/wa-sqlite':
-        specifier: ^1.7.0
-        version: 1.7.0
       '@rollup/plugin-node-resolve':
         specifier: 'catalog:'
         version: 16.0.3(rollup@4.59.0)
@@ -839,8 +839,8 @@ importers:
   tools/diagnostics-app:
     dependencies:
       '@journeyapps/wa-sqlite':
-        specifier: ^1.7.0
-        version: 1.7.0
+        specifier: 'catalog:'
+        version: 2.0.0
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3993,6 +3993,9 @@ packages:
 
   '@journeyapps/wa-sqlite@1.7.0':
     resolution: {integrity: sha512-xQZ670aKDo4FWxIFpLqY0AGDpURr09aYIO08UkLdWvFw8C018nCiqY0ILJudGRhRdXORhv7K2xD2OXZ2QxU39w==}
+
+  '@journeyapps/wa-sqlite@2.0.0':
+    resolution: {integrity: sha512-rRvA568ybaop0vFmKLv3eUzG9Cwf04G3S16bKibrKzpcq6loBQxgVcJgbN6CfFAXd/4+uj3F+R3/yKhHZKYh/w==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -22123,6 +22126,8 @@ snapshots:
       chalk: 4.1.2
 
   '@journeyapps/wa-sqlite@1.7.0': {}
+
+  '@journeyapps/wa-sqlite@2.0.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ overrides:
 catalog:
   # We must depend on an exact version of wa-sqlite, as we want to update the core extension
   # (which can be breaking for SDKs) without a major revision.
-  '@journeyapps/wa-sqlite': 2.0.0
+  '@journeyapps/wa-sqlite': 2.0.1
   '@microsoft/api-extractor': ^7.58.7
   '@nuxt/devtools-kit': ^3.2.3
   '@nuxt/devtools-ui-kit': ^3.2.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,9 @@ overrides:
   'seroval': '>=1.5.6'
 
 catalog:
-  '@journeyapps/wa-sqlite': ^1.5.0
+  # We must depend on an exact version of wa-sqlite, as we want to update the core extension
+  # (which can be breaking for SDKs) without a major revision.
+  '@journeyapps/wa-sqlite': 2.0.0
   '@microsoft/api-extractor': ^7.58.7
   '@nuxt/devtools-kit': ^3.2.3
   '@nuxt/devtools-ui-kit': ^3.2.3

--- a/tools/diagnostics-app/package.json
+++ b/tools/diagnostics-app/package.json
@@ -10,7 +10,7 @@
     "start": "pnpm build && pnpm preview"
   },
   "dependencies": {
-    "@journeyapps/wa-sqlite": "^1.7.0",
+    "@journeyapps/wa-sqlite": "catalog:",
     "@monaco-editor/react": "^4.7.0",
     "@powersync/react": "workspace:*",
     "@powersync/web": "workspace:*",

--- a/tools/diagnostics-app/src/library/powersync/PowerSyncStats.ts
+++ b/tools/diagnostics-app/src/library/powersync/PowerSyncStats.ts
@@ -69,7 +69,10 @@ export async function fetchPowerSyncStats(getAll: GetAll, objectNames: Set<strin
           const tableInfo = await getAll(`PRAGMA table_info("${tableName}")`);
           const dataCols = tableInfo.filter((c: any) => c.name !== 'id').map((c: any) => `"${c.name}"`);
 
-          const sizeExpr = dataCols.length > 0 ? `, sum(${dataCols.map((c) => `length(ifnull(${c}, ''))`).join(' + ')}) as data_size` : '';
+          const sizeExpr =
+            dataCols.length > 0
+              ? `, sum(${dataCols.map((c) => `length(ifnull(${c}, ''))`).join(' + ')}) as data_size`
+              : '';
           const result = await getAll(`
             SELECT
               count(*) as count
@@ -126,7 +129,7 @@ export async function fetchPowerSyncStats(getAll: GetAll, objectNames: Set<strin
     if (objectNames.has('ps_buckets')) {
       if (bucketCount === 0) {
         try {
-          const countResult = await getAll(`SELECT count(*) as count FROM ps_buckets WHERE name != '$local'`);
+          const countResult = await getAll(`SELECT count(*) as count FROM ps_buckets`);
           bucketCount = Number(countResult[0]?.count) || 0;
         } catch {
           // ps_buckets exists but query failed
@@ -137,8 +140,7 @@ export async function fetchPowerSyncStats(getAll: GetAll, objectNames: Set<strin
         // Try count_at_last + count_since_last first (newer SDK versions)
         try {
           const opsResult = await getAll(`
-            SELECT sum(count_at_last + count_since_last) as total_ops
-            FROM ps_buckets WHERE name != '$local'
+            SELECT sum(count_at_last + count_since_last) as total_ops FROM ps_buckets
           `);
           totalOps = Number(opsResult[0]?.total_ops) || 0;
         } catch {
@@ -150,8 +152,7 @@ export async function fetchPowerSyncStats(getAll: GetAll, objectNames: Set<strin
         // Fallback: last_op is the checkpoint sequence number per bucket (~= total ops)
         try {
           const opIdResult = await getAll(`
-            SELECT sum(cast(last_op as integer)) as total_ops
-            FROM ps_buckets WHERE name != '$local'
+            SELECT sum(cast(last_op as integer)) as total_ops FROM ps_buckets
           `);
           totalOps = Number(opIdResult[0]?.total_ops) || 0;
         } catch {

--- a/tools/powersynctests/ios/Podfile.lock
+++ b/tools/powersynctests/ios/Podfile.lock
@@ -25,9 +25,9 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - powersync-react-native (1.35.6):
+  - powersync-react-native (2.0.0):
     - hermes-engine
-    - powersync-sqlite-core (~> 0.4.12)
+    - powersync-sqlite-core (~> 0.5.1)
     - RCTRequired
     - RCTTypeSafety
     - React
@@ -50,7 +50,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - powersync-sqlite-core (0.4.14)
+  - powersync-sqlite-core (0.5.1)
   - RCTDeprecation (0.86.0)
   - RCTRequired (0.86.0)
   - RCTSwiftUI (0.86.0)
@@ -2126,8 +2126,8 @@ SPEC CHECKSUMS:
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
   hermes-engine: 55148b6d9f59a81514e4602d9af4759dd288f194
   op-sqlite: 6e75f040190a3bbd46758c08d252980c3a466e69
-  powersync-react-native: 5103c1f81ad39b63df734360f2ba65a26f4b9d19
-  powersync-sqlite-core: 6ce0b8b254812855e4ec52899ddc3ac6a30bda12
+  powersync-react-native: e2e5c6a845201114c14f05e5175802b9ed31bb6d
+  powersync-sqlite-core: a9945744f1a0cb7f1c81879d679b197fca43e2ef
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b
   RCTRequired: 30451112e6fef4e6f31b4e7eee0845156e35e4b0
   RCTSwiftUI: 5aaf0b07e747ba749dc6acc94d8bd41eea4b570f

--- a/tools/powersynctests/ios/Podfile.lock
+++ b/tools/powersynctests/ios/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
     - Yoga
   - powersync-react-native (2.0.0):
     - hermes-engine
-    - powersync-sqlite-core (~> 0.5.1)
+    - powersync-sqlite-core (~> 0.5.2)
     - RCTRequired
     - RCTTypeSafety
     - React
@@ -50,7 +50,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - powersync-sqlite-core (0.5.1)
+  - powersync-sqlite-core (0.5.2)
   - RCTDeprecation (0.86.0)
   - RCTRequired (0.86.0)
   - RCTSwiftUI (0.86.0)
@@ -2126,8 +2126,8 @@ SPEC CHECKSUMS:
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
   hermes-engine: 55148b6d9f59a81514e4602d9af4759dd288f194
   op-sqlite: 6e75f040190a3bbd46758c08d252980c3a466e69
-  powersync-react-native: e2e5c6a845201114c14f05e5175802b9ed31bb6d
-  powersync-sqlite-core: a9945744f1a0cb7f1c81879d679b197fca43e2ef
+  powersync-react-native: 419e1144ee8a5aac1571914c8f37a61088a4dd40
+  powersync-sqlite-core: bc08b93d58df5a012e99cd3795ceb2d1bc97e5a3
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b
   RCTRequired: 30451112e6fef4e6f31b4e7eee0845156e35e4b0
   RCTSwiftUI: 5aaf0b07e747ba749dc6acc94d8bd41eea4b570f


### PR DESCRIPTION
This updates the core extension to version 0.5.2. It follows the usual checklist of updating wa-sqlite, sql-js, node, react-native and capacitor. For sql-js, this also refactors update notifications to use the core extension instead of JavaScript callbacks.

Breaking changes in the core extension update are:

1. Time values are now encoded as microsecond timestamps (instead of seconds). Closes https://github.com/powersync-ja/powersync-js/issues/945.
2. The `$local` bucket has been replaced with the `powersync_control('target_checkpoint_request_id')` interface.
3. Initialization and schema-update functions must be called in transactions. We already fixed this in the JS SDK because implicit transactions also broke the OPFS writeahead VFS, there was just one missing case in a test.
4. The `powersync_last_synce_at()` function has been removed, I don't know why nuxt would possibly call that directly but I have adopted a literal port to `powersync_offline_sync_status()`.

This also makes `@journeyapps/wa-sqlite` a regular instead of a peer-dependency, meaning that users won't have to worry about keeping these packages in sync. We depend on an exact version of wa-sqlite now, allowing us to land subsequent core extension updates without another major bump on that package.