### PR TITLE
Fix connect() transiently clobbering the offline-restored sync status

### DIFF
--- a/.changeset/eight-jokes-refuse.md
+++ b/.changeset/eight-jokes-refuse.md
@@ -5,4 +5,4 @@
 Fix `connect()` transiently reporting a sync status without core state (`hasSynced: undefined`, no
 stream subscriptions), clobbering the offline sync status restored when the database was opened.
 Also fix aborted or failed connection attempts resetting the restored status the same way before
-the sync core had reported a status for them.
+the core extension had reported a status for them.

--- a/.changeset/eight-jokes-refuse.md
+++ b/.changeset/eight-jokes-refuse.md
@@ -1,0 +1,8 @@
+---
+'@powersync/shared-internals': patch
+---
+
+Fix `connect()` transiently reporting a sync status without core state (`hasSynced: undefined`, no
+stream subscriptions), clobbering the offline sync status restored when the database was opened.
+Also fix aborted or failed connection attempts resetting the restored status the same way before
+the sync core had reported a status for them.

--- a/packages/node/tests/sync.test.ts
+++ b/packages/node/tests/sync.test.ts
@@ -6,13 +6,16 @@ import {
   ProgressWithOperations,
   Schema,
   SyncOptions,
+  SyncStatus,
   SyncStreamConnectionMethod
 } from '@powersync/common';
 import {
   bucket,
+  checkpoint,
   MockSyncService,
   createMockSyncServiceTest,
   mockSyncServiceTest,
+  stream,
   TestConnector,
   waitForSyncStatus
 } from './utils.js';
@@ -823,6 +826,105 @@ function defineSyncTests(bson: boolean) {
     expect(another.currentStatus.priorityStatusEntries).toHaveLength(1);
     expect(another.currentStatus.statusForPriority(0).hasSynced).toBeTruthy();
     await another.waitForFirstSync({ priority: 0 });
+  });
+
+  mockSyncServiceTest('connecting does not clobber offline sync state', async ({ syncService }) => {
+    // Complete a full sync including a stream subscription, then close the database.
+    let database = await syncService.createDatabase();
+    const subscription = await database.syncStream('a').subscribe();
+    database.connect(new TestConnector(), options);
+    await vi.waitFor(() => expect(syncService.connectedListeners).toHaveLength(1));
+
+    syncService.pushLine(
+      checkpoint({
+        last_op_id: 0,
+        buckets: [bucket('a', 0, { priority: 3, subscriptions: [{ sub: 0 }] })],
+        streams: [stream('a', false)]
+      })
+    );
+    syncService.pushLine({ checkpoint_complete: { last_op_id: '0' } });
+    await database.waitForFirstSync();
+    subscription.unsubscribe();
+    await database.close();
+    await vi.waitFor(() => expect(syncService.connectedListeners).toHaveLength(0));
+
+    // Re-opening the database restores the previous sync state.
+    database = await syncService.createDatabase();
+    const streamDescription = { name: 'a', parameters: null };
+    expect(database.currentStatus.hasSynced).toBe(true);
+    expect(database.currentStatus.forStream(streamDescription)?.subscription.hasSynced).toBe(true);
+
+    const statuses: SyncStatus[] = [];
+    database.registerListener({
+      statusChanged: (status) => statuses.push(status)
+    });
+
+    // Connect while holding the write lock: the sync core's first status update (which needs
+    // powersync_control on the write connection) is then guaranteed to arrive after the CRUD
+    // upload loop's initial read-only pass reports its upload state.
+    let releaseWriteLock!: () => void;
+    const writeLockHeld = new Promise<void>((lockHeld) => {
+      database.writeLock(() => {
+        lockHeld();
+        return new Promise<void>((release) => (releaseWriteLock = release));
+      });
+    });
+    await writeLockHeld;
+
+    database.connect(new TestConnector(), options);
+    await vi.waitFor(() => expect(statuses).not.toHaveLength(0));
+    releaseWriteLock();
+    await database.waitForStatus((s) => s.connected);
+
+    // The restored state must survive connecting - no emitted status may drop it.
+    for (const status of statuses) {
+      expect(status.hasSynced).toBe(true);
+      expect(status.forStream(streamDescription)?.subscription.hasSynced).toBe(true);
+    }
+  });
+
+  mockSyncServiceTest('aborted connect does not clobber offline sync state', async ({ syncService }) => {
+    // Complete a full sync, then close the database.
+    let database = await syncService.createDatabase();
+    database.connect(new TestConnector(), options);
+    await vi.waitFor(() => expect(syncService.connectedListeners).toHaveLength(1));
+
+    syncService.pushLine(checkpoint({ last_op_id: 0 }));
+    syncService.pushLine({ checkpoint_complete: { last_op_id: '0' } });
+    await database.waitForFirstSync();
+    await database.close();
+    await vi.waitFor(() => expect(syncService.connectedListeners).toHaveLength(0));
+
+    database = await syncService.createDatabase();
+    expect(database.currentStatus.hasSynced).toBe(true);
+
+    const statuses: SyncStatus[] = [];
+    database.registerListener({
+      statusChanged: (status) => statuses.push(status)
+    });
+
+    // Hold the write lock so that the connection attempt is aborted before the sync core could
+    // report a status for it.
+    let releaseWriteLock!: () => void;
+    const writeLockHeld = new Promise<void>((lockHeld) => {
+      database.writeLock(() => {
+        lockHeld();
+        return new Promise<void>((release) => (releaseWriteLock = release));
+      });
+    });
+    await writeLockHeld;
+
+    database.connect(new TestConnector(), options);
+    await vi.waitFor(() => expect(statuses).not.toHaveLength(0));
+    const disconnected = database.disconnect();
+    releaseWriteLock();
+    await disconnected;
+
+    // Marking the never-connected attempt as disconnected must not drop the restored state.
+    for (const status of statuses) {
+      expect(status.hasSynced).toBe(true);
+    }
+    expect(database.currentStatus.hasSynced).toBe(true);
   });
 
   mockSyncServiceTest('raw tables with inferred statements', async ({ syncService }) => {

--- a/packages/node/tests/sync.test.ts
+++ b/packages/node/tests/sync.test.ts
@@ -859,7 +859,7 @@ function defineSyncTests(bson: boolean) {
       statusChanged: (status) => statuses.push(status)
     });
 
-    // Connect while holding the write lock: the sync core's first status update (which needs
+    // Connect while holding the write lock: the core extension's first status update (which needs
     // powersync_control on the write connection) is then guaranteed to arrive after the CRUD
     // upload loop's initial read-only pass reports its upload state.
     let releaseWriteLock!: () => void;
@@ -903,7 +903,7 @@ function defineSyncTests(bson: boolean) {
       statusChanged: (status) => statuses.push(status)
     });
 
-    // Hold the write lock so that the connection attempt is aborted before the sync core could
+    // Hold the write lock so that the connection attempt is aborted before the core extension could
     // report a status for it.
     let releaseWriteLock!: () => void;
     const writeLockHeld = new Promise<void>((lockHeld) => {

--- a/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
+++ b/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
@@ -167,8 +167,17 @@ export abstract class BasePowerSyncDatabase<Options extends BasePowerSyncDatabas
           const sync = this.generateSyncStreamImplementation(connector, options);
           const onDispose = sync.registerListener({
             statusChanged: (snapshot) => {
-              this.currentStatus = snapshot;
-              this.iterateListeners((cb) => cb.statusChanged?.(snapshot));
+              // A new sync stream implementation can report JavaScript-side state (like upload
+              // progress) before the sync core has reported its first status. Those snapshots
+              // have no core state - keep the known core state (e.g. the offline sync status
+              // resolved during initialization) instead of clobbering it with an empty one.
+              const updatedStatus =
+                snapshot.core == null && this.currentStatus.core != null
+                  ? new SyncStatusSnapshot(this.currentStatus.core, snapshot.jsState)
+                  : snapshot;
+
+              this.currentStatus = updatedStatus;
+              this.iterateListeners((cb) => cb.statusChanged?.(updatedStatus));
             }
           });
           await sync.waitForReady();

--- a/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
+++ b/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
@@ -167,10 +167,7 @@ export abstract class BasePowerSyncDatabase<Options extends BasePowerSyncDatabas
           const sync = this.generateSyncStreamImplementation(connector, options);
           const onDispose = sync.registerListener({
             statusChanged: (snapshot) => {
-              // A new sync stream implementation can report JavaScript-side state (like upload
-              // progress) before the sync core has reported its first status. Those snapshots
-              // have no core state - keep the known core state (e.g. the offline sync status
-              // resolved during initialization) instead of clobbering it with an empty one.
+              // For a JavaScriptSyncState update before the sync client was able to resolve the full status from the core extension, use the known offline sync state resolved during initialization.
               const updatedStatus =
                 snapshot.core == null && this.currentStatus.core != null
                   ? new SyncStatusSnapshot(this.currentStatus.core, snapshot.jsState)

--- a/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -336,9 +336,7 @@ The next upload iteration will be delayed.`
   private markAsDisconnected() {
     const current = this.syncStatus.core;
     if (current == null) {
-      // The sync core never reported a status for this connection attempt, so there is no
-      // connection state to reset. Synthesizing an empty core status here would clobber sync
-      // state previously restored from the database.
+      // There's no connection attempt for which state could be cleared.
       return;
     }
 

--- a/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -335,12 +335,19 @@ The next upload iteration will be delayed.`
 
   private markAsDisconnected() {
     const current = this.syncStatus.core;
+    if (current == null) {
+      // The sync core never reported a status for this connection attempt, so there is no
+      // connection state to reset. Synthesizing an empty core status here would clobber sync
+      // state previously restored from the database.
+      return;
+    }
+
     this.updateSyncStatus({
       connected: false,
       connecting: false,
-      priority_status: current?.priority_status ?? [],
+      priority_status: current.priority_status,
       downloading: null,
-      streams: current?.streams ?? []
+      streams: current.streams
     });
   }
 


### PR DESCRIPTION
## What & why

On a warm boot, `BasePowerSyncDatabase` restores the offline sync status (`powersync_offline_sync_status()`) during init, so returning clients correctly start with `hasSynced: true` and their persisted stream subscription state. But two status emissions from a freshly created sync stream implementation could reach the database's `statusChanged` listener before the sync core reported its first status for the connection attempt, transiently clobbering that restored state (full symptom timeline and downstream impact in #1050):

- The CRUD upload loop reports its upload state after the first pass, which can happen before the core's first `UpdateSyncStatus`. That snapshot carries `core == null`, and the listener replaced `currentStatus` wholesale — `hasSynced` flips to `undefined` and `forStream(...)` loses the subscription until the core's first status lands a task later.
- `markAsDisconnected()` on an implementation whose core never reported a status (an aborted or failed connection attempt) synthesized an empty but non-null core status (no streams, no priority entries), with the same effect.

## Changes

- `BasePowerSyncDatabase`: when an incoming snapshot has no core state while the database has one, keep the known core state and adopt the snapshot's `jsState` (the same merge idiom `resolveOfflineSyncStatus` already uses).
- `AbstractStreamingSyncImplementation.markAsDisconnected()`: return early when the core never reported a status for this connection attempt — there is no connection state to reset, and synthesizing an empty status would drop restored state. This extends the stream-preserving behavior `markAsDisconnected` already had for established connections.
- Two regression tests in `packages/node/tests/sync.test.ts` (run for both JSON and BSON): sync → close → reopen → connect, and the disconnect-during-connect variant. They hold the database write lock while connecting, which blocks the core's first status (`powersync_control` needs the write connection) while the upload loop's initial empty-queue pass is read-only — making the originally ~30 ms race deterministic. Both fail on `main` (`hasSynced` becomes `undefined`/`false`) and pass with this change.

## Notes for reviewers

- The database-level merge also covers the web SDK: worker-forwarded statuses (`SharedWebStreamingSyncImplementation`) and broadcast-channel statuses (`TabLocalStreamingSyncImplementation`) enter the tab through `updateSyncStatus(core, dataFlow)` and land in the same listener.
- The guard only affects the pre-first-core-status window: no code path resets a snapshot's `core` back to null after the core has reported once.

Fixes #1050

🤖 Generated with [Claude Code](https://claude.com/claude-code)