### PR TITLE
Fix a few minor concurrency issues

### DIFF
--- a/.changeset/gentle-masks-travel.md
+++ b/.changeset/gentle-masks-travel.md
@@ -1,0 +1,5 @@
+---
+'@powersync/web': patch
+---
+
+Fix timeout option having no effect with OPFS WriteAhead VFS.

--- a/.changeset/mean-rabbits-deny.md
+++ b/.changeset/mean-rabbits-deny.md
@@ -1,0 +1,5 @@
+---
+'@powersync/web': patch
+---
+
+Log error when a worker fails to load.

--- a/packages/common/src/client/CommonPowerSyncDatabase.ts
+++ b/packages/common/src/client/CommonPowerSyncDatabase.ts
@@ -343,7 +343,7 @@ export interface CommonPowerSyncDatabase extends BaseObserverInterface<PowerSync
 
   /**
    * Open a read-only transaction.
-   * Read transactions can run concurrently to a write transaction.
+   * When multiple connections are available, read transactions can run concurrently to a write transaction.
    * Changes from any write transaction are not visible to read transactions started before it.
    *
    * @param callback - Function to execute within the transaction

--- a/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -206,6 +206,7 @@ export abstract class AbstractStreamingSyncImplementation
   private async _uploadAllCrud(signal: AbortSignal, options: ResolvedSyncOptions): Promise<void> {
     return this.obtainLock({
       type: LockType.CRUD,
+      signal,
       callback: async () => {
         /**
          * Keep track of the first item in the CRUD queue for the last `uploadCrud` iteration.

--- a/packages/shared-internals/src/utils/ControlledExecutor.ts
+++ b/packages/shared-internals/src/utils/ControlledExecutor.ts
@@ -65,14 +65,17 @@ export class ControlledExecutor<T> {
 
   private async execute(param: T) {
     this.runningTask = this.task(param);
-    await this.runningTask;
-    this.runningTask = undefined;
+    try {
+      await this.runningTask;
+    } finally {
+      this.runningTask = undefined;
 
-    if (this.pendingTaskParam) {
-      const pendingParam = this.pendingTaskParam;
-      this.pendingTaskParam = undefined;
+      if (this.pendingTaskParam) {
+        const pendingParam = this.pendingTaskParam;
+        this.pendingTaskParam = undefined;
 
-      this.execute(pendingParam);
+        this.execute(pendingParam);
+      }
     }
   }
 }

--- a/packages/web/src/db/adapters/AsyncWebAdapter.ts
+++ b/packages/web/src/db/adapters/AsyncWebAdapter.ts
@@ -132,7 +132,7 @@ function readWritePoolState(writer: DatabaseClient, readers: DatabaseClient[]): 
       let timeout: any = null;
       let release: UnlockFn | undefined;
       if (options?.timeoutMs) {
-        timeout = setTimeout(() => abortController.abort(), options.timeoutMs);
+        timeout = setTimeout(() => abortController.abort('requesting database timed out'), options.timeoutMs);
       }
 
       try {

--- a/packages/web/src/db/adapters/AsyncWebAdapter.ts
+++ b/packages/web/src/db/adapters/AsyncWebAdapter.ts
@@ -132,7 +132,7 @@ function readWritePoolState(writer: DatabaseClient, readers: DatabaseClient[]): 
       let timeout: any = null;
       let release: UnlockFn | undefined;
       if (options?.timeoutMs) {
-        timeout = setTimeout(() => abortController.abort, options.timeoutMs);
+        timeout = setTimeout(() => abortController.abort(), options.timeoutMs);
       }
 
       try {

--- a/packages/web/src/db/adapters/wa-sqlite/WASQLiteOpenFactory.ts
+++ b/packages/web/src/db/adapters/wa-sqlite/WASQLiteOpenFactory.ts
@@ -89,7 +89,7 @@ export class WASQLiteOpenFactory implements SQLOpenFactory {
         let workerConnection: WorkerConnection;
         if (typeof optionsDbWorker == 'function') {
           const worker = optionsDbWorker(this.options);
-          workerConnection = connectToExistingWorker(worker, 'database');
+          workerConnection = connectToExistingWorker(worker, this.logger, 'database');
         } else {
           const needsDedicated = vfsRequiresDedicatedWorkers(vfs);
           const useShared = !needsDedicated && enableMultiTabs;
@@ -98,7 +98,8 @@ export class WASQLiteOpenFactory implements SQLOpenFactory {
             service: 'database',
             databaseIdentifier: this.options.dbFilename,
             shared: useShared,
-            customWorker: optionsDbWorker
+            customWorker: optionsDbWorker,
+            loggerForErrors: this.logger
           });
         }
 

--- a/packages/web/src/db/sync/SharedWebStreamingSyncImplementation.ts
+++ b/packages/web/src/db/sync/SharedWebStreamingSyncImplementation.ts
@@ -96,13 +96,14 @@ export class SharedWebStreamingSyncImplementation extends WebStreamingSyncImplem
 
     const syncWorker = options.sync?.worker;
     if (typeof syncWorker === 'function') {
-      this.worker = connectToExistingWorker(syncWorker(), 'sync');
+      this.worker = connectToExistingWorker(syncWorker(), options.logger, 'sync');
     } else {
       this.worker = connectToWorker({
         service: 'sync',
         databaseIdentifier: this.webOptions.identifier!,
         shared: true,
-        customWorker: syncWorker
+        customWorker: syncWorker,
+        loggerForErrors: options.logger
       });
     }
 

--- a/packages/web/src/worker/client.ts
+++ b/packages/web/src/worker/client.ts
@@ -82,7 +82,7 @@ export function connectToExistingWorker(
     logger.log({
       level: LogLevels.error,
       error: event.error,
-      message: 'Error in database or sync worker, this likely discrupts PowerSync.'
+      message: 'Error in database or sync worker, this likely disrupts PowerSync.'
     });
   }
 

--- a/packages/web/src/worker/client.ts
+++ b/packages/web/src/worker/client.ts
@@ -1,3 +1,4 @@
+import { LogLevels, PowerSyncLogger } from '@powersync/common';
 import { SharedWorkerConnectionRequest, WorkerService } from './SharedWorkerConnectionRequest.js';
 
 export interface OpenWorkerOptions {
@@ -5,6 +6,7 @@ export interface OpenWorkerOptions {
   databaseIdentifier: string;
   customWorker?: string | URL;
   shared: boolean;
+  loggerForErrors: PowerSyncLogger;
 }
 
 export interface WorkerConnection {
@@ -17,7 +19,8 @@ export function connectToWorker({
   service,
   databaseIdentifier,
   customWorker,
-  shared
+  shared,
+  loggerForErrors
 }: OpenWorkerOptions): WorkerConnection {
   const name = `${shared ? 'shared-' : ''}powersync-${databaseIdentifier}`;
   let worker: Worker | SharedWorker;
@@ -38,7 +41,7 @@ export function connectToWorker({
     worker = spawnDefaultPowerSyncWorker(shared, name);
   }
 
-  return connectToExistingWorker(worker, service);
+  return connectToExistingWorker(worker, loggerForErrors, service);
 }
 
 /**
@@ -68,7 +71,23 @@ function spawnDefaultPowerSyncWorker(shared: boolean, name: string): Worker | Sh
       });
 }
 
-export function connectToExistingWorker(worker: Worker | SharedWorker, service: WorkerService): WorkerConnection {
+export function connectToExistingWorker(
+  worker: Worker | SharedWorker,
+  logger: PowerSyncLogger,
+  service: WorkerService
+): WorkerConnection {
+  function logError(event: ErrorEvent) {
+    // TODO: Ideally, we should be able to handle worker errors by forwarding them to async Comlink callers.
+    // Currently, comlink calls on errored workers would just be stuck forever.
+    logger.log({
+      level: LogLevels.error,
+      error: event.error,
+      message: 'Error in database or sync worker, this likely discrupts PowerSync.'
+    });
+  }
+
+  (worker as AbstractWorker).addEventListener('error', logError);
+
   const isShared = isSharedWorker(worker);
   if (isShared) {
     const { port1, port2 } = new MessageChannel();
@@ -81,6 +100,7 @@ export function connectToExistingWorker(worker: Worker | SharedWorker, service: 
       endpoint: port2,
       worker,
       close() {
+        worker.removeEventListener('error', logError);
         port2.close();
       }
     };
@@ -89,6 +109,7 @@ export function connectToExistingWorker(worker: Worker | SharedWorker, service: 
       endpoint: worker as Worker,
       worker,
       close() {
+        worker.removeEventListener('error', logError);
         worker.terminate();
       }
     };

--- a/packages/web/src/worker/sync/SharedSyncImplementation.ts
+++ b/packages/web/src/worker/sync/SharedSyncImplementation.ts
@@ -123,6 +123,8 @@ export class SharedSyncImplementation extends BaseObserver<SharedSyncImplementat
   logger: BroadcastLogger;
   protected readonly database = this.generateReconnectableDatabase();
 
+  private sharedCloseSignal = generateTabCloseSignal();
+
   constructor() {
     super();
     this.ports = [];
@@ -517,7 +519,7 @@ export class SharedSyncImplementation extends BaseObserver<SharedSyncImplementat
     const remote = Comlink.wrap<OpenWorkerConnection>(workerPort);
     const identifier = this.syncParams!.dbParams.dbFilename;
 
-    const clientLockName = await generateTabCloseSignal();
+    const clientLockName = await this.sharedCloseSignal;
 
     /**
      * The open could fail if the tab is closed while we're busy opening the database.

--- a/packages/web/tests/main.test.ts
+++ b/packages/web/tests/main.test.ts
@@ -116,8 +116,6 @@ it('should log worker errors', async () => {
   db.init();
 
   await vi.waitFor(() => {
-    console.log(logs);
-
     expect(logs).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/packages/web/tests/main.test.ts
+++ b/packages/web/tests/main.test.ts
@@ -1,6 +1,6 @@
-import { PowerSyncDatabase, WASQLiteOpenFactory, WASQLiteVFS } from '@powersync/web';
+import { LogRecord, PowerSyncDatabase, WASQLiteOpenFactory, WASQLiteVFS } from '@powersync/web';
 import { v4 as uuid } from 'uuid';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { TEST_SCHEMA, TestDatabase } from './utils/test-schema.js';
 import { generateTestDb } from './utils/testDb.js';
 import { defaultLogLevel, defaultTestLogger } from './utils/logger.js';
@@ -96,6 +96,38 @@ describe('Basic - with in-memory', () => {
   );
 });
 
+it('should log worker errors', async () => {
+  const logs: LogRecord[] = [];
+
+  const db = new PowerSyncDatabase({
+    schema: TEST_SCHEMA,
+    logger: {
+      log(record) {
+        logs.push(record);
+      }
+    },
+    database: {
+      worker: '/does_not_exist.js',
+      dbFilename: 'test.db'
+    }
+  });
+
+  // This will never resolve due to the broken worker.
+  db.init();
+
+  await vi.waitFor(() => {
+    console.log(logs);
+
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          message: 'Error in database or sync worker, this likely disrupts PowerSync.'
+        })
+      ])
+    );
+  });
+});
+
 function describeBasicTests(generateDB: () => PowerSyncDatabase) {
   return () => {
     it('should execute a select query using getAll', async () => {
@@ -146,6 +178,15 @@ function describeBasicTests(generateDB: () => PowerSyncDatabase) {
         return await tx.getAll<{ name: string }>('SELECT name FROM customers');
       });
       expect(names).deep.equal([{ name: 'name' }]);
+    });
+
+    it('can abort', async () => {
+      const db = generateDB();
+
+      await db.writeLock(async () => {
+        // Acquiring a second write lock with a timeout should throw.
+        await expect(db.writeTransaction(async () => {}, 100)).rejects.toThrow('timed out');
+      });
     });
   };
 }

--- a/packages/web/tests/src/db/write_ahead_log_opfs.test.ts
+++ b/packages/web/tests/src/db/write_ahead_log_opfs.test.ts
@@ -34,6 +34,12 @@ test('supports concurrent reads', async () => {
       await Promise.all([ctx1.execute('SELECT 1'), ctx2.execute('SELECT 2')]);
     });
   });
+
+  // We can't use concurrent write transactions, but we should be able to abort.
+  await db.writeLock(async () => {
+    // Acquiring a second write lock with a timeout should throw.
+    await expect(db.writeTransaction(async () => {}, 100)).rejects.toThrow('timed out');
+  });
 });
 
 test('can update schema', async () => {


### PR DESCRIPTION
This fixes a few minor issues:

1. We document that read transactions can run concurrently to a write transaction, which is technically only true when an actual connection pool is used (not guaranteed on the web).
2. Obtaining the crud lock in the sync client does not pass an abort signal.
3. If the callback to `ControlledExecutor` throws, it is permanently stuck. It's not the responsibility of that class to catch errors (they're asynchronous and should be reported as unhandled promise rejections), but it shouldn't become stuck.
4. Due to a typo, database lock timeouts didn't work with the OPFS WriteAhead VFS.
5. If loading a database or sync worker failed, it would fail silently (apart from an error in the console) and the only observable behavior is that our comlink calls to it are permanently stuck. This registers an `error` event handler to at least log this case, which allows users to forward that to their custom log sinks. That's still far from great, we should also be able to apply this error to pending calls. Comlink doesn't exactly make that easy though, so that would require more changes.
6. The shared sync worker acquires a new random lock per connected client that can trivially be shared instead.

AI use: These issues were found with an AI scan by a customer, fixes are manual, reviewed with Claude Code to complete the circle.