### PR TITLE
Web: Support longer `dbFilename` values

### DIFF
--- a/.changeset/ten-avocados-watch.md
+++ b/.changeset/ten-avocados-watch.md
@@ -1,0 +1,5 @@
+---
+'@powersync/web': patch
+---
+
+Increase maximum `dbFilename` length to 112 and improve errors (closes https://github.com/powersync-ja/powersync-js/issues/1052).

--- a/packages/web/src/db/adapters/resolveAndValidateOptions.ts
+++ b/packages/web/src/db/adapters/resolveAndValidateOptions.ts
@@ -3,6 +3,15 @@ import { TemporaryStorageOption, WebSpecificOpenOptions } from './options.js';
 import { vfsRequiresDedicatedWorkers, WASQLiteVFS } from './wa-sqlite/vfs.js';
 
 /**
+ * The maximum length of a db filename we support.
+ *
+ * We configure the same on WA-SQLite (which otherwise defaults to a maximum length of 64). We don't want to support
+ * very long path names as Safari maps OPFS files directly to OS files, and APFS has a 255-byte filename limit. Since
+ * some VFS append additional characters for pooled file access handles, we want to stay well below that.
+ */
+export const maxPathNameLength = 128;
+
+/**
  * @internal
  */
 export function resolveAndValidateOptions<And = {}>(

--- a/packages/web/src/db/adapters/wa-sqlite/RawSqliteConnection.ts
+++ b/packages/web/src/db/adapters/wa-sqlite/RawSqliteConnection.ts
@@ -3,6 +3,7 @@ import { Factory as WaSqliteFactory, SQLITE_ROW } from '@journeyapps/wa-sqlite';
 import { loadModuleAndVfs, WASQLiteVFS } from './vfs.js';
 import { TemporaryStorageOption } from '../options.js';
 import { RawQueryResult, SqliteValue } from '@powersync/common';
+import { maxPathNameLength } from '../resolveAndValidateOptions.js';
 
 export interface RawWebResult extends Required<RawQueryResult> {
   autocommit: boolean;
@@ -62,6 +63,7 @@ export class RawSqliteConnection {
 
   private async openSQLiteAPI(): Promise<SQLiteAPI> {
     const { module, vfs } = await loadModuleAndVfs(this.options);
+    vfs.mxPathname = maxPathNameLength;
     const sqlite3 = WaSqliteFactory(module);
     sqlite3.vfs_register(vfs, true);
     /**

--- a/packages/web/src/db/adapters/wa-sqlite/WASQLiteOpenFactory.ts
+++ b/packages/web/src/db/adapters/wa-sqlite/WASQLiteOpenFactory.ts
@@ -8,7 +8,7 @@ import { DatabaseClient, OpenWorkerConnection } from './DatabaseClient.js';
 import { generateTabCloseSignal } from '../../../shared/tab_close_signal.js';
 import { AsyncDbAdapter, PoolConnection } from '../AsyncWebAdapter.js';
 import { RawWaSqliteDatabaseOptions } from './RawSqliteConnection.js';
-import { resolveAndValidateOptions } from '../resolveAndValidateOptions.js';
+import { maxPathNameLength, resolveAndValidateOptions } from '../resolveAndValidateOptions.js';
 import { connectToExistingWorker, connectToWorker, WorkerConnection } from '../../../worker/client.js';
 
 export interface WASQLiteOpenFactoryOptions {
@@ -25,6 +25,13 @@ export class WASQLiteOpenFactory implements SQLOpenFactory {
 
   constructor(options: WASQLiteOpenFactoryOptions) {
     this.options = resolveAndValidateOptions(options.open);
+
+    // Account for the fact that SQLite might append -journal suffixes
+    const maxLength = maxPathNameLength - 16;
+    if (this.options.dbFilename.length > maxLength) {
+      throw new Error(`dbFilename too long (max length is ${maxLength})`);
+    }
+
     this.logger = options.logger;
   }
 

--- a/packages/web/tests/main.test.ts
+++ b/packages/web/tests/main.test.ts
@@ -126,6 +126,45 @@ it('should log worker errors', async () => {
   });
 });
 
+describe('can use long path names', () => {
+  const testedVfs = [
+    WASQLiteVFS.IDBBatchAtomicVFS,
+    WASQLiteVFS.AccessHandlePoolVFS,
+    WASQLiteVFS.OPFSCoopSyncVFS,
+    WASQLiteVFS.OPFSWriteAheadVFS,
+    WASQLiteVFS.InMemoryVfs
+  ];
+
+  for (const vfs of testedVfs) {
+    describe(vfs, () => {
+      it('should be able to use database names exceeding 64 characters', async () => {
+        const db = generateTestDb({
+          schema: TEST_SCHEMA,
+          logger: defaultTestLogger,
+          database: {
+            dbFilename: vfs + 'a'.repeat(70),
+            vfs
+          }
+        });
+        await db.init();
+      });
+
+      it('throws when opening database with path exceeding 112 characters', async () => {
+        expect(() => {
+          new PowerSyncDatabase({
+            schema: TEST_SCHEMA,
+            logger: defaultTestLogger,
+            database: {
+              dbFilename: vfs + 'a'.repeat(112),
+              vfs
+            }
+          });
+        }).toThrow('dbFilename too long (max length is 112)');
+      });
+    });
+  }
+});
+
 function describeBasicTests(generateDB: () => PowerSyncDatabase) {
   return () => {
     it('should execute a select query using getAll', async () => {


### PR DESCRIPTION
By default, wa-sqlite uses path buffers with a [maximum length of 64](https://github.com/rhashimoto/wa-sqlite/blob/fb1bdf4e5ae1c7d9c01ae79eda320cb942d54aa7/src/VFS.js#L10). This controls the amount of bytes SQLite allocates for path buffers, there's no fundamental limit not allowing longer path names.

This increases the path buffer length to 128, and reports better errors when that limit is exceeded.

Reported in https://github.com/powersync-ja/powersync-js/issues/1052.