### PR TITLE
[Fix] `@powersync/shared-internals` should have `@powersync/common` as peer dependency

### DIFF
--- a/.changeset/warm-maps-carry.md
+++ b/.changeset/warm-maps-carry.md
@@ -1,0 +1,6 @@
+---
+'@powersync/shared-internals': patch
+---
+
+Declare `@powersync/common` as a peer dependency so the main entry point resolves it under strict `node_modules` layouts.
+

--- a/packages/shared-internals/package.json
+++ b/packages/shared-internals/package.json
@@ -45,8 +45,10 @@
     "test:exports": "attw --pack . --profile node16 --exclude-entrypoints internal/sync_protocol --ignore-rules cjs-resolves-to-esm",
     "postversion": "node tool/update_version.js"
   },
+  "peerDependencies": {
+    "@powersync/common": "workspace:*"
+  },
   "devDependencies": {
-    "@powersync/common": "workspace:*",
     "@rollup/plugin-commonjs": "catalog:",
     "@rollup/plugin-inject": "catalog:",
     "@rollup/plugin-json": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -651,10 +651,11 @@ importers:
         version: 0.85.3(@babel/core@7.29.7)(@react-native-community/cli@20.2.0(typescript@6.0.3))(@types/react@19.2.14)(react@19.2.4)
 
   packages/shared-internals:
-    devDependencies:
+    dependencies:
       '@powersync/common':
         specifier: workspace:*
         version: link:../common
+    devDependencies:
       '@rollup/plugin-commonjs':
         specifier: 'catalog:'
         version: 29.0.2(rollup@4.59.0)


### PR DESCRIPTION
## Problem

While upgrading to V2 in another repo, we ran into the following:
```
Rollup failed to resolve import "@powersync/common" from 
.../@powersync/shared-internals/lib/client/BasePowerSyncDatabase.js 
```

Which required the following entry to be added in `pnpm-workspace.yaml`

```yaml
packageExtensions:
  '@powersync/shared-internals':
    peerDependencies:
      '@powersync/common': '^2.0.0'
```

## Solution

Declare `@powersync/common` as a peer dependency so the main entry point resolves it under strict `node_modules` layouts.
