### PR TITLE
Use core extension update hooks for op-sqlite

### DIFF
--- a/.changeset/silver-fishes-fold.md
+++ b/.changeset/silver-fishes-fold.md
@@ -1,0 +1,5 @@
+---
+'@powersync/react-native': minor
+---
+
+For consistency with other platforms and better performance, use update hooks from the PowerSync SQLite core extension instead of registering them as JavaScript callbacks.

--- a/packages/react-native/src/db/adapters/op-sqlite/OPSQLiteConnection.ts
+++ b/packages/react-native/src/db/adapters/op-sqlite/OPSQLiteConnection.ts
@@ -1,4 +1,4 @@
-import { DB, SQLBatchTuple, UpdateHookOperation } from '@op-engineering/op-sqlite';
+import { DB, SQLBatchTuple } from '@op-engineering/op-sqlite';
 import {
   LockContext,
   QueryResult,
@@ -10,13 +10,6 @@ import {
 
 export type OPSQLiteConnectionOptions = {
   baseDB: DB;
-};
-
-export type OPSQLiteUpdateNotification = {
-  table: string;
-  operation: UpdateHookOperation;
-  row?: any;
-  rowId: number;
 };
 
 export class OPSQLiteConnection extends LockContext {

--- a/packages/react-native/src/db/adapters/op-sqlite/OPSQLiteConnection.ts
+++ b/packages/react-native/src/db/adapters/op-sqlite/OPSQLiteConnection.ts
@@ -1,7 +1,5 @@
 import { DB, SQLBatchTuple, UpdateHookOperation } from '@op-engineering/op-sqlite';
 import {
-  BaseObserver,
-  BatchedUpdateNotification,
   LockContext,
   QueryResult,
   queryResultFromMapped,
@@ -23,38 +21,10 @@ export type OPSQLiteUpdateNotification = {
 
 export class OPSQLiteConnection extends LockContext {
   protected DB: DB;
-  private updateBuffer: Set<string>;
-  readonly tableUpdateDispatcher = new BaseObserver();
 
   constructor(protected options: OPSQLiteConnectionOptions) {
     super();
     this.DB = options.baseDB;
-    this.updateBuffer = new Set();
-
-    this.DB.rollbackHook(() => {
-      this.updateBuffer = new Set();
-    });
-
-    this.DB.updateHook((update) => {
-      this.addTableUpdate(update);
-    });
-  }
-
-  addTableUpdate(update: OPSQLiteUpdateNotification) {
-    this.updateBuffer.add(update.table);
-  }
-
-  flushUpdates() {
-    if (!this.updateBuffer.size) {
-      return;
-    }
-
-    const batchedUpdate: BatchedUpdateNotification = {
-      tables: Array.from(this.updateBuffer)
-    };
-
-    this.updateBuffer = new Set();
-    this.tableUpdateDispatcher.iterateListeners((l) => l.tablesUpdated?.(batchedUpdate));
   }
 
   close() {

--- a/packages/react-native/src/db/adapters/op-sqlite/OPSqliteAdapter.ts
+++ b/packages/react-native/src/db/adapters/op-sqlite/OPSqliteAdapter.ts
@@ -1,6 +1,6 @@
 import { NativeModules } from 'react-native';
 import { getDylibPath, open, type DB } from '@op-engineering/op-sqlite';
-import { DBAdapter, DBLockOptions, QueryResult } from '@powersync/common';
+import { BatchedUpdateNotification, DBAdapter, DBLockOptions, QueryResult } from '@powersync/common';
 import { timeoutSignal, Semaphore } from '@powersync/shared-internals';
 import { Platform } from 'react-native';
 import { OPSQLiteConnection } from './OPSQLiteConnection';
@@ -54,7 +54,9 @@ export class OPSQLiteDBAdapter extends DBAdapter {
       ...baseStatements,
       `PRAGMA journal_mode = ${journalMode}`,
       `PRAGMA journal_size_limit = ${journalSizeLimit}`,
-      `PRAGMA synchronous = ${synchronous}`
+      `PRAGMA synchronous = ${synchronous}`,
+      // Changes should only occur in the write connection
+      `SELECT powersync_update_hooks('install')`
     ];
 
     for (const statement of writeConnectionStatements) {
@@ -71,11 +73,6 @@ export class OPSQLiteDBAdapter extends DBAdapter {
         }
       }
     }
-
-    // Changes should only occur in the write connection
-    underlyingWriteConnection.tableUpdateDispatcher.registerListener({
-      tablesUpdated: (notification) => this.iterateListeners((cb) => cb.tablesUpdated?.(notification))
-    });
 
     const underlyingReadConnections = [];
     for (let i = 0; i < READ_CONNECTIONS; i++) {
@@ -212,7 +209,19 @@ export class OPSQLiteDBAdapter extends DBAdapter {
     const { signal, cleanUpInnerSignal } = this.generateNestedAbortSignal(options);
     const { item, release } = await this.writeConnection!.requestOne(signal);
     try {
-      return await fn(item).finally(() => item.flushUpdates());
+      const result = await fn(item);
+
+      // Fetc committed table updates
+      const {
+        rawRows: [[jsonUpdate]]
+      } = await item.executeRaw("SELECT powersync_update_hooks('get')");
+
+      const notification: BatchedUpdateNotification = {
+        tables: JSON.parse(jsonUpdate as string)
+      };
+      this.iterateListeners((l) => l.tablesUpdated?.(notification));
+
+      return result;
     } finally {
       release();
       cleanUpInnerSignal?.();

--- a/packages/react-native/src/db/adapters/op-sqlite/OPSqliteAdapter.ts
+++ b/packages/react-native/src/db/adapters/op-sqlite/OPSqliteAdapter.ts
@@ -209,9 +209,9 @@ export class OPSQLiteDBAdapter extends DBAdapter {
     const { signal, cleanUpInnerSignal } = this.generateNestedAbortSignal(options);
     const { item, release } = await this.writeConnection!.requestOne(signal);
     try {
-      const result = await fn(item);
-
-      // Fetc committed table updates
+      return await fn(item);
+    } finally {
+      // Fetch committed table updates
       const {
         rawRows: [[jsonUpdate]]
       } = await item.executeRaw("SELECT powersync_update_hooks('get')");
@@ -219,10 +219,10 @@ export class OPSQLiteDBAdapter extends DBAdapter {
       const notification: BatchedUpdateNotification = {
         tables: JSON.parse(jsonUpdate as string)
       };
-      this.iterateListeners((l) => l.tablesUpdated?.(notification));
+      if (notification.tables.length) {
+        this.iterateListeners((l) => l.tablesUpdated?.(notification));
+      }
 
-      return result;
-    } finally {
       release();
       cleanUpInnerSignal?.();
     }

--- a/tools/powersynctests/src/tests/queries.test.ts
+++ b/tools/powersynctests/src/tests/queries.test.ts
@@ -227,6 +227,12 @@ export function registerBaseTests() {
 
     it('Transaction, manual rollback', async () => {
       const { name, age, networth } = generateUserInfo();
+      let didNotify = false;
+      const l = db.database.registerListener({
+        tablesUpdated() {
+          didNotify=true;
+        }
+      });
 
       await db.writeTransaction(async (tx) => {
         await tx.execute('INSERT INTO "users" (id, name, age, networth) VALUES(uuid(), ?, ?, ?)', [
@@ -239,6 +245,34 @@ export function registerBaseTests() {
 
       const res = await db.execute('SELECT * FROM users');
       expect(res.rows?._array).to.eql([]);
+      expect(!didNotify);
+      l();
+    });
+
+    it('Manual transaction', async () => {
+      const { name, age, networth } = generateUserInfo();
+      let didNotify = false;
+      const l = db.database.registerListener({
+        tablesUpdated() {
+          didNotify=true;
+        }
+      });
+
+      await db.writeLock(async (lock) => {
+        await lock.execute('INSERT INTO "users" (id, name, age, networth) VALUES(uuid(), ?, ?, ?)', [
+          name,
+          age,
+          networth
+        ]);
+        await lock.execute('BEGIN');
+        await lock.execute('DELETE FROM users');
+        await lock.execute('ROLLBACK');
+      });
+
+      expect(didNotify);
+      const res = await db.execute('SELECT * FROM users');
+      expect(res.rows?.length).to.eql(1);
+      l();
     });
 
     /**

--- a/tools/powersynctests/src/tests/queries.test.ts
+++ b/tools/powersynctests/src/tests/queries.test.ts
@@ -245,7 +245,7 @@ export function registerBaseTests() {
 
       const res = await db.execute('SELECT * FROM users');
       expect(res.rows?._array).to.eql([]);
-      expect(!didNotify);
+      expect(didNotify).to.be.false;
       l();
     });
 
@@ -269,7 +269,7 @@ export function registerBaseTests() {
         await lock.execute('ROLLBACK');
       });
 
-      expect(didNotify);
+      expect(didNotify).to.be.true;
       const res = await db.execute('SELECT * FROM users');
       expect(res.rows?.length).to.eql(1);
       l();


### PR DESCRIPTION
In the React Native package, we use update hooks available directly from `op-sqlite` to track changed tables. This PR replaces that with a call to `powersync_update_hooks` from the core extension. This has two main benefits:

1. Update hooks are called for every write, and there's overhead of calling back into JavaScript. For a large initial sync, not calling our JavaScript update hook millions of times is an improvement. The update hook in the core extension is written in Rust and only collects table names forwarded to JavaScript at the end of a `writeLock` scope.
2. We use these update hooks in almost every other JavaScript package (Node, Capacitor, Web, sql.js) and most of our other SDKs. They're well tested, and this makes React Native consistent with them.

A minor fixed correctness issue is that the old method of tracking update hooks clears tables on rollbacks, which means that if a `writeLock` block contains multiple transactions where only the last one is rolled back, all updates would be lost. The core extension does not have this issue, I've added a regression test for that specifically.

It is worth noting that only a single update/rollback/commit hook can be installed on a SQLite database, and those are now taken up by the core extension. If `op-sqlite` tried to install its own hooks in this state, stuff would go wrong! I have checked `op-sqlite` code, it only registers hooks if we call the respective JavaScript method or use op-sqlite reactive queries. We don't use either.

AI use: Changes are manual, I used Claude Code to review them and fixed minor issues it flagged.