### PR TITLE
fix(react): don't call useRef conditionally in checkQueryChanged

### DIFF
--- a/.changeset/tricky-pumas-marry.md
+++ b/.changeset/tricky-pumas-marry.md
@@ -1,0 +1,5 @@
+---
+'@powersync/react': patch
+---
+
+Fixed a crash in `useQuery` when a query throws while being compiled on some renders but not others. The internal `checkQueryChanged` helper declared a `useRef` after an early return, so the hook was called conditionally. The query is now also re-applied once it compiles again after a failed compilation.

--- a/packages/react/src/hooks/watched/watch-utils.ts
+++ b/packages/react/src/hooks/watched/watch-utils.ts
@@ -14,30 +14,51 @@ interface WatchCompatibleQueryWithParams<T> extends WatchCompatibleQuery<T> {
   stringifiedParameters?: string;
 }
 
+interface ObservedQueryState {
+  sqlStatement: string;
+  stringifiedParams: string;
+  stringifiedOptions: string;
+}
+
 export const checkQueryChanged = <T>(query: WatchCompatibleQueryWithParams<T>, options: AdditionalOptions) => {
-  let _compiled: CompiledQuery;
+  /**
+   * The query state which was observed during the previous render.
+   *  - `undefined` indicates the initial render, no query has been observed yet.
+   *  - `null` indicates that the previous render could not compile the query.
+   *
+   * This ref is declared before compiling the query. Compilation can throw, and a hook may never
+   * be declared after a conditional return - doing so changes the order of hooks between renders,
+   * which crashes the component.
+   */
+  const previousQueryRef = React.useRef<ObservedQueryState | null | undefined>(undefined);
+  const isInitialRender = previousQueryRef.current === undefined;
+
+  let compiled: CompiledQuery;
   try {
-    _compiled = query.compile();
+    compiled = query.compile();
   } catch (error) {
-    return false; // If compilation fails, we assume the query has changed
+    // If compilation fails we can't compare anything. Record the failure so that a subsequent
+    // successful compilation is reported as a change: consumers are still using the query which
+    // could not be compiled.
+    previousQueryRef.current = null;
+    return false;
   }
-  const compiled = _compiled!;
 
   const stringifiedParams = query.stringifiedParameters ?? JSON.stringify(compiled.parameters);
   const stringifiedOptions = JSON.stringify(options);
 
-  const previousQueryRef = React.useRef({ sqlStatement: compiled.sql, stringifiedParams, stringifiedOptions });
+  const previousQuery = previousQueryRef.current;
 
   if (
-    previousQueryRef.current.sqlStatement !== compiled.sql ||
-    previousQueryRef.current.stringifiedParams != stringifiedParams ||
-    previousQueryRef.current.stringifiedOptions != stringifiedOptions
+    previousQuery == null ||
+    previousQuery.sqlStatement !== compiled.sql ||
+    previousQuery.stringifiedParams != stringifiedParams ||
+    previousQuery.stringifiedOptions != stringifiedOptions
   ) {
-    previousQueryRef.current.sqlStatement = compiled.sql;
-    previousQueryRef.current.stringifiedParams = stringifiedParams;
-    previousQueryRef.current.stringifiedOptions = stringifiedOptions;
+    previousQueryRef.current = { sqlStatement: compiled.sql, stringifiedParams, stringifiedOptions };
 
-    return true;
+    // The initial render is never a change: the query has not been used anywhere yet.
+    return !isInitialRender;
   }
 
   return false;

--- a/packages/react/tests/useQuery.test.tsx
+++ b/packages/react/tests/useQuery.test.tsx
@@ -647,6 +647,47 @@ describe('useQuery', () => {
         );
       });
 
+      it('should recover when a query compiles successfully after a failed compilation', async () => {
+        const db = openPowerSync();
+
+        // Emulates a conditionally constructed query, e.g. a Drizzle projection built from
+        // optional fields, which throws while being compiled on some renders but not others.
+        let compilationFails = true;
+        const query: commonSdk.CompilableQuery<{ a: string }> = {
+          execute: () => db.getAll<{ a: string }>('SELECT ? AS a', ['foo']),
+          compile: () => {
+            if (compilationFails) {
+              throw new Error('error');
+            }
+            return { sql: 'SELECT ? AS a', parameters: ['foo'] };
+          }
+        };
+
+        const { result, rerender } = renderHook(() => useQuery(query), {
+          wrapper: ({ children }) => testWrapper({ children, db })
+        });
+
+        await waitFor(
+          async () => {
+            expect(result.current.error).toEqual(Error('error'));
+          },
+          { timeout: 500, interval: 100 }
+        );
+
+        // The query now compiles. Rendering must not break the order of hooks.
+        compilationFails = false;
+        expect(() => rerender()).not.toThrow();
+
+        await waitFor(
+          async () => {
+            const currentResult = result.current;
+            expect(currentResult.error).toBeFalsy();
+            expect(currentResult.data).toEqual([{ a: 'foo' }]);
+          },
+          { timeout: 500, interval: 100 }
+        );
+      });
+
       it('should use an existing WatchedQuery instance', async () => {
         const db = openPowerSync();
 

--- a/packages/react/tests/watchUtils.test.tsx
+++ b/packages/react/tests/watchUtils.test.tsx
@@ -1,0 +1,134 @@
+import { CompiledQuery, WatchCompatibleQuery } from '@powersync/common';
+import { cleanup, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { AdditionalOptions } from '../src/hooks/watched/watch-types';
+import { checkQueryChanged } from '../src/hooks/watched/watch-utils';
+
+describe('checkQueryChanged', () => {
+  beforeEach(() => {
+    cleanup();
+  });
+
+  /**
+   * A query which compiles to whatever `compile` currently returns, or throws if it is set to
+   * a function which throws.
+   */
+  const createQuery = (compile: () => CompiledQuery): WatchCompatibleQuery<any> & { compile: () => CompiledQuery } => ({
+    compile,
+    execute: async () => []
+  });
+
+  const options: AdditionalOptions = {};
+
+  it('should not report a change for the initial render', () => {
+    const query = createQuery(() => ({ sql: 'SELECT 1', parameters: [] }));
+    const { result } = renderHook(() => checkQueryChanged(query, options));
+    expect(result.current).toEqual(false);
+  });
+
+  it('should not report a change while the compiled query stays the same', () => {
+    const query = createQuery(() => ({ sql: 'SELECT ?', parameters: ['a'] }));
+    const { result, rerender } = renderHook(() => checkQueryChanged(query, options));
+    expect(result.current).toEqual(false);
+
+    rerender();
+    expect(result.current).toEqual(false);
+
+    rerender();
+    expect(result.current).toEqual(false);
+  });
+
+  it('should report a change when the SQL statement changes', () => {
+    let sql = 'SELECT 1';
+    const query = createQuery(() => ({ sql, parameters: [] }));
+    const { result, rerender } = renderHook(() => checkQueryChanged(query, options));
+    expect(result.current).toEqual(false);
+
+    sql = 'SELECT 2';
+    rerender();
+    expect(result.current).toEqual(true);
+
+    // The statement is unchanged again
+    rerender();
+    expect(result.current).toEqual(false);
+  });
+
+  it('should report a change when the parameters change', () => {
+    let parameters: any[] = ['a'];
+    const query = createQuery(() => ({ sql: 'SELECT ?', parameters }));
+    const { result, rerender } = renderHook(() => checkQueryChanged(query, options));
+    expect(result.current).toEqual(false);
+
+    parameters = ['b'];
+    rerender();
+    expect(result.current).toEqual(true);
+
+    rerender();
+    expect(result.current).toEqual(false);
+  });
+
+  it('should report a change when the options change', () => {
+    const query = createQuery(() => ({ sql: 'SELECT 1', parameters: [] }));
+    let currentOptions: AdditionalOptions = { throttleMs: 10 };
+    const { result, rerender } = renderHook(() => checkQueryChanged(query, currentOptions));
+    expect(result.current).toEqual(false);
+
+    currentOptions = { throttleMs: 20 };
+    rerender();
+    expect(result.current).toEqual(true);
+
+    rerender();
+    expect(result.current).toEqual(false);
+  });
+
+  it('should not report a change while the query cannot be compiled', () => {
+    const query = createQuery(() => {
+      throw new Error('could not compile');
+    });
+    const { result, rerender } = renderHook(() => checkQueryChanged(query, options));
+    expect(result.current).toEqual(false);
+
+    expect(() => rerender()).not.toThrow();
+    expect(result.current).toEqual(false);
+  });
+
+  it('should report a change once the query compiles after a failed compilation', () => {
+    let compilationFails = true;
+    const query = createQuery(() => {
+      if (compilationFails) {
+        throw new Error('could not compile');
+      }
+      return { sql: 'SELECT 1', parameters: [] };
+    });
+
+    const { result, rerender } = renderHook(() => checkQueryChanged(query, options));
+    expect(result.current).toEqual(false);
+
+    // The hook order must be stable, even though the first render bailed out early.
+    compilationFails = false;
+    expect(() => rerender()).not.toThrow();
+    // The consumers of this hook still hold the query which could not be compiled, they need to
+    // be notified that a usable query is available now.
+    expect(result.current).toEqual(true);
+
+    rerender();
+    expect(result.current).toEqual(false);
+  });
+
+  it('should not throw when a previously compiling query starts failing', () => {
+    let compilationFails = false;
+    const query = createQuery(() => {
+      if (compilationFails) {
+        throw new Error('could not compile');
+      }
+      return { sql: 'SELECT 1', parameters: [] };
+    });
+
+    const { result, rerender } = renderHook(() => checkQueryChanged(query, options));
+    expect(result.current).toEqual(false);
+
+    compilationFails = true;
+    expect(() => rerender()).not.toThrow();
+    expect(result.current).toEqual(false);
+  });
+});


### PR DESCRIPTION
### Summary

`useQuery` hard-crashes when the query it is given throws while being compiled on one render but not on the next.

[`checkQueryChanged`](https://github.com/powersync-ja/powersync-js/blob/87c1e5b/packages/react/src/hooks/watched/watch-utils.ts#L17-L44) declares `React.useRef` on line 29, *after* the early `return false` on line 22:

```ts
export const checkQueryChanged = <T>(query, options) => {
  let _compiled: CompiledQuery;
  try {
    _compiled = query.compile();
  } catch (error) {
    return false;             // <- early return
  }
  ...
  const previousQueryRef = React.useRef({ ... });   // <- hook after the early return
```

The hook is therefore called conditionally, which breaks the rules of hooks. `checkQueryChanged` runs on every `useQuery`, `useSuspenseQuery` and `useSingleSuspenseQuery` render through `constructCompatibleQuery`, so the whole component tears down:

```
Warning: React has detected a change in the order of Hooks called by TestComponent.

   Previous render            Next render
   ------------------------------------------------------
1. useContext                 useContext
2. useContext                 useContext
3. useMemo                    useMemo
4. useMemo                    useMemo
5. useContext                 useRef
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

[Error: Uncaught TypeError: Cannot read properties of undefined (reading 'sqlStatement')]

The above error occurred in the <TestComponent> component:
Consider adding an error boundary to your tree to customize error handling behavior.
```

React reuses the value of the hook that previously occupied that slot, so `previousQueryRef.current` is `undefined` and the very next line throws.

It breaks in both directions. When a query that used to compile starts failing, the render is one hook short instead:

```
Error: Rendered fewer hooks than expected. This may be caused by an accidental early return statement.
```

### How this is reached

`compile()` throwing is supported behaviour, not misuse: the suite already covers it in [`should show an error if parsing the query results in an error`](https://github.com/powersync-ja/powersync-js/blob/87c1e5b/packages/react/tests/useQuery.test.tsx#L624). That test survives only because its `compile()` throws on *every* render, so the hook count stays consistent. The crash needs the outcome to change between renders.

The realistic trigger is a conditionally built projection. With `drizzle-orm@0.44.7` (the version this repo pins) and `toCompilableQuery`:

```js
db.select({ id: lists.id, name: undefined }).from(lists).toSQL()
// TypeError: Cannot convert undefined or null to object
```

so a component that builds its projection from optional props/state — `select({ id: lists.id, name: showName ? lists.name : undefined })` — compiles on some renders and throws on others, and toggling `showName` crashes the tree. I checked the other shapes I expected to throw (`inArray(col, [])`, `eq(col, undefined)`, `limit(NaN)`) and they all compile fine, so the trigger is genuinely narrow — but the failure mode when it is hit is an unrecoverable crash rather than the error state the hook is designed to report.

This survived because `react-hooks/rules-of-hooks` never ran here. The root `package.json` has `"lint": "eslint ."`, but there is no eslint config and no eslint (or `eslint-plugin-react-hooks`) dependency at the root, so `pnpm lint` cannot run.

### The fix

Declare the ref before compiling, and let it hold three states:

* `undefined` — initial render, nothing observed yet
* `null` — the previous render could not compile the query
* the observed sql/params/options otherwise

Behaviour for a query that always compiles is unchanged: the initial render still reports "not changed" (previously achieved by seeding the ref with the current values), and later renders still report a change only when the SQL, the parameters or the options differ.

One behaviour is deliberately new. When a compilation failure is followed by a successful one, `checkQueryChanged` now returns `true`. Simply hoisting the ref and treating the first successful compile as "not changed" stops the crash but leaves the hook broken in a quieter way: the `WatchedQuery` was created with the query that could not be compiled, `useWatchedQuery` only propagates a new query through `updateSettings` when `queryChanged` is true, so the hook would stay stuck on `error` forever. I verified that — with the hoist-only variant, the added `useQuery` test fails with `expected Error: error to be falsy`. Recording the failed compilation is what lets consumers pick the query up again.

`queryChanged` has three consumers and the change is consistent with all of them:
* `useWatchedQuery` — `true` calls `watchedQuery.updateSettings({ query, ... })` inline
* `useSingleQuery` — `queryChanged` sits in the `useCallback`/`useEffect` deps, so flipping it re-runs the query
* `useSuspenseQuery` / `useSingleSuspenseQuery` — ignore the value, but still go through `constructCompatibleQuery` and so were exposed to the same crash

### Tests

`packages/react/tests/useQuery.test.tsx` — a `useQuery` test next to the existing "parsing the query results in an error" one, asserting that a query which starts compiling after a failed compilation neither crashes nor stays in the error state. It runs in both the normal and `StrictMode` variants of the existing matrix.

`packages/react/tests/watchUtils.test.tsx` — unit tests for `checkQueryChanged` covering both crash directions plus the unchanged semantics (initial render, unchanged query, changed SQL, changed parameters, changed options, permanently failing compilation). The six semantics tests pass before and after the change, which is what pins the existing behaviour down.

Before: `82 passed | 2 skipped (84)`.
After: `92 passed | 2 skipped (94)`.

With the change to `watch-utils.ts` reverted and the new tests kept, 4 of them fail with the `TypeError` / `Rendered fewer hooks than expected` above, and the 6 semantics tests still pass.

`common`, `drizzle-driver`, `kysely-driver`, `tanstack-react-query`, `vue` and `web` are green.
