### PR TITLE
Implement new protocol for checkpoint requests

### DIFF
--- a/.changeset/ninety-nails-raise.md
+++ b/.changeset/ninety-nails-raise.md
@@ -1,0 +1,11 @@
+---
+'@powersync/shared-internals': minor
+'@powersync/react-native': minor
+'@powersync/capacitor': minor
+'@powersync/common': minor
+'@powersync/node': minor
+'@powersync/nuxt': minor
+'@powersync/web': minor
+---
+
+Add `checkpointMode` option to `ConnectOptions` to use a more efficient way to request checkpoints from PowerSync after uploads.

--- a/packages/capacitor/src/PowerSyncDatabase.ts
+++ b/packages/capacitor/src/PowerSyncDatabase.ts
@@ -116,16 +116,8 @@ class CapacitorPowerSyncDatabase extends WebPowerSyncDatabase {
 
       return new CapacitorStreamingSyncImplementation({
         ...(this.options as {}),
-        adapter: this.bucketStorageAdapter,
-        remote,
-        uploadCrud: async () => {
-          await this.waitForReady();
-          await connector.uploadData(this);
-        },
-        identifier: this.database.name,
-        logger: this.logger,
-        subscriptions: options.subscriptions,
-        serializedSchema: options.serializedSchema
+        ...this.commonSyncOptions(connector, options),
+        remote
       });
     } else {
       this.logger.log({ level: LogLevels.debug, message: `Using default web sync implementation for web platform` });

--- a/packages/common/etc/common.api.md
+++ b/packages/common/etc/common.api.md
@@ -254,6 +254,16 @@ export interface BatchedUpdateNotification {
     tables: string[];
 }
 
+// @public
+export type CheckpointMode = 'legacy' | 'requests' | {
+    requests: CheckpointRequestsOptions;
+};
+
+// @public
+export interface CheckpointRequestsOptions {
+    retryDelay: number;
+}
+
 // @public (undocumented)
 export class Column {
     constructor(options: ColumnOptions);
@@ -742,6 +752,7 @@ export type PendingStatementParameter = 'Id' | {
 // @public (undocumented)
 export interface PowerSyncBackendConnector {
     fetchCredentials: () => Promise<PowerSyncCredentials | null>;
+    postCheckpointRequest?(clientId: string, requestId: string): Promise<string>;
     uploadData: (database: CommonPowerSyncDatabase) => Promise<void>;
 }
 
@@ -1037,6 +1048,7 @@ export interface SyncDataFlowStatus {
 // @public
 export interface SyncOptions {
     appMetadata?: Record<string, string>;
+    checkpointMode?: CheckpointMode;
     connectionMethod?: SyncStreamConnectionMethod;
     crudUploadThrottleMs?: number;
     // (undocumented)

--- a/packages/common/src/client/connection/PowerSyncBackendConnector.ts
+++ b/packages/common/src/client/connection/PowerSyncBackendConnector.ts
@@ -25,4 +25,16 @@ export interface PowerSyncBackendConnector {
    * Any thrown errors will result in a retry after the configured wait period (default: 5 seconds).
    */
   uploadData: (database: CommonPowerSyncDatabase) => Promise<void>;
+
+  /**
+   * Posts a client-generated checkpoint request to the backend and returns the effective checkpoint request state.
+   *
+   * This method is optional. It only needs to be implemented when the selected {@link CheckpointMode} is `requests`
+   * and [asynchronous backend uploads](https://docs.powersync.com/client-sdks/advanced/checkpoint-requests#asynchronous-upload-backends)
+   * are used. In any other case, this method should not be present on backend connectors.
+   *
+   * @param requestId The client-generated checkpoint request ID (a positive 64-bit integer encoded as a string).
+   * @param clientId The PowerSync client ID for the current device.
+   */
+  postCheckpointRequest?(clientId: string, requestId: string): Promise<string>;
 }

--- a/packages/common/src/client/connection/PowerSyncBackendConnector.ts
+++ b/packages/common/src/client/connection/PowerSyncBackendConnector.ts
@@ -33,8 +33,8 @@ export interface PowerSyncBackendConnector {
    * and [asynchronous backend uploads](https://docs.powersync.com/client-sdks/advanced/checkpoint-requests#asynchronous-upload-backends)
    * are used. In any other case, this method should not be present on backend connectors.
    *
-   * @param requestId The client-generated checkpoint request ID (a positive 64-bit integer encoded as a string).
-   * @param clientId The PowerSync client ID for the current device.
+   * @param requestId - The client-generated checkpoint request ID (a positive 64-bit integer encoded as a string).
+   * @param clientId - The PowerSync client ID for the current device.
    */
   postCheckpointRequest?(clientId: string, requestId: string): Promise<string>;
 }

--- a/packages/common/src/client/sync/options.ts
+++ b/packages/common/src/client/sync/options.ts
@@ -100,8 +100,11 @@ export type CheckpointMode = 'legacy' | 'requests' | { requests: CheckpointReque
 /**
  * Options associated with a {@link CheckpointMode} when the requests-based checkpoint option is used.
  *
- * @alpha
+ * @public
  */
 export interface CheckpointRequestsOptions {
+  /**
+   * The delay, in milliseconds, to wait before re-sending a checkpoint request when it hasn't been applied in time.
+   */
   retryDelay: number;
 }

--- a/packages/common/src/client/sync/options.ts
+++ b/packages/common/src/client/sync/options.ts
@@ -84,8 +84,8 @@ export enum FetchStrategy {
 /**
  * The mechanism to request checkpoints from the PowerSync service.
  *
- * Checkpoint requests are used after a client uploads local mutations. Once synced, checkpoints provide the guarantee
- * that uploaded data is synced down again.
+ * Checkpoint requests are used after a client uploads local mutations. The PowerSync service later references them in
+ * downloaded data, allowing the SDK to assume that uploaded data has been synced down again.
  *
  * There are two ways to send checkpoint requests: A legacy (but default and stable) format supported by all PowerSync
  * service versions, and a newer (`requests`) method which is only available from PowerSync service version 1.24.0 or

--- a/packages/common/src/client/sync/options.ts
+++ b/packages/common/src/client/sync/options.ts
@@ -49,6 +49,11 @@ export interface SyncOptions {
    * milliseconds.
    */
   crudUploadThrottleMs?: number;
+
+  /**
+   * The mode used to request checkpoints from the service (used after uploading local data).
+   */
+  checkpointMode?: CheckpointMode;
 }
 
 /**
@@ -74,4 +79,29 @@ export enum FetchStrategy {
    * This reduces processing overhead and improves real-time responsiveness.
    */
   Sequential = 'sequential'
+}
+
+/**
+ * The mechanism to request checkpoints from the PowerSync service.
+ *
+ * Checkpoint requests are used after a client uploads local mutations. Once synced, checkpoints provide the guarantee
+ * that uploaded data is synced down again.
+ *
+ * There are two ways to send checkpoint requests: A legacy (but default and stable) format supported by all PowerSync
+ * service versions, and a newer (`requests`) method which is only available from PowerSync service version 1.24.0 or
+ * later.
+ *
+ * Note that the requests checkpoint mode is an alpha API.
+ *
+ * @public
+ */
+export type CheckpointMode = 'legacy' | 'requests' | { requests: CheckpointRequestsOptions };
+
+/**
+ * Options associated with a {@link CheckpointMode} when the requests-based checkpoint option is used.
+ *
+ * @alpha
+ */
+export interface CheckpointRequestsOptions {
+  retryDelay: number;
 }

--- a/packages/common/src/client/sync/options.ts
+++ b/packages/common/src/client/sync/options.ts
@@ -105,6 +105,8 @@ export type CheckpointMode = 'legacy' | 'requests' | { requests: CheckpointReque
 export interface CheckpointRequestsOptions {
   /**
    * The delay, in milliseconds, to wait before re-sending a checkpoint request when it hasn't been applied in time.
+   *
+   * The minimum value for this is 10 seconds, lower values will be ignored.
    */
   retryDelay: number;
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -17,7 +17,13 @@ export { CrudEntry, OpId, UpdateType } from './client/sync/bucket/CrudEntry.js';
 export * from './client/sync/bucket/CrudTransaction.js';
 export * from './client/sync/stream/JsonValue.js';
 export * from './client/sync/sync-streams.js';
-export { SyncOptions, SyncStreamConnectionMethod, FetchStrategy } from './client/sync/options.js';
+export {
+  SyncOptions,
+  SyncStreamConnectionMethod,
+  FetchStrategy,
+  CheckpointMode,
+  CheckpointRequestsOptions
+} from './client/sync/options.js';
 
 export { ProgressWithOperations, SyncProgress } from './db/crud/SyncProgress.js';
 export * from './db/crud/SyncStatus.js';

--- a/packages/node/src/db/PowerSyncDatabase.ts
+++ b/packages/node/src/db/PowerSyncDatabase.ts
@@ -44,10 +44,6 @@ class NodePowerSyncDatabase extends BasePowerSyncDatabase<NodePowerSyncDatabaseO
     return openDatabase(this.options, (open) => new WorkerConnectionPool(open));
   }
 
-  protected generateBucketStorageAdapter(): BucketStorageAdapter {
-    return new SqliteBucketStorage(this.database, this.logger);
-  }
-
   protected generateSyncStreamImplementation(
     connector: PowerSyncBackendConnector,
     options: CreateSyncImplementationOptions
@@ -56,15 +52,8 @@ class NodePowerSyncDatabase extends BasePowerSyncDatabase<NodePowerSyncDatabaseO
     const remote = new NodeRemote(connector, logger, this.options.remoteOptions);
 
     return new NodeStreamingSyncImplementation({
-      adapter: this.bucketStorageAdapter,
-      remote,
-      uploadCrud: async () => {
-        await this.waitForReady();
-        await connector.uploadData(this);
-      },
-      ...options,
-      identifier: this.database.name,
-      logger
+      ...this.commonSyncOptions(connector, options),
+      remote
     });
   }
 }

--- a/packages/node/tests/sync.test.ts
+++ b/packages/node/tests/sync.test.ts
@@ -21,6 +21,7 @@ import {
 } from './utils.js';
 import { BucketChecksum, OplogEntryJSON } from '@powersync/shared-internals/internal/sync_protocol';
 import { BasePowerSyncDatabase } from '@powersync/shared-internals';
+import { asyncNotifier } from '../../shared-internals/src/utils/async.js';
 
 const defaultConnectOptions: SyncOptions = {
   // This might help with test stability/timeouts if a retry is needed.
@@ -30,6 +31,167 @@ const defaultConnectOptions: SyncOptions = {
 describe('Sync', () => {
   describe('json', () => defineSyncTests(false));
   describe('bson', () => defineSyncTests(true));
+
+  describe('checkpoint requests', () => {
+    mockSyncServiceTest('requests checkpoints for updates', async ({ syncService }) => {
+      const database = await syncService.createDatabase();
+      await database.connect(new TestConnector(), { checkpointMode: 'requests' });
+
+      await vi.waitFor(() => expect(syncService.checkpointRequests).toHaveLength(1));
+
+      await database.execute('INSERT INTO lists (id, name) VALUES (?, ?)', ['id', 'local write']);
+      const watched = database.watch('SELECT name FROM lists')[Symbol.asyncIterator]();
+      expect((await watched.next()).value.array).toStrictEqual([{ name: 'local write' }]);
+
+      // The local write should eventually be uploaded.
+      await vi.waitFor(() => expect(syncService.checkpointRequests).toHaveLength(2), { timeout: 2000 });
+
+      syncService.pushLine({
+        checkpoint: {
+          last_op_id: '1',
+          buckets: [bucket('a', 1)],
+          write_checkpoint: String(syncService.lastWriteCheckpoint)
+        }
+      });
+      syncService.pushLine({
+        data: {
+          bucket: 'a',
+          data: [
+            {
+              checksum: 0,
+              op_id: '1',
+              object_id: 'id',
+              object_type: 'lists',
+              op: 'REMOVE'
+            }
+          ]
+        }
+      });
+      syncService.pushLine({ checkpoint_complete: { last_op_id: '1' } });
+      expect((await watched.next()).value.array).toStrictEqual([]);
+    });
+
+    mockSyncServiceTest('reports download error when requesting checkpoints fails', async ({ syncService }) => {
+      const database = await syncService.createDatabase();
+      syncService.installRequestInterceptor(async (request) => {
+        if (request.url.includes('/sync/checkpoint-request')) {
+          return new Response('not found', { status: 404 });
+        }
+        return undefined;
+      });
+
+      database.connect(new TestConnector(), { checkpointMode: 'requests' });
+      await database.waitForStatus((s) => s.downloadError != null);
+      expect(database.currentStatus.connected).toBeFalsy();
+    });
+
+    mockSyncServiceTest('reposts current checkpoint until applied', async ({ syncService }) => {
+      const checkpointRequests = asyncNotifier();
+      const neverAbort = new AbortController().signal;
+      syncService.installRequestInterceptor(async (request) => {
+        if (request.url.includes('/sync/checkpoint-request')) {
+          checkpointRequests.notify();
+        }
+      });
+      const database = await syncService.createDatabase();
+
+      vi.useFakeTimers();
+      await database.connect(new TestConnector(), { checkpointMode: 'requests' });
+      // Wait for the initial post (seed)
+      await checkpointRequests.waitForNotification(neverAbort);
+
+      for (let i = 0; i < 10; i++) {
+        let didPostCheckpointRequestAgain = false;
+        checkpointRequests.waitForNotification(neverAbort).finally(() => (didPostCheckpointRequestAgain = true));
+
+        while (!didPostCheckpointRequestAgain) {
+          await vi.advanceTimersToNextTimerAsync();
+        }
+      }
+
+      // Finally, include the checkpoint.
+      syncService.pushLine({ checkpoint: { last_op_id: '0', buckets: [], write_checkpoint: '1' } });
+      syncService.pushLine({ checkpoint_complete: { last_op_id: '0' } });
+      await database.waitForFirstSync();
+
+      const totalRequests = syncService.checkpointRequests.length;
+      // Which means we shouldn't keep requesting it.
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+      expect(syncService.checkpointRequests.length).toStrictEqual(totalRequests);
+
+      vi.useRealTimers();
+    });
+
+    mockSyncServiceTest('download is retried on checkpoint request', async ({ syncService }) => {
+      const db = await syncService.createDatabase();
+
+      await db.connect(new TestConnector(), { checkpointMode: 'requests', retryDelayMs: 10_000 });
+
+      // Destroy the initial connection by sending a bogus line
+      const start = performance.now();
+      syncService.pushLine({ checkpoint: { buckets: [], last_op_id: 'invalid line' } });
+      await db.waitForStatus((s) => s.downloadError != null);
+
+      // Trigger an upload here. Because the upload needs a seeded sync iteration, we should reconnect immediately
+      // instead of after the configured 10s delay.
+      await db.execute('INSERT INTO lists (id, name) VALUES (uuid(), ?)', ['restart plz']);
+
+      await db.waitForStatus((s) => s.connected);
+      const end = performance.now();
+      expect(end - start).toBeLessThan(5_000);
+    });
+
+    mockSyncServiceTest('can use checkpoint method from connector', async ({ syncService }) => {
+      const didRequestCheckpoint = Promise.withResolvers<void>();
+      const connector = new (class extends TestConnector {
+        async postCheckpointRequest(_clientId: string, requestId: string) {
+          expect(requestId).toStrictEqual('1');
+          didRequestCheckpoint.resolve();
+
+          return requestId;
+        }
+      })();
+
+      const db = await syncService.createDatabase();
+      await db.connect(connector, { checkpointMode: 'requests' });
+      await didRequestCheckpoint.promise;
+    });
+
+    mockSyncServiceTest('reconciles checkpoint state on token expiry', async ({ syncService }) => {
+      const db = await syncService.createDatabase();
+      syncService.lastWriteCheckpoint = 100;
+      await db.connect(new TestConnector(), { checkpointMode: 'requests' });
+      await vi.waitFor(() => expect(syncService.checkpointRequests).toHaveLength(1));
+
+      // Simulate what would happen if we suddenly switched users after the old token expired. The client expects a
+      // checkpoint of 100, for another user the service wouldn't have that counter yet. The client must request a
+      // checkpoint with the existing id, allowing the service to recognize that this device + user combo needs higher
+      // checkpoint ids.
+      syncService.lastWriteCheckpoint = 0;
+      syncService.pushLine({ token_expires_in: 5 });
+      await vi.waitFor(() => expect(syncService.checkpointRequests).toHaveLength(2));
+      expect(syncService.lastWriteCheckpoint).toStrictEqual(100);
+    });
+
+    mockSyncServiceTest('reads sync lines before checkpoint requests are ready', async ({ syncService }) => {
+      const hasInitialRequest = Promise.withResolvers<void>();
+      const completeInitialRequest = Promise.withResolvers<void>();
+      syncService.installRequestInterceptor(async (request) => {
+        if (request.url.includes('/sync/checkpoint-request')) {
+          hasInitialRequest.resolve();
+          await completeInitialRequest.promise;
+        }
+      });
+
+      const db = await syncService.createDatabase();
+      await db.connect(new TestConnector(), { checkpointMode: 'requests' });
+      await hasInitialRequest.promise;
+
+      syncService.pushLine({ checkpoint: { last_op_id: '0', buckets: [], write_checkpoint: '1' } });
+      await db.waitForStatus((s) => s.downloading);
+      completeInitialRequest.resolve();
+    });
+  });
 
   mockSyncServiceTest('can migrate between sync implementations', async ({ syncService }) => {
     let database = await syncService.createDatabase();

--- a/packages/node/tests/sync.test.ts
+++ b/packages/node/tests/sync.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, vi } from 'vitest';
 
 import {
   CommonPowerSyncDatabase,
+  LogRecord,
   PowerSyncLogger,
   ProgressWithOperations,
   Schema,
@@ -33,6 +34,28 @@ describe('Sync', () => {
   describe('bson', () => defineSyncTests(true));
 
   describe('checkpoint requests', () => {
+    mockSyncServiceTest('warns for custom connectors without requests being enabled', async ({ syncService }) => {
+      const records: LogRecord[] = [];
+
+      const database = await syncService.createDatabase({ logger: { log: records.push.bind(records) } });
+      const connector = new (class extends TestConnector {
+        async postCheckpointRequest(_clientId: string, requestId: string) {
+          return requestId;
+        }
+      })();
+
+      await database.connect(connector);
+      expect(records).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.stringContaining(
+              'implements postCheckpointRequest, but connect() was called without checkpoint requests'
+            )
+          })
+        ])
+      );
+    });
+
     mockSyncServiceTest('requests checkpoints for updates', async ({ syncService }) => {
       const database = await syncService.createDatabase();
       await database.connect(new TestConnector(), { checkpointMode: 'requests' });

--- a/packages/node/tests/utils.ts
+++ b/packages/node/tests/utils.ts
@@ -111,6 +111,8 @@ export function createMockSyncServiceTest(bson: boolean) {
 
       const listeners: Listener[] = [];
       let requestInterceptor: (request: Request) => Promise<Response | void> = async () => {};
+      let lastWriteCheckpoint = 0;
+      let checkpointRequests: number[] = [];
 
       const inMemoryFetch: typeof fetch = async (info, init?) => {
         const request = new Request(info, init);
@@ -153,6 +155,18 @@ export function createMockSyncServiceTest(bson: boolean) {
             status: 200,
             headers: { 'content-type': bson ? 'application/vnd.powersync.bson-stream' : 'application/x-ndjson' }
           });
+        } else if (request.url.indexOf('/sync/checkpoint-request') != -1) {
+          const body = await request.json();
+          const requestedId = Number(body['checkpoint_request_id']);
+          checkpointRequests.push(requestedId);
+          lastWriteCheckpoint = Math.max(lastWriteCheckpoint, requestedId);
+
+          return new Response(
+            JSON.stringify({
+              data: { checkpoint_request_id: lastWriteCheckpoint.toString() }
+            }),
+            { status: 200 }
+          );
         } else if (request.url.indexOf('/write-checkpoint2.json') != -1) {
           return new Response(
             JSON.stringify({
@@ -195,7 +209,14 @@ export function createMockSyncServiceTest(bson: boolean) {
             listener.stream.enqueue(line);
           }
         },
-        createDatabase: newConnection
+        createDatabase: newConnection,
+        get lastWriteCheckpoint(): number {
+          return lastWriteCheckpoint;
+        },
+        set lastWriteCheckpoint(value: number) {
+          lastWriteCheckpoint = value;
+        },
+        checkpointRequests
       });
     }
   });
@@ -207,6 +228,8 @@ export interface MockSyncService {
   installRequestInterceptor(interceptor: (request: Request) => Promise<Response | void>): void;
   pushLine: (line: StreamingSyncLine) => void;
   connectedListeners: any[];
+  lastWriteCheckpoint: number;
+  readonly checkpointRequests: number[];
 
   createDatabase: (options?: Partial<NodePowerSyncDatabaseOptions>) => Promise<PowerSyncDatabase>;
 }

--- a/packages/nuxt/src/runtime/utils/NuxtPowerSyncDatabase.ts
+++ b/packages/nuxt/src/runtime/utils/NuxtPowerSyncDatabase.ts
@@ -90,13 +90,9 @@ export class NuxtDatabaseImplementation extends WebPowerSyncDatabase {
           logger ? logger.log({ level: LogLevels.warn, message: warning }) : console.warn(warning);
         }
         return new SharedWebStreamingSyncImplementation({
-          ...options,
+          ...this.commonSyncOptions(connector, options),
           adapter,
           remote: new WebRemote(connector, logger),
-          uploadCrud: async () => {
-            await this.waitForReady();
-            await connector.uploadData(this);
-          },
           logger,
           db: this.database as WebDBAdapter,
           logLevel: this.resolvedOpenOptions.databaseWorkerLogLevel ?? LogLevels.info,
@@ -104,13 +100,9 @@ export class NuxtDatabaseImplementation extends WebPowerSyncDatabase {
         });
       } else {
         return new WebStreamingSyncImplementation({
-          ...options,
+          ...this.commonSyncOptions(connector, options),
           adapter,
           remote: new WebRemote(connector, logger),
-          uploadCrud: async () => {
-            await this.waitForReady();
-            await connector.uploadData(this);
-          },
           identifier: 'database' in this.options ? this.options.database.dbFilename : 'diagnostics-sync',
           logger
         });

--- a/packages/react-native/src/db/PowerSyncDatabase.ts
+++ b/packages/react-native/src/db/PowerSyncDatabase.ts
@@ -53,15 +53,8 @@ class ReactNativePowerSyncDatabase extends BasePowerSyncDatabase<ReactNativeData
     const remote = new ReactNativeRemote(connector, this.logger, this.options.remote);
 
     return new ReactNativeStreamingSyncImplementation({
-      ...options,
-      adapter: this.bucketStorageAdapter,
-      remote,
-      uploadCrud: async () => {
-        await this.waitForReady();
-        await connector.uploadData(this);
-      },
-      identifier: this.database.name,
-      logger: this.logger
+      ...this.commonSyncOptions(connector, options),
+      remote
     });
   }
 

--- a/packages/react-native/tests/sync/ReactNativeRemote.test.ts
+++ b/packages/react-native/tests/sync/ReactNativeRemote.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, Mock, vi } from 'vitest';
 
-import { PowerSyncFetchImplementation, ReactNativeRemote } from '../../src/sync/stream/ReactNativeRemote';
+import { ReactNativeRemote } from '../../src/sync/stream/ReactNativeRemote';
 import { createConsoleLogger } from '@powersync/common';
 import { FetchOptions } from '@powersync/shared-internals';
+import type { PowerSyncFetchImplementation } from '../../src/sync/stream/fetch';
 
 const connector = {
   fetchCredentials: async () => ({
@@ -41,7 +42,7 @@ describe('ReactNativeRemote', () => {
     const [fetchImplementation, mock] = mockFetchImplementation();
     const remote = new ReactNativeRemote(connector, logger, { fetchImplementation });
 
-    await remote.get('/write-checkpoint2.json');
+    await remote.fetchAndDecodeJson({ path: '/write-checkpoint2.json' });
 
     expect(mock).toHaveBeenCalledWith({
       resource: 'https://example.com/write-checkpoint2.json',

--- a/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
+++ b/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
@@ -47,7 +47,10 @@ import {
 } from './ConnectionManager.js';
 import { Mutex } from '../utils/mutex.js';
 import { TriggerManagerConfig, TriggerManagerImpl } from './triggers/TriggerManagerImpl.js';
-import { StreamingSyncImplementation } from './sync/stream/AbstractStreamingSyncImplementation.js';
+import {
+  AbstractStreamingSyncImplementationOptions,
+  StreamingSyncImplementation
+} from './sync/stream/AbstractStreamingSyncImplementation.js';
 import { CoreSyncStatus } from './sync/stream/core-instruction.js';
 import { CrudEntryImpl, CrudEntryJSON } from './sync/bucket/CrudEntry.js';
 import { OnChangeQueryProcessor } from './watched/OnChangeQueryProcessor.js';
@@ -58,6 +61,7 @@ import { CustomQuery } from './CustomQuery.js';
 import { MEMORY_TRIGGER_CLAIM_MANAGER } from './triggers/MemoryTriggerClaimManager.js';
 import { symbolAsyncIterator } from '../utils/compatibility.js';
 import { MAX_OP_ID } from '../constants.js';
+import { SqliteBucketStorage } from './sync/bucket/SqliteBucketStorage.js';
 
 const POWERSYNC_TABLE_MATCH = /(^ps_data__|^ps_data_local__)/;
 
@@ -257,7 +261,29 @@ export abstract class BasePowerSyncDatabase<Options extends BasePowerSyncDatabas
     options: CreateSyncImplementationOptions
   ): StreamingSyncImplementation;
 
-  protected abstract generateBucketStorageAdapter(): BucketStorageAdapter;
+  protected commonSyncOptions(connector: PowerSyncBackendConnector, options: CreateSyncImplementationOptions) {
+    return {
+      ...options,
+      adapter: this.bucketStorageAdapter,
+      uploadCrud: async () => {
+        await this.waitForReady();
+        await connector.uploadData(this);
+      },
+      postCheckpointRequest: (clientId, requestId) => {
+        if (connector.postCheckpointRequest) {
+          return this.waitForReady().then((_) => connector.postCheckpointRequest!(clientId, requestId));
+        } else {
+          return null;
+        }
+      },
+      identifier: this.database.name,
+      logger: this.logger
+    } satisfies Partial<AbstractStreamingSyncImplementationOptions>;
+  }
+
+  protected generateBucketStorageAdapter(): BucketStorageAdapter {
+    return new SqliteBucketStorage(this.database, this.logger);
+  }
 
   async waitForReady(): Promise<void> {
     if (this.ready) {

--- a/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
+++ b/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
@@ -34,11 +34,7 @@ import {
   SqliteRecord,
   SyncStreamConnectionMethod
 } from '@powersync/common';
-import {
-  BucketStorageAdapter,
-  PSInternalTable,
-  targetCheckpointRequestId
-} from './sync/bucket/BucketStorageAdapter.js';
+import { BucketStorageAdapter, PSInternalTable } from './sync/bucket/BucketStorageAdapter.js';
 import { SyncStatusSnapshot } from '../db/crud/SyncStatus.js';
 import {
   ConnectionManager,

--- a/packages/shared-internals/src/client/ConnectionManager.ts
+++ b/packages/shared-internals/src/client/ConnectionManager.ts
@@ -150,11 +150,20 @@ export class ConnectionManager extends BaseObserver<ConnectionManagerListener> {
     const hadPendingOptions = !!this.pendingConnectionOptions;
 
     // Update pending options to the latest values
+    const resolvedOptions = resolveSyncOptions(options, this.options.defaultConnectionMethod);
     this.pendingConnectionOptions = {
       connector,
-      options: resolveSyncOptions(options, this.options.defaultConnectionMethod),
+      options: resolvedOptions,
       schema: serializedSchema
     };
+
+    if (connector.postCheckpointRequest && resolvedOptions.checkpointMode == 'legacy') {
+      this.logger.log({
+        level: LogLevels.warn,
+        message:
+          'The backend connector implements postCheckpointRequest, but connect() was called without checkpoint requests enabled.'
+      });
+    }
 
     // Disconnecting here provides aborting in progress connection attempts.
     // The connectInternal method will clear pending options once it starts connecting (with the options).

--- a/packages/shared-internals/src/client/sync/bucket/BucketStorageAdapter.ts
+++ b/packages/shared-internals/src/client/sync/bucket/BucketStorageAdapter.ts
@@ -45,6 +45,7 @@ export interface BucketStorageAdapter extends BaseObserverInterface<BucketStorag
 
   updateLocalTarget(cb: () => Promise<string>): Promise<boolean>;
   handleCrudCheckpoint(lastClientId: number, writeCheckpoint?: string): Promise<void>;
+  readCheckpointRequestId(variant: 'next' | 'current' | 'seed', payload?: string): Promise<string>;
 
   /**
    * Get an unique client id.

--- a/packages/shared-internals/src/client/sync/bucket/SqliteBucketStorage.ts
+++ b/packages/shared-internals/src/client/sync/bucket/SqliteBucketStorage.ts
@@ -108,6 +108,8 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
   }
 
   readCheckpointRequestId(variant: 'next' | 'current' | 'seed', payload: string | null = null): Promise<string> {
+    // This needs to run in a write transaction because some checkpoint request reads interact with sync client state
+    // bound to the write connection.
     return this.db.writeTransaction(async (tx) => {
       return (await rawPowerSyncControl(tx, `${variant}_checkpoint_request_id`, payload))!;
     });

--- a/packages/shared-internals/src/client/sync/bucket/SqliteBucketStorage.ts
+++ b/packages/shared-internals/src/client/sync/bucket/SqliteBucketStorage.ts
@@ -107,6 +107,12 @@ export class SqliteBucketStorage extends BaseObserver<BucketStorageListener> imp
     });
   }
 
+  readCheckpointRequestId(variant: 'next' | 'current' | 'seed', payload: string | null = null): Promise<string> {
+    return this.db.writeTransaction(async (tx) => {
+      return (await rawPowerSyncControl(tx, `${variant}_checkpoint_request_id`, payload))!;
+    });
+  }
+
   async nextCrudItem(): Promise<CrudEntry | undefined> {
     const next = await this.db.getOptional<CrudEntryJSON>('SELECT * FROM ps_crud ORDER BY id ASC LIMIT 1');
     if (!next) {

--- a/packages/shared-internals/src/client/sync/options.ts
+++ b/packages/shared-internals/src/client/sync/options.ts
@@ -19,6 +19,7 @@ export function resolveSyncOptions(
     params: options.params ?? {},
     includeDefaultStreams: options.includeDefaultStreams ?? true,
     retryDelayMs: options.retryDelayMs ?? 5000,
-    crudUploadThrottleMs: options.crudUploadThrottleMs ?? 1000
+    crudUploadThrottleMs: options.crudUploadThrottleMs ?? 1000,
+    checkpointMode: options.checkpointMode ?? 'legacy'
   };
 }

--- a/packages/shared-internals/src/client/sync/stream/AbstractRemote.ts
+++ b/packages/shared-internals/src/client/sync/stream/AbstractRemote.ts
@@ -173,16 +173,30 @@ export abstract class AbstractRemote {
     };
   }
 
-  async get(path: string, headers?: Record<string, string>): Promise<any> {
+  async fetchAndDecodeJson({
+    path,
+    method = 'GET',
+    headers,
+    body,
+    signal
+  }: {
+    path: string;
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  }): Promise<any> {
     const request = await this.buildRequest(path);
     const res = await this.fetch({
       resource: request.url,
       request: {
-        method: 'GET',
+        method,
         headers: {
           ...headers,
           ...request.headers
-        }
+        },
+        body,
+        signal
       },
       expectStreamingResponse: false
     });

--- a/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -14,6 +14,7 @@ import { AbortOperation } from '../../../utils/AbortOperation.js';
 import { BucketStorageAdapter, PowerSyncControlCommand } from '../bucket/BucketStorageAdapter.js';
 import { AbstractRemote, SyncStreamOptions } from './AbstractRemote.js';
 import {
+  CheckpointRequestPayload,
   CoreSyncStatus,
   Instruction,
   NonInterruptingInstruction,
@@ -29,6 +30,7 @@ import {
 import { asyncNotifier } from '../../../utils/async.js';
 import { JavaScriptSyncState, SyncStatusSnapshot } from '../../../db/crud/SyncStatus.js';
 import { ResolvedSyncOptions } from '../options.js';
+import { CheckpointStateSignals, isCheckpointRequestApplied } from './CheckpointState.js';
 
 /**
  * @internal
@@ -56,6 +58,10 @@ export interface AbstractStreamingSyncImplementationOptions {
   adapter: BucketStorageAdapter;
   subscriptions: SubscribedStream[];
   uploadCrud: () => Promise<void>;
+  /**
+   * Posts a checkpoint request with the connector, returning null if the connector doesn't support that.
+   */
+  postCheckpointRequest: (clientId: string, requestId: string) => Promise<string | null> | null;
   /**
    * An identifier for which PowerSync DB this sync implementation is
    * linked to. Most commonly DB name, but not restricted to DB name.
@@ -93,7 +99,6 @@ export interface StreamingSyncImplementation
    * @throws if not connected or if abort is not controlled internally
    */
   disconnect(): Promise<void>;
-  getWriteCheckpoint: () => Promise<string>;
   isConnected: boolean;
   triggerCrudUpload: () => void;
   waitForReady(): Promise<void>;
@@ -120,11 +125,12 @@ export abstract class AbstractStreamingSyncImplementation
   protected options: AbstractStreamingSyncImplementationOptions;
   protected abortController: AbortController | null;
   protected crudUpdateListener?: () => void;
-  protected streamingSyncPromise?: Promise<[void, void]>;
+  protected streamingSyncPromise?: Promise<[void, void, void]>;
   protected logger: PowerSyncLogger;
   protected activeStreams: SubscribedStream[];
   private connectionMayHaveChanged = false;
   private crudUploadNotifier = asyncNotifier();
+  private checkpoints = new CheckpointStateSignals();
 
   private notifyCompletedUploads?: () => void;
   private handleActiveStreamsChange?: () => void;
@@ -182,10 +188,41 @@ export abstract class AbstractStreamingSyncImplementation
 
   abstract obtainLock<T>(lockOptions: LockOptions<T>): Promise<T>;
 
-  async getWriteCheckpoint(): Promise<string> {
+  private async requestNextCheckpointFromService(abort: AbortSignal): Promise<string> {
+    await this.checkpoints.waitForCheckpointRequestsReady(abort);
+
+    const nextCheckpointRequestId = await this.options.adapter.readCheckpointRequestId('next');
+    const clientId = await this.options.adapter.getClientId();
+    return await this.requestCheckpointFromService(abort, {
+      client_id: clientId,
+      checkpoint_request_id: nextCheckpointRequestId
+    });
+  }
+
+  private async requestCheckpointFromService(signal: AbortSignal, request: CheckpointRequestPayload): Promise<string> {
+    // First, check if we can use a custom checkpoint request implementation.
+    {
+      const customResponse = await this.options.postCheckpointRequest(request.client_id, request.checkpoint_request_id);
+      if (customResponse != null) {
+        return customResponse;
+      }
+    }
+
+    const status = await this.options.remote.fetchAndDecodeJson({
+      method: 'POST',
+      path: '/sync/checkpoint-request',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(request),
+      signal
+    });
+
+    return status.data.checkpoint_request_id;
+  }
+
+  private async getLegacyWriteCheckpoint(): Promise<string> {
     const clientId = await this.options.adapter.getClientId();
     let path = `/write-checkpoint2.json?client_id=${clientId}`;
-    const response = await this.options.remote.get(path);
+    const response = await this.options.remote.fetchAndDecodeJson({ path });
     const checkpoint = response['data']['write_checkpoint'] as string;
     this.logger.log({ level: LogLevels.debug, message: `Created write checkpoint: ${checkpoint}` });
     return checkpoint;
@@ -239,7 +276,13 @@ The next upload iteration will be delayed.`
               this.updateJsSyncState({ uploadError: undefined });
             } else {
               // Uploading is completed
-              const neededUpdate = await this.options.adapter.updateLocalTarget(() => this.getWriteCheckpoint());
+              const neededUpdate = await this.options.adapter.updateLocalTarget(() => {
+                if (options.checkpointMode === 'legacy') {
+                  return this.getLegacyWriteCheckpoint();
+                } else {
+                  return this.requestNextCheckpointFromService(signal);
+                }
+              });
               if (neededUpdate) {
                 this.notifyCompletedUploads?.();
               } else if (checkedCrudItem != null) {
@@ -280,8 +323,13 @@ The next upload iteration will be delayed.`
       this.crudUploadLoop(controller.signal, options).catch((error) =>
         this.logger.log({ level: LogLevels.error, message: 'Error in crud upload loop', error })
       ),
-      this.streamingSync(controller.signal, options)
-    ]);
+      this.streamingSync(controller.signal, options),
+      this.repostUnacknowledgedCheckpointRequests(controller.signal, options)
+    ]).finally(() => {
+      // These promises only complete when we want to disconnect. No further sync iteration can resume checkpoint
+      // requests, so fail any that are still pending.
+      this.checkpoints.disconnected();
+    });
 
     // Return a promise that resolves when the connection status is updated to indicate that we're connected. We do this
     // by waiting for connecting to be true and then false again.
@@ -342,11 +390,10 @@ The next upload iteration will be delayed.`
     }
 
     this.updateSyncStatus({
+      ...current,
       connected: false,
       connecting: false,
-      priority_status: current.priority_status,
-      downloading: null,
-      streams: current.streams
+      downloading: null
     });
   }
 
@@ -419,6 +466,7 @@ The next upload iteration will be delayed.`
 
         this.updateJsSyncState({ downloadError: ex as Error });
       } finally {
+        this.checkpoints.downloadIterationEnded();
         this.notifyCompletedUploads = undefined;
 
         if (!signal.aborted) {
@@ -431,7 +479,7 @@ The next upload iteration will be delayed.`
 
           // On error, wait a little before retrying
           if (shouldDelayRetry) {
-            await this.delayRetry(nestedAbortController.signal, options.retryDelayMs);
+            await this.delayRetry(nestedAbortController.signal, options.retryDelayMs, true);
           }
         }
       }
@@ -550,6 +598,66 @@ The next upload iteration will be delayed.`
     };
   }
 
+  /**
+   * Watches the current checkpoint request id to re-request it if we take too long to receive it.
+   *
+   * This does not require navigator locks: It waits for checkpoints to be seeded, which can only happen in the context
+   * of a download loop.
+   *
+   * Note that requesting checkpoints with ids the service has already seen is a cheap no-op.
+   */
+  private async repostUnacknowledgedCheckpointRequests(abort: AbortSignal, options: ResolvedSyncOptions) {
+    let retryDelay: number;
+    const mode = options.checkpointMode;
+    if (mode == 'legacy') return;
+
+    if (mode == 'requests') {
+      retryDelay = 10_000;
+    } else {
+      retryDelay = Math.max(mode.requests.retryDelay, 10_000);
+    }
+
+    while (!abort.aborted) {
+      try {
+        await this.checkpoints.waitForCheckpointRequestsReady(abort, false);
+
+        const requestId = await this.options.adapter.readCheckpointRequestId('current');
+        // Give the request some time to sync.
+        await this.delayRetry(abort, retryDelay);
+
+        // If a new request was made, reset the timer.
+        if (requestId != (await this.options.adapter.readCheckpointRequestId('current'))) {
+          continue;
+        }
+
+        // If the request was applied, we don't need to retry.
+        if (isCheckpointRequestApplied(this.syncStatus?.core, requestId)) {
+          continue;
+        }
+
+        // Make sure we're online and ready before making the request
+        await this.checkpoints.waitForCheckpointRequestsReady(abort, false);
+
+        // It's safe if this request races with a new one. The service will reject it.
+        this.logger.log({ level: LogLevels.debug, message: `Retry checkpoint request ${requestId}` });
+        await this.requestCheckpointFromService(abort, {
+          client_id: await this.options.adapter.getClientId(),
+          checkpoint_request_id: requestId
+        });
+      } catch (e) {
+        if (abort.aborted) return;
+
+        this.logger.log({ level: LogLevels.warn, error: e, message: 'Error retrying checkpoint request.' });
+        await this.delayRetry(abort, retryDelay);
+      }
+    }
+  }
+
+  private async seedCheckpointRequestState(abort: AbortSignal, request: CheckpointRequestPayload) {
+    const seed = await this.requestCheckpointFromService(abort, request);
+    await this.options.adapter.readCheckpointRequestId('seed', seed);
+  }
+
   private async rustSyncIteration(
     signal: AbortSignal,
     resolvedOptions: ResolvedSyncOptions
@@ -570,7 +678,8 @@ The next upload iteration will be delayed.`
         parameters: resolvedOptions.params,
         app_metadata: resolvedOptions.appMetadata,
         active_streams: syncImplementation.activeStreams,
-        include_defaults: resolvedOptions.includeDefaultStreams
+        include_defaults: resolvedOptions.includeDefaultStreams,
+        checkpoint_mode: resolvedOptions.checkpointMode === 'legacy' ? 'legacy' : 'requests'
       };
       if (serializedSchema) {
         options.schema = serializedSchema;
@@ -671,10 +780,11 @@ The next upload iteration will be delayed.`
 
       for (const startInstruction of await startCommand()) {
         if ('EstablishSyncStream' in startInstruction) {
+          const establish = startInstruction.EstablishSyncStream;
           const syncOptions: SyncStreamOptions = {
             path: '/sync/stream',
             abortSignal: signal,
-            data: startInstruction.EstablishSyncStream.request
+            data: establish.request
           };
 
           controlInvocations = injectable(
@@ -683,6 +793,24 @@ The next upload iteration will be delayed.`
               connection: resolvedOptions
             })
           );
+
+          if (establish.checkpoint_request) {
+            // Start checkpoint request validation concurrently, without blocking line processing on it. We reconcile
+            // checkpoint states on each started download iteration to:
+            //   1. Align service and client checkpoint ids, allowing both parties to safely forget old checkpoints.
+            //   2. If the user id changes between connections, agreeing on the highest checkpoint request between the
+            //      old and new user to make sure we'll receive that checkpoint eventually.
+            const seed = this.checkpoints.markCheckpointsReady(
+              this.seedCheckpointRequestState(signal, establish.checkpoint_request)
+            );
+
+            seed.catch((e) => {
+              // Make the download iteration fail if checkpoint requests are broken.
+              if (!signal.aborted) {
+                controlInvocations?.injectError(e);
+              }
+            });
+          }
         } else if ('CloseSyncStream' in startInstruction) {
           return defaultResult;
         } else {
@@ -761,14 +889,15 @@ The next upload iteration will be delayed.`
     this.updateSyncStatus(this.syncStatus.core, state);
   }
 
-  private async delayRetry(signal: AbortSignal, delay: number): Promise<void> {
+  private async delayRetry(signal: AbortSignal, delay: number, resumeOnCheckpointRequest = false): Promise<void> {
     return new Promise((resolve) => {
-      if (signal?.aborted) {
+      if (signal.aborted) {
         // If the signal is already aborted, resolve immediately
         resolve();
         return;
       }
 
+      let nested: AbortController | null = null;
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
       const endDelay = () => {
@@ -777,11 +906,23 @@ The next upload iteration will be delayed.`
           clearTimeout(timeoutId);
           timeoutId = undefined;
         }
-        signal?.removeEventListener('abort', endDelay);
+        if (nested) {
+          nested.abort();
+          nested = null;
+        }
+        signal.removeEventListener('abort', endDelay);
       };
 
-      signal?.addEventListener('abort', endDelay, { once: true });
-      timeoutId = setTimeout(endDelay, delay);
+      signal.addEventListener('abort', endDelay, { once: true });
+
+      // Add a random +/- 10% jitter to the retry delay.
+      const randomizedDelay = delay * (0.9 + Math.random() * 0.2);
+      timeoutId = setTimeout(endDelay, randomizedDelay);
+
+      if (resumeOnCheckpointRequest) {
+        nested = new AbortController();
+        this.checkpoints.waitForCheckpointWaiter(nested.signal).finally(endDelay);
+      }
     });
   }
 

--- a/packages/shared-internals/src/client/sync/stream/CheckpointState.ts
+++ b/packages/shared-internals/src/client/sync/stream/CheckpointState.ts
@@ -84,7 +84,7 @@ export class CheckpointStateSignals {
       }
     } while ((await this.stateChanged.waitForEvent(abort)) != null);
 
-    return false; // current is null, meaning the wait was aborted
+    return false; // waitForEvent returned null, meaning the wait was aborted
   }
 }
 

--- a/packages/shared-internals/src/client/sync/stream/CheckpointState.ts
+++ b/packages/shared-internals/src/client/sync/stream/CheckpointState.ts
@@ -1,3 +1,4 @@
+import { BaseListener, BaseObserver } from '@powersync/common';
 import { asyncNotifier, EventQueue } from '../../../utils/async.js';
 import { CoreSyncStatus } from './core-instruction.js';
 
@@ -11,7 +12,7 @@ const pending: CheckpointState = { state: 'pending' };
 
 export class CheckpointStateSignals {
   private currentState: CheckpointState = pending;
-  private readonly stateChanged = new EventQueue<CheckpointState>();
+  private readonly stateChanged = new BaseObserver<CheckpointStateListener>();
 
   /**
    * Use to immediately restart another download iteration if it is retry delay when a new checkpoint is requested.
@@ -20,7 +21,7 @@ export class CheckpointStateSignals {
 
   private updateState(state: CheckpointState) {
     this.currentState = state;
-    this.stateChanged.notify(state);
+    this.stateChanged.iterateListeners((l) => l.stateChanged?.());
   }
 
   /**
@@ -65,31 +66,64 @@ export class CheckpointStateSignals {
    * @returns Turue if checkpoints are ready, false if aborted.
    */
   async waitForCheckpointRequestsReady(abort: AbortSignal, wakeDownloadLoop = true): Promise<boolean> {
-    do {
-      const current = this.currentState;
-
-      switch (current.state) {
-        case 'disconnected':
-          throwCannotRequestDueToDisconnectedError();
-        case 'ready':
-          return true;
-        case 'error':
-          throw current.error;
-        case 'pending': {
-          // Wait for the next event.
-          if (wakeDownloadLoop) {
-            this.waitingForCheckpointsReady.notify();
+    return new Promise((resolve, reject) => {
+      // Resolves the promise from the current state if possible, returning true if it was.
+      const handleState = () => {
+        const state = this.currentState;
+        switch (state.state) {
+          case 'disconnected':
+            reject(cannotRequestDueToDisconnectedError());
+            return true;
+          case 'ready':
+            resolve(true);
+            return true;
+          case 'error':
+            reject(state.error);
+            return true;
+          case 'pending': {
+            // Wait for the next event.
+            if (wakeDownloadLoop) {
+              this.waitingForCheckpointsReady.notify();
+            }
+            return false;
           }
         }
-      }
-    } while ((await this.stateChanged.waitForEvent(abort)) != null);
+      };
 
-    return false; // waitForEvent returned null, meaning the wait was aborted
+      if (handleState()) {
+        return;
+      }
+
+      let removeListener: () => void;
+      let onAbort: () => void;
+
+      function cleanup() {
+        removeListener();
+        abort.removeEventListener('abort', onAbort);
+      }
+
+      onAbort = () => {
+        resolve(false);
+        cleanup();
+      };
+      removeListener = this.stateChanged.registerListener({
+        stateChanged() {
+          if (handleState()) {
+            cleanup();
+          }
+        }
+      });
+      abort.addEventListener('abort', onAbort);
+    });
   }
 }
 
-export function throwCannotRequestDueToDisconnectedError(): never {
-  throw new Error('Cannot request checkpoints, sync client is disconnected.');
+interface CheckpointStateListener extends BaseListener {
+  stateChanged(): void;
+}
+
+export function cannotRequestDueToDisconnectedError(): Error {
+  return new Error('Cannot request checkpoints, sync client is disconnected.');
 }
 
 export function isCheckpointRequestApplied(status: CoreSyncStatus | null, requestId: string): boolean {

--- a/packages/shared-internals/src/client/sync/stream/CheckpointState.ts
+++ b/packages/shared-internals/src/client/sync/stream/CheckpointState.ts
@@ -1,0 +1,98 @@
+import { asyncNotifier, EventQueue } from '../../../utils/async.js';
+import { CoreSyncStatus } from './core-instruction.js';
+
+export type CheckpointState =
+  | { state: 'pending' }
+  | { state: 'disconnected' }
+  | { state: 'ready' }
+  | { state: 'error'; error: unknown };
+
+const pending: CheckpointState = { state: 'pending' };
+
+export class CheckpointStateSignals {
+  private currentState: CheckpointState = pending;
+  private readonly stateChanged = new EventQueue<CheckpointState>();
+
+  /**
+   * Use to immediately restart another download iteration if it is retry delay when a new checkpoint is requested.
+   */
+  private waitingForCheckpointsReady = asyncNotifier();
+
+  private updateState(state: CheckpointState) {
+    this.currentState = state;
+    this.stateChanged.notify(state);
+  }
+
+  /**
+   * Marks the current download iteration as ended, blocking new checkpoint requests until the seed performed in the
+   * next iteration.
+   */
+  downloadIterationEnded() {
+    this.updateState(pending);
+
+    // Checkpoint waiters called after this should be able to resume the download iteration.
+    this.waitingForCheckpointsReady = asyncNotifier();
+  }
+
+  /**
+   * Marks the sync client as disconnected, failing all outstanding checkpoint requests and preventing new ones.
+   */
+  disconnected() {
+    this.updateState({ state: 'disconnected' });
+  }
+
+  /**
+   * Returns a promise that resolves with the abort signal or when we have a waiter wanting to request a checkpoint.
+   */
+  waitForCheckpointWaiter(signal: AbortSignal) {
+    return this.waitingForCheckpointsReady.waitForNotification(signal);
+  }
+
+  markCheckpointsReady(completion: Promise<void>): Promise<void> {
+    return completion.then(
+      (_) => this.updateState({ state: 'ready' }),
+      (error) => {
+        this.updateState({ state: 'error', error });
+        throw error;
+      }
+    );
+  }
+
+  /**
+   * Waits until a download iteration is active and has seeded the checkpoint state, meaning that checkpoint ids can
+   * safely be allocated.
+   *
+   * @returns Turue if checkpoints are ready, false if aborted.
+   */
+  async waitForCheckpointRequestsReady(abort: AbortSignal, wakeDownloadLoop = true): Promise<boolean> {
+    do {
+      const current = this.currentState;
+
+      switch (current.state) {
+        case 'disconnected':
+          throwCannotRequestDueToDisconnectedError();
+        case 'ready':
+          return true;
+        case 'error':
+          throw current.error;
+        case 'pending': {
+          // Wait for the next event.
+          if (wakeDownloadLoop) {
+            this.waitingForCheckpointsReady.notify();
+          }
+        }
+      }
+    } while ((await this.stateChanged.waitForEvent(abort)) != null);
+
+    return false; // current is null, meaning the wait was aborted
+  }
+}
+
+export function throwCannotRequestDueToDisconnectedError(): never {
+  throw new Error('Cannot request checkpoints, sync client is disconnected.');
+}
+
+export function isCheckpointRequestApplied(status: CoreSyncStatus | null, requestId: string): boolean {
+  const applied = status?.internal_last_applied_checkpoint_request_id;
+  return applied != null && BigInt(applied) >= BigInt(requestId);
+}

--- a/packages/shared-internals/src/client/sync/stream/core-instruction.ts
+++ b/packages/shared-internals/src/client/sync/stream/core-instruction.ts
@@ -25,6 +25,7 @@ export interface LogLine {
 
 export interface EstablishSyncStream {
   request: unknown;
+  checkpoint_request?: CheckpointRequestPayload;
 }
 
 export interface UpdateSyncStatus {
@@ -37,6 +38,7 @@ export interface CoreSyncStatus {
   priority_status: SyncPriorityStatus[];
   downloading: DownloadProgress | null;
   streams: CoreStreamSubscription[];
+  internal_last_applied_checkpoint_request_id?: string;
 }
 
 /// An `ActiveStreamSubscription` from the core extension + serialized progress information.
@@ -71,6 +73,11 @@ export interface BucketProgress {
 
 export interface FetchCredentials {
   did_expire: boolean;
+}
+
+export interface CheckpointRequestPayload {
+  client_id: string;
+  checkpoint_request_id: string;
 }
 
 export function isInterruptingInstruction(instruction: Instruction): instruction is InterruptingInstruction {

--- a/packages/shared-internals/src/utils/stream_transform.ts
+++ b/packages/shared-internals/src/utils/stream_transform.ts
@@ -34,6 +34,7 @@ export function map<T1, T2>(source: SimpleAsyncIterator<T1>, map: (source: T1) =
 
 export interface InjectableIterator<T> extends SimpleAsyncIterator<T> {
   inject(event: T): void;
+  injectError(error: unknown): void;
 }
 
 /**
@@ -54,7 +55,7 @@ export function injectable<T>(source: SimpleAsyncIterator<T>): InjectableIterato
   let pendingSourceEvent: ((w: Waiter) => void) | null = null;
   let sourceFetchInFlight = false;
 
-  let pendingInjectedEvents: T[] = [];
+  let pendingInjectedEvents: PromiseSettledResult<T>[] = [];
 
   const consumeWaiter = () => {
     const pending = waiter;
@@ -102,7 +103,14 @@ export function injectable<T>(source: SimpleAsyncIterator<T>): InjectableIterato
 
         // Second priority: Dispatch injected events
         if (pendingInjectedEvents.length) {
-          return resolve(valueResult(pendingInjectedEvents.shift()!));
+          const event = pendingInjectedEvents.shift()!;
+          if (event.status === 'fulfilled') {
+            resolve(valueResult(event.value));
+          } else {
+            reject(event.reason);
+          }
+
+          return;
         }
 
         // Nothing pending? Fetch from source
@@ -117,7 +125,15 @@ export function injectable<T>(source: SimpleAsyncIterator<T>): InjectableIterato
       if (pending != null) {
         pending.resolve(valueResult(event));
       } else {
-        pendingInjectedEvents.push(event);
+        pendingInjectedEvents.push({ status: 'fulfilled', value: event });
+      }
+    },
+    injectError(error) {
+      const pending = consumeWaiter();
+      if (pending != null) {
+        pending.reject(error);
+      } else {
+        pendingInjectedEvents.push({ status: 'rejected', reason: error });
       }
     }
   };

--- a/packages/shared-internals/tests/client/sync/stream/CheckpointState.test.ts
+++ b/packages/shared-internals/tests/client/sync/stream/CheckpointState.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'vitest';
+import {
+  CheckpointStateSignals,
+  cannotRequestDueToDisconnectedError
+} from '../../../../src/client/sync/stream/CheckpointState.js';
+
+const neverAbort = new AbortController().signal;
+
+describe('CheckpointStateSignals', () => {
+  describe('waitForCheckpointRequestsReady', () => {
+    test('resolves immediately when already ready', async () => {
+      const signals = new CheckpointStateSignals();
+      signals.markCheckpointsReady(Promise.resolve());
+      await Promise.resolve();
+
+      await expect(signals.waitForCheckpointRequestsReady(neverAbort)).resolves.toBe(true);
+    });
+
+    test('rejects when disconnected', async () => {
+      const signals = new CheckpointStateSignals();
+      signals.disconnected();
+
+      await expect(signals.waitForCheckpointRequestsReady(neverAbort)).rejects.toThrow(
+        cannotRequestDueToDisconnectedError().message
+      );
+    });
+
+    test('rejects with the error', async () => {
+      const signals = new CheckpointStateSignals();
+      const error = new Error('boom');
+      signals.markCheckpointsReady(Promise.reject(error)).catch(() => {});
+      await Promise.resolve();
+
+      await expect(signals.waitForCheckpointRequestsReady(neverAbort)).rejects.toThrow('boom');
+    });
+
+    test('can be aborted', async () => {
+      const signals = new CheckpointStateSignals();
+      const abort = new AbortController();
+
+      const pendingResult = signals.waitForCheckpointRequestsReady(abort.signal);
+      abort.abort();
+
+      await expect(pendingResult).resolves.toBe(false);
+    });
+
+    test('supports concurrent waiters', async () => {
+      const signals = new CheckpointStateSignals();
+
+      const first = signals.waitForCheckpointRequestsReady(neverAbort);
+      const second = signals.waitForCheckpointRequestsReady(neverAbort);
+      await Promise.resolve();
+
+      signals.markCheckpointsReady(Promise.resolve());
+
+      await expect(first).resolves.toBe(true);
+      await expect(second).resolves.toBe(true);
+    });
+  });
+
+  test('waitForCheckpointWaiter is notified when a caller starts waiting while pending', async () => {
+    const signals = new CheckpointStateSignals();
+
+    const waiterNotified = signals.waitForCheckpointWaiter(neverAbort);
+    signals.waitForCheckpointRequestsReady(neverAbort);
+
+    await expect(waiterNotified).resolves.toBeUndefined();
+  });
+
+  test('does not notify waitForCheckpointWaiter when wakeDownloadLoop is false', async () => {
+    const signals = new CheckpointStateSignals();
+    const abort = new AbortController();
+
+    let resolved = false;
+    const waiterNotified = signals.waitForCheckpointWaiter(abort.signal).then(() => {
+      resolved = true;
+    });
+    signals.waitForCheckpointRequestsReady(neverAbort, false);
+    await Promise.resolve();
+
+    expect(resolved).toBe(false);
+
+    abort.abort();
+    await waiterNotified;
+    expect(resolved).toBe(true);
+  });
+});

--- a/packages/shared-internals/tests/utils/stream_transform.test.ts
+++ b/packages/shared-internals/tests/utils/stream_transform.test.ts
@@ -93,6 +93,36 @@ describe('injectable', () => {
     }
   });
 
+  test('forwards injected errors', async () => {
+    let pendingCall: ((value: IteratorResult<number>) => void) | null = null;
+    const stream = injectable<number>({
+      next() {
+        return new Promise((resolve) => (pendingCall = resolve));
+      }
+    });
+
+    // injectError() before next() is called: error is queued and rejects the next next() call.
+    stream.injectError(new Error('queued error'));
+    await expect(stream.next()).rejects.toThrow('queued error');
+
+    // injectError() while a next() call is pending: rejects that pending call directly.
+    const next = stream.next();
+    expect(pendingCall).not.toBeNull();
+
+    stream.injectError(new Error('pending error'));
+    await expect(next).rejects.toThrow('pending error');
+
+    // The stream keeps working after an injected error has been consumed.
+    {
+      const next2 = stream.next();
+      expect(pendingCall).not.toBeNull();
+      pendingCall!(valueResult(3));
+      pendingCall = null;
+
+      expect(await next2).toStrictEqual(valueResult(3));
+    }
+  });
+
   test('does not start a second source fetch while one is already in flight', async () => {
     const outstandingEvents: Array<(value: IteratorResult<number>) => void> = [];
 

--- a/packages/web/src/db/PowerSyncDatabase.ts
+++ b/packages/web/src/db/PowerSyncDatabase.ts
@@ -143,10 +143,6 @@ export class WebPowerSyncDatabase extends BasePowerSyncDatabase<WebPowerSyncData
     return super.resolveOfflineSyncStatus();
   }
 
-  protected generateBucketStorageAdapter(): BucketStorageAdapter {
-    return new SqliteBucketStorage(this.database, this.logger);
-  }
-
   protected async runExclusive<T>(cb: () => Promise<T>) {
     if (this.resolvedOpenOptions.ssrMode) {
       return WebPowerSyncDatabase.SHARED_MUTEX.runExclusive(cb);
@@ -161,15 +157,8 @@ export class WebPowerSyncDatabase extends BasePowerSyncDatabase<WebPowerSyncData
     const remote = new WebRemote(connector, this.logger);
     const syncOptions: WebStreamingSyncImplementationOptions = {
       ...(this.options as {}),
-      ...options,
-      adapter: this.bucketStorageAdapter,
-      remote,
-      uploadCrud: async () => {
-        await this.waitForReady();
-        await connector.uploadData(this);
-      },
-      identifier: this.database.name,
-      logger: this.logger
+      ...this.commonSyncOptions(connector, options),
+      remote
     };
 
     if (this.resolvedOpenOptions.ssrMode) {

--- a/packages/web/src/db/sync/SSRWebStreamingSyncImplementation.ts
+++ b/packages/web/src/db/sync/SSRWebStreamingSyncImplementation.ts
@@ -45,20 +45,6 @@ export class SSRStreamingSyncImplementation extends BaseObserver implements Stre
   }
 
   /**
-   * Returns a placeholder checkpoint. This should not be used.
-   */
-  async getWriteCheckpoint() {
-    return '1';
-  }
-
-  /**
-   * The SSR mode adapter will never complete syncing.
-   */
-  async hasCompletedSync() {
-    return false;
-  }
-
-  /**
    * This is a no-op in SSR mode.
    */
   triggerCrudUpload() {}

--- a/packages/web/src/db/sync/SharedWebStreamingSyncImplementation.ts
+++ b/packages/web/src/db/sync/SharedWebStreamingSyncImplementation.ts
@@ -59,6 +59,10 @@ class SharedSyncClientProvider extends AbstractSharedSyncClientProvider {
     await this.options.uploadCrud();
   }
 
+  override async postCheckpointRequest(clientId: string, requestId: string): Promise<string | null> {
+    return await this.options.postCheckpointRequest(clientId, requestId);
+  }
+
   get logger() {
     return this.options.logger;
   }
@@ -185,11 +189,6 @@ export class SharedWebStreamingSyncImplementation extends WebStreamingSyncImplem
   async disconnect(): Promise<void> {
     await this.waitForReady();
     return this.syncManager.disconnect();
-  }
-
-  async getWriteCheckpoint(): Promise<string> {
-    await this.waitForReady();
-    return this.syncManager.getWriteCheckpoint();
   }
 
   async dispose(): Promise<void> {

--- a/packages/web/src/worker/sync/AbstractSharedSyncClientProvider.ts
+++ b/packages/web/src/worker/sync/AbstractSharedSyncClientProvider.ts
@@ -8,6 +8,7 @@ export abstract class AbstractSharedSyncClientProvider {
   abstract fetchCredentials(): Promise<PowerSyncCredentials | null>;
   abstract invalidateCredentials(): void;
   abstract uploadCrud(): Promise<void>;
+  abstract postCheckpointRequest(clientId: string, requestId: string): Promise<string | null>;
   abstract statusChanged(status: SyncStatusJson): void;
   abstract getDBWorkerPort(): Promise<MessagePort>;
 

--- a/packages/web/src/worker/sync/SharedSyncImplementation.ts
+++ b/packages/web/src/worker/sync/SharedSyncImplementation.ts
@@ -60,7 +60,7 @@ export type ManualSharedSyncPayload = {
 export type SharedSyncInitOptions = {
   streamOptions: Omit<
     WebStreamingSyncImplementationOptions,
-    'adapter' | 'uploadCrud' | 'remote' | 'subscriptions' | 'logger'
+    'adapter' | 'uploadCrud' | 'postCheckpointRequest' | 'remote' | 'subscriptions' | 'logger'
   >;
   dbParams: ResolvedWebSQLOpenOptions;
   enableBroadcastLogs: boolean;
@@ -86,14 +86,6 @@ export type WrappedSyncPort = {
 };
 
 /**
- * @internal
- */
-export type RemoteOperationAbortController = {
-  controller: AbortController;
-  activePort: WrappedSyncPort;
-};
-
-/**
  * HACK: The shared implementation wraps and provides its own
  * PowerSyncBackendConnector when generating the streaming sync implementation.
  * We provide this unused placeholder when connecting with the ConnectionManager.
@@ -109,9 +101,6 @@ export class SharedSyncImplementation extends BaseObserver<SharedSyncImplementat
 
   protected isInitialized: Promise<void>;
   protected statusListener?: () => void;
-
-  protected fetchCredentialsController?: RemoteOperationAbortController;
-  protected uploadDataController?: RemoteOperationAbortController;
 
   protected syncParams: SharedSyncInitOptions | null;
   protected lastConnectOptions: ResolvedSyncOptions | undefined;
@@ -334,18 +323,6 @@ export class SharedSyncImplementation extends BaseObserver<SharedSyncImplementat
       // Remove from the list of active ports
       this.ports.splice(index, 1);
 
-      /**
-       * The port might currently be in use. Any active functions might
-       * not resolve. Abort them here.
-       */
-      [this.fetchCredentialsController, this.uploadDataController].forEach((abortController) => {
-        if (abortController?.activePort == port) {
-          abortController!.controller.abort(
-            new AbortOperation('Closing pending requests after client port is removed')
-          );
-        }
-      });
-
       // Close the worker wrapped database connection, we can't accurately rely on this connection
       for (const closeListener of trackedPort.closeListeners) {
         await closeListener();
@@ -360,12 +337,6 @@ export class SharedSyncImplementation extends BaseObserver<SharedSyncImplementat
   triggerCrudUpload() {
     this.withSyncImplementation(async (sync) => {
       sync.triggerCrudUpload();
-    });
-  }
-
-  async getWriteCheckpoint(): Promise<string> {
-    return this.withSyncImplementation(async (sync) => {
-      return sync.getWriteCheckpoint();
     });
   }
 
@@ -411,63 +382,53 @@ export class SharedSyncImplementation extends BaseObserver<SharedSyncImplementat
               this.logger.log({ level: LogLevels.error, message: 'error invalidating credentials', error });
             }
           },
-          fetchCredentials: async () => {
-            const lastPort = await this.getLastWrappedPort();
-            if (!lastPort) {
-              throw new Error('No client port found to fetch credentials');
-            }
-            return new Promise(async (resolve, reject) => {
-              const abortController = new AbortController();
-              this.fetchCredentialsController = {
-                controller: abortController,
-                activePort: lastPort
-              };
+          fetchCredentials: () => {
+            return this.#useConnector((port) => {
+              this.logger.log({
+                level: LogLevels.info,
+                message: 'calling the last port client provider for credentials'
+              });
 
-              abortController.signal.onabort = reject;
-              try {
-                this.logger.log({
-                  level: LogLevels.info,
-                  message: 'calling the last port client provider for credentials'
-                });
-                resolve(await lastPort.clientProvider.fetchCredentials());
-              } catch (ex) {
-                reject(ex);
-              } finally {
-                this.fetchCredentialsController = undefined;
-              }
-            });
+              return port.clientProvider.fetchCredentials();
+            }, 'fetchCredentials');
           }
         },
         this.logger
       ),
-      uploadCrud: async () => {
-        const lastPort = await this.getLastWrappedPort();
-        if (!lastPort) {
-          throw new Error('No client port found to upload crud');
-        }
-
-        return new Promise(async (resolve, reject) => {
-          const abortController = new AbortController();
-          this.uploadDataController = {
-            controller: abortController,
-            activePort: lastPort
-          };
-
-          // Resolving will make it retry
-          abortController.signal.onabort = () => resolve();
-          try {
-            resolve(await lastPort.clientProvider.uploadCrud());
-          } catch (ex) {
-            reject(ex);
-          } finally {
-            this.uploadDataController = undefined;
-          }
-        });
+      uploadCrud: () => {
+        return this.#useConnector((port) => port.clientProvider.uploadCrud(), 'uploadCrud');
+      },
+      postCheckpointRequest: (clientId, requestId) => {
+        return this.#useConnector(
+          (port) => port.clientProvider.postCheckpointRequest(clientId, requestId),
+          'postCheckpointRequest'
+        );
       },
       ...syncParams.streamOptions,
       subscriptions: this.subscriptions,
       // Logger cannot be transferred just yet
       logger: this.logger
+    });
+  }
+
+  async #useConnector<T>(inner: (port: WrappedSyncPort) => Promise<T>, debugContext: string): Promise<T> {
+    const lastPort = await this.getLastWrappedPort();
+    if (!lastPort) {
+      throw new Error(`No client port found for ${debugContext}`);
+    }
+
+    return new Promise((resolve, reject) => {
+      function portClosed() {
+        reject(new Error(`Tab closed while handling ${debugContext}`));
+      }
+
+      lastPort.closeListeners.push(portClosed);
+
+      inner(lastPort)
+        .then(resolve, reject)
+        .finally(() => {
+          lastPort.closeListeners.splice(lastPort.closeListeners.indexOf(portClosed), 1);
+        });
     });
   }
 

--- a/packages/web/src/worker/sync/WorkerClient.ts
+++ b/packages/web/src/worker/sync/WorkerClient.ts
@@ -78,10 +78,6 @@ export class WorkerClient {
     return this.sync.setParams(params);
   }
 
-  getWriteCheckpoint() {
-    return this.sync.getWriteCheckpoint();
-  }
-
   connect(options: ResolvedSyncOptions, schema: any) {
     return this.sync.connect(options, schema);
   }

--- a/packages/web/tests/src/db/PowersyncDatabase.test.ts
+++ b/packages/web/tests/src/db/PowersyncDatabase.test.ts
@@ -1,10 +1,9 @@
-import { LogLevels, LogRecord, PowerSyncDatabase } from '@powersync/web';
+import { LogLevels, LogRecord, PowerSyncBackendConnector, PowerSyncDatabase } from '@powersync/web';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { TEST_SCHEMA } from '../../utils/test-schema.js';
 
 describe('PowerSyncDatabase', () => {
   let db: PowerSyncDatabase;
-  let mockConnector: any;
   let mockLogger: Mock<(record: LogRecord) => void>;
 
   beforeEach(() => {
@@ -26,7 +25,7 @@ describe('PowerSyncDatabase', () => {
 
   describe('connect', () => {
     it('should log debug message when attempting to connect', async () => {
-      await db.connect(mockConnector);
+      await db.connect({} as PowerSyncBackendConnector);
       expect(mockLogger).toHaveBeenCalledWith({
         level: LogLevels.debug,
         message: 'Attempting to connect to PowerSync instance'

--- a/packages/web/tests/stream.test.ts
+++ b/packages/web/tests/stream.test.ts
@@ -24,14 +24,30 @@ describe('Streaming', { sequential: true }, () => {
     {
       sequential: true
     },
-    describeStreamingTests((syncOptions) =>
-      generateConnectedDatabase(
-        {
-          logger
-        },
-        syncOptions
-      )
-    )
+    () => {
+      describeStreamingTests((syncOptions) =>
+        generateConnectedDatabase(
+          {
+            logger
+          },
+          syncOptions
+        )
+      )();
+
+      it('can use custom checkpoint requests', async () => {
+        const didRequestCheckpoint = Promise.withResolvers<void>();
+        const connector = new (class extends TestConnector {
+          async postCheckpointRequest(_clientId: string, requestId: string) {
+            expect(requestId).toStrictEqual('1');
+            didRequestCheckpoint.resolve();
+
+            return requestId;
+          }
+        })();
+        await generateConnectedDatabase({ logger }, { checkpointMode: 'requests' }, connector);
+        await didRequestCheckpoint.promise;
+      });
+    }
   );
 
   describe(

--- a/packages/web/tests/utils/MockStreamOpenFactory.ts
+++ b/packages/web/tests/utils/MockStreamOpenFactory.ts
@@ -138,6 +138,13 @@ export class MockedStreamPowerSync extends PowerSyncDatabase {
         await this.waitForReady();
         await connector.uploadData(this);
       },
+      postCheckpointRequest: (clientId, requestId) => {
+        if (connector.postCheckpointRequest) {
+          return this.waitForReady().then((_) => connector.postCheckpointRequest!(clientId, requestId));
+        }
+
+        return null;
+      },
       identifier: this.database.name,
       subscriptions: [],
       serializedSchema: options.serializedSchema

--- a/packages/web/tests/utils/MockStreamOpenFactory.ts
+++ b/packages/web/tests/utils/MockStreamOpenFactory.ts
@@ -55,11 +55,19 @@ export class MockRemote extends AbstractRemote {
     throw new Error('Not implemented');
   }
 
-  async get(path: string, headers?: Record<string, string> | undefined): Promise<any> {
-    // mock a response for write checkpoint API
-    if (path.includes('checkpoint')) {
+  override async fetchAndDecodeJson({
+    path
+  }: {
+    path: string;
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  }): Promise<any> {
+    if (path.includes('checkpoint2.json')) {
       return this.generateCheckpoint();
     }
+
     throw new Error('Not implemented');
   }
 
@@ -94,7 +102,7 @@ export class MockRemote extends AbstractRemote {
     throw new Error('Mocked WebRemote does not support WebSockets');
   }
 
-  async fetchStream(options: SyncStreamOptions): Promise<SimpleAsyncIterator<Uint8Array | string>> {
+  override async fetchStream(options: SyncStreamOptions): Promise<SimpleAsyncIterator<Uint8Array | string>> {
     const mockResponse = await this.postStreaming(options.path, options.data, options.abortSignal);
     const mockReader = mockResponse.getReader();
     options.abortSignal?.addEventListener('abort', async () => {

--- a/packages/web/tests/utils/generateConnectedDatabase.ts
+++ b/packages/web/tests/utils/generateConnectedDatabase.ts
@@ -1,5 +1,6 @@
 import {
   DatabaseSource,
+  PowerSyncBackendConnector,
   PowerSyncLogger,
   SQLOpenFactory,
   Schema,
@@ -53,7 +54,8 @@ export function generateDefaultOptions(options: GenerateConnectedDatabaseOptions
 
 export async function generateConnectedDatabase(
   databaseOptions?: GenerateConnectedDatabaseOptions,
-  syncOptions?: SyncOptions
+  syncOptions?: SyncOptions,
+  connector?: PowerSyncBackendConnector
 ) {
   const resolvedOptions = generateDefaultOptions(databaseOptions ?? {});
 
@@ -62,7 +64,7 @@ export async function generateConnectedDatabase(
    * Required since we cannot extend multiple classes.
    */
   const callbacks: Map<string, () => void> = new Map();
-  const connector = new TestConnector();
+  connector ??= new TestConnector();
   const uploadSpy = vi.spyOn(connector, 'uploadData');
   const remote = new MockRemote(connector, defaultTestLogger, () => callbacks.forEach((c) => c()));
 

--- a/packages/web/tests/utils/mockSyncServiceTest.ts
+++ b/packages/web/tests/utils/mockSyncServiceTest.ts
@@ -24,7 +24,9 @@ export const AppSchema = new Schema({
 });
 
 export type MockedTestConnector = {
-  [Key in keyof PowerSyncBackendConnector]: MockedFunction<PowerSyncBackendConnector[Key]>;
+  [Key in keyof Omit<PowerSyncBackendConnector, 'postCheckpointRequest'>]: MockedFunction<
+    PowerSyncBackendConnector[Key]
+  >;
 };
 /**
  * Creates a test connector with vi.fn implementations for testing.

--- a/tools/diagnostics-app/src/library/powersync/ConnectionManager.ts
+++ b/tools/diagnostics-app/src/library/powersync/ConnectionManager.ts
@@ -140,6 +140,9 @@ export async function connect() {
     uploadCrud: async () => {
       // No-op
     },
+    postCheckpointRequest() {
+      return null; // No-op
+    },
     identifier: 'diagnostics',
     subscriptions: [],
     logger: baseLogger,


### PR DESCRIPTION
This adds an option making the JS SDKs use the new checkpoint request protocol described in https://github.com/orgs/powersync-ja/discussions/317. While that discussion contains all the relevant context, it basically boils down to flaws in the current `/write-checkpoint2.json` request used to request write checkpoints after uploads. Requested write checkpoints are embedded in the sync protocol, allowing clients to recognize when their local writes should have synced back down again, at which point downloaded changes can be applied.

`/write-checkpoint2.json` has two flaws fixed by the new protocol:

1. The sequence of write checkpoints needs to increment at every request for every `(device_id, user_id)` pair. This means the service can't ever delete write checkpoint state.
2. When a client switches users, that changes the `(device_id, user_id)` pair which means the next write checkpoint might disrupt the sequence. Nothing in the client is prepared for that, and this can lead to the sync client not applying changes.

The new protocol replaces `GET /write-checkpoint2.json` with `POST /sync/checkpoint-request`. The key change is that the client includes an expected counter in the request, the service uses that value or its own (whichever is higher). This fixes both problems, but requires a few implementation changes:

1. As older service versions don't support this, it needs to be opt-in.
2. By the design of the core extension, new checkpoint requests using this format can only be posted when a sync iteration is active _and_ that iteration has posted its expected counter to the service (which makes sure that subsequent target checkpoints we request after uploads use the reconciled counter state).
3. We need to keep supporting custom checkpoints for team/enterprise customers. Because the SDK can now fetch these proactively, this adds an optional `postCheckpointRequest` to backend connectors.
4. Another change is that once we have a checkpoint request, we should keep posting it if it hasn't been applied yet. This is relatively cheap, ensures this shows up in service logs, and acts as a catch-all for network failures which might have gotten the checkpoint sequence out-of-sync.

Note that this does not add [checkpoint requests](https://docs.powersync.com/client-sdks/advanced/checkpoint-requests), I will add support for those in a follow-up PR.

AI use disclosure: I used Claude Code to help with simpler tests and to self-review this.