### PR TITLE
Explicit checkpoint requests

### DIFF
--- a/.changeset/ninety-nails-raise.md
+++ b/.changeset/ninety-nails-raise.md
@@ -8,4 +8,8 @@
 '@powersync/web': minor
 ---
 
-Add `checkpointMode` option to `ConnectOptions` to use a more efficient way to request checkpoints from PowerSync after uploads.
+Add `requestCheckpoint()` to `PowerSyncDatabase` to request an explicit sync acknowledgement.
+This feature requires a new `checkpointMode: 'requests'` option on `ConnectOptions` switching to a more
+efficient way to request checkpoints from the PowerSync service.
+
+For more details on this feature, see [Sync Catch-Up](https://docs.powersync.com/client-sdks/advanced/checkpoint-requests).

--- a/demos/react-native-supabase-todolist/.env
+++ b/demos/react-native-supabase-todolist/.env
@@ -4,3 +4,6 @@ EXPO_PUBLIC_SUPABASE_ANON_KEY=foo
 EXPO_PUBLIC_SUPABASE_BUCKET= # Optional. Only required when syncing attachments and using Supabase Storage. See packages/powersync-attachments.
 EXPO_PUBLIC_POWERSYNC_URL=https://foo.powersync.journeyapps.com
 EXPO_PUBLIC_EAS_PROJECT_ID=foo # Optional. Only required when using EAS.
+# Whether to use https://docs.powersync.com/client-sdks/advanced/checkpoint-requests to implement a swipe-to-refresh
+# pattern with explicit sync.
+EXPO_PUBLIC_USE_POWERSYNC_CHECKPOINT_REQUESTS=false

--- a/demos/react-native-supabase-todolist/app/views/todos/lists.tsx
+++ b/demos/react-native-supabase-todolist/app/views/todos/lists.tsx
@@ -1,16 +1,18 @@
 import * as React from 'react';
 import { StatusBar } from 'expo-status-bar';
-import { ScrollView, View } from 'react-native';
+import { Alert, RefreshControl, ScrollView, View } from 'react-native';
 import { FAB } from '@rneui/themed';
 import { MaterialIcons } from '@expo/vector-icons';
 import { prompt } from '../../../library/utils/prompt';
+import { useAbortSignal } from '../../../library/utils/useAbortSignal';
 
 import { router, Stack } from 'expo-router';
 import { LIST_TABLE, TODO_TABLE, ListRecord } from '../../../library/powersync/AppSchema';
 import { useSystem } from '../../../library/powersync/system';
-import { useQuery } from '@powersync/react-native';
+import { useQuery, useStatus } from '@powersync/react-native';
 import { ListItemWidget } from '../../../library/widgets/ListItemWidget';
 import { GuardBySync } from '../../../library/widgets/GuardBySync';
+import { AppConfig } from '../../../library/supabase/AppConfig';
 
 const description = (total: number, completed: number = 0) => {
   return `${total - completed} pending, ${completed} completed`;
@@ -18,6 +20,9 @@ const description = (total: number, completed: number = 0) => {
 
 const ListsViewWidget: React.FC = () => {
   const system = useSystem();
+  const status = useStatus();
+  const [isRefreshing, setIsRefreshing] = React.useState(false);
+  const abortSignal = useAbortSignal();
   const { data: listRecords } = useQuery<ListRecord & { total_tasks: number; completed_tasks: number }>(`
       SELECT
         ${LIST_TABLE}.*, COUNT(${TODO_TABLE}.id) AS total_tasks, SUM(CASE WHEN ${TODO_TABLE}.completed = true THEN 1 ELSE 0 END) as completed_tasks
@@ -52,6 +57,19 @@ const ListsViewWidget: React.FC = () => {
     });
   };
 
+  const explicitSync = async () => {
+    try {
+      setIsRefreshing(true);
+      const checkpoint = await system.powersync.requestCheckpoint();
+      await checkpoint.waitForSync({ signal: abortSignal });
+    } catch (e) {
+      console.log('Error in explicit sync request', e);
+      Alert.alert('Error', 'Failed to reach checkpoint.');
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
   return (
     <View style={{ flex: 1, flexGrow: 1 }}>
       <Stack.Screen
@@ -80,21 +98,28 @@ const ListsViewWidget: React.FC = () => {
         }}
       />
       <GuardBySync>
-        <ScrollView key={'lists'} style={{ maxHeight: '90%' }}>
+        <ScrollView
+          key={'lists'}
+          style={{ maxHeight: '90%' }}
+          refreshControl={
+            AppConfig.usePowerSyncCheckpointRequests && status?.connected ? (
+              <RefreshControl refreshing={isRefreshing} onRefresh={explicitSync} />
+            ) : undefined
+          }>
           {listRecords.map((r) => (
-              <ListItemWidget
-                key={r.id}
-                title={r.name!}
-                description={description(r.total_tasks, r.completed_tasks)}
-                onDelete={() => deleteList(r.id)}
-                onPress={() => {
-                  router.push({
-                    pathname: 'views/todos/edit/[id]',
-                    params: { id: r.id }
-                  });
-                }}
-              />
-            ))}
+            <ListItemWidget
+              key={r.id}
+              title={r.name!}
+              description={description(r.total_tasks, r.completed_tasks)}
+              onDelete={() => deleteList(r.id)}
+              onPress={() => {
+                router.push({
+                  pathname: 'views/todos/edit/[id]',
+                  params: { id: r.id }
+                });
+              }}
+            />
+          ))}
         </ScrollView>
       </GuardBySync>
 

--- a/demos/react-native-supabase-todolist/library/powersync/system.ts
+++ b/demos/react-native-supabase-todolist/library/powersync/system.ts
@@ -90,7 +90,9 @@ export class System {
 
   async init() {
     await this.powersync.init();
-    await this.powersync.connect(this.supabaseConnector);
+    await this.powersync.connect(this.supabaseConnector, {
+      checkpointMode: AppConfig.usePowerSyncCheckpointRequests ? 'requests' : 'legacy'
+    });
 
     if (this.photoAttachmentQueue) {
       await this.photoAttachmentQueue.startSync();

--- a/demos/react-native-supabase-todolist/library/supabase/AppConfig.ts
+++ b/demos/react-native-supabase-todolist/library/supabase/AppConfig.ts
@@ -2,5 +2,6 @@ export const AppConfig = {
   supabaseUrl: process.env.EXPO_PUBLIC_SUPABASE_URL,
   supabaseAnonKey: process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY,
   supabaseBucket: process.env.EXPO_PUBLIC_SUPABASE_BUCKET || '',
-  powersyncUrl: process.env.EXPO_PUBLIC_POWERSYNC_URL
+  powersyncUrl: process.env.EXPO_PUBLIC_POWERSYNC_URL,
+  usePowerSyncCheckpointRequests: process.env.EXPO_PUBLIC_USE_POWERSYNC_CHECKPOINT_REQUESTS === 'true'
 };

--- a/demos/react-native-supabase-todolist/library/utils/useAbortSignal.ts
+++ b/demos/react-native-supabase-todolist/library/utils/useAbortSignal.ts
@@ -1,0 +1,11 @@
+import { useEffect, useMemo } from 'react';
+
+export function useAbortSignal(): AbortSignal {
+  const controller = useMemo(() => new AbortController(), []);
+
+  useEffect(() => {
+    return () => controller.abort();
+  }, [controller]);
+
+  return controller.signal;
+}

--- a/demos/react-native-supabase-todolist/process-env.d.ts
+++ b/demos/react-native-supabase-todolist/process-env.d.ts
@@ -9,6 +9,7 @@ declare global {
       EXPO_PUBLIC_SUPABASE_BUCKET: string;
       EXPO_PUBLIC_POWERSYNC_URL: string;
       EXPO_PUBLIC_EAS_PROJECT_ID: string;
+      EXPO_PUBLIC_USE_POWERSYNC_CHECKPOINT_REQUESTS: 'false' | 'true';
     }
   }
 }

--- a/demos/react-supabase-todolist/.env.local.template
+++ b/demos/react-supabase-todolist/.env.local.template
@@ -3,3 +3,6 @@
 VITE_SUPABASE_URL=https://foo.supabase.co
 VITE_SUPABASE_ANON_KEY=foo
 VITE_POWERSYNC_URL=https://foo.powersync.journeyapps.com
+# Whether to use https://docs.powersync.com/client-sdks/advanced/checkpoint-requests to implement an explicit refresh
+# button for sync.
+VITE_USE_POWERSYNC_CHECKPOINT_REQUESTS=false

--- a/demos/react-supabase-todolist/src/app/utils/helpers.ts
+++ b/demos/react-supabase-todolist/src/app/utils/helpers.ts
@@ -1,3 +1,5 @@
+import { useEffect, useMemo } from 'react';
+
 type ExtractGenerator = (jsonColumnName: string, columnName: string) => string;
 
 export enum ExtractType {
@@ -34,3 +36,13 @@ export const generateJsonExtracts = (type: ExtractType, jsonColumnName: string, 
 
   return columns.map((column) => generator(jsonColumnName, column)).join(', ');
 };
+
+export function useAbortSignal(): AbortSignal {
+  const controller = useMemo(() => new AbortController(), []);
+
+  useEffect(() => {
+    return () => controller.abort();
+  }, [controller]);
+
+  return controller.signal;
+}

--- a/demos/react-supabase-todolist/src/app/views/layout.tsx
+++ b/demos/react-supabase-todolist/src/app/views/layout.tsx
@@ -1,15 +1,19 @@
 import { LOGIN_ROUTE, SQL_CONSOLE_ROUTE, TODO_LISTS_ROUTE } from '@/app/router';
 import { useNavigationPanel } from '@/components/navigation/NavigationPanelContext';
-import { useSupabase } from '@/components/providers/SystemProvider';
+import { syncOptions, useCheckpointRequests, useSupabase } from '@/components/providers/SystemProvider';
 import ChecklistRtlIcon from '@mui/icons-material/ChecklistRtl';
 import ExitToAppIcon from '@mui/icons-material/ExitToApp';
 import MenuIcon from '@mui/icons-material/Menu';
 import NorthIcon from '@mui/icons-material/North';
+import RefreshIconBase from '@mui/icons-material/Refresh';
 import SignalWifiOffIcon from '@mui/icons-material/SignalWifiOff';
 import SouthIcon from '@mui/icons-material/South';
 import TerminalIcon from '@mui/icons-material/Terminal';
 import WifiIcon from '@mui/icons-material/Wifi';
+import { css, keyframes } from '@emotion/react';
 import {
+  Alert,
+  AlertColor,
   AppBar,
   Box,
   Divider,
@@ -22,13 +26,16 @@ import {
   ListItemText,
   Menu,
   MenuItem,
+  Snackbar,
   Toolbar,
+  Tooltip,
   Typography,
   styled
 } from '@mui/material';
 import { usePowerSync, useStatus } from '@powersync/react';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAbortSignal } from '../utils/helpers';
 
 export default function ViewsLayout({ children }: { children: React.ReactNode }) {
   const powerSync = usePowerSync();
@@ -40,6 +47,28 @@ export default function ViewsLayout({ children }: { children: React.ReactNode })
   const { title } = useNavigationPanel();
 
   const [connectionAnchor, setConnectionAnchor] = React.useState<null | HTMLElement>(null);
+  const [explicitRefresh, setExplicitRefresh] = React.useState<'working' | 'success' | 'error' | null>(null);
+  const snackbarStatus = useMemo<{ severity: AlertColor; message: string } | undefined>(() => {
+    if (explicitRefresh == 'success') {
+      return { severity: 'success', message: 'Synced successfully!' };
+    } else if (explicitRefresh == 'error') {
+      return { severity: 'error', message: 'Sync checkpoint failed' };
+    }
+  }, [explicitRefresh]);
+  const abortSignal = useAbortSignal();
+
+  async function explicitSync() {
+    setExplicitRefresh('working');
+
+    try {
+      const checkpoint = await powerSync.requestCheckpoint();
+      await checkpoint.waitForSync({ signal: abortSignal });
+      setExplicitRefresh('success');
+    } catch (e) {
+      console.log('Error in explicit sync request', e);
+      setExplicitRefresh('error');
+    }
+  }
 
   const NAVIGATION_ITEMS = React.useMemo(
     () => [
@@ -82,6 +111,13 @@ export default function ViewsLayout({ children }: { children: React.ReactNode })
           <Box sx={{ flexGrow: 1 }}>
             <Typography>{title}</Typography>
           </Box>
+          {status?.connected && useCheckpointRequests === 'true' && (
+            <Tooltip title="Request explicit sync">
+              <IconButton size="small" color="inherit" aria-label="refresh" onClick={explicitSync}>
+                <S.RefreshIcon spinning={explicitRefresh == 'working'} />
+              </IconButton>
+            </Tooltip>
+          )}
           <NorthIcon sx={{ marginRight: '-10px' }} color={status?.uploading ? 'primary' : 'inherit'} />
           <SouthIcon color={status?.downloading ? 'primary' : 'inherit'} />
           <Box
@@ -109,7 +145,7 @@ export default function ViewsLayout({ children }: { children: React.ReactNode })
               <MenuItem
                 onClick={(event) => {
                   setConnectionAnchor(null);
-                  powerSync.connect(supabase);
+                  powerSync.connect(supabase, syncOptions);
                 }}>
                 Connect
               </MenuItem>
@@ -137,11 +173,35 @@ export default function ViewsLayout({ children }: { children: React.ReactNode })
         </List>
       </Drawer>
       <S.MainBox>{children}</S.MainBox>
+      <Snackbar
+        open={snackbarStatus != null}
+        autoHideDuration={4000}
+        onClose={() => setExplicitRefresh(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}>
+        <Alert onClose={() => setExplicitRefresh(null)} severity={snackbarStatus?.severity} sx={{ width: '100%' }}>
+          {snackbarStatus?.message}
+        </Alert>
+      </Snackbar>
     </S.MainBox>
   );
 }
 
 namespace S {
+  const spin = keyframes`
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  `;
+
+  export const RefreshIcon = styled(RefreshIconBase, {
+    shouldForwardProp: (prop: string) => prop !== 'spinning'
+  })<{ spinning: boolean }>`
+    animation: ${(props: { spinning: boolean }) => (props.spinning ? css`${spin} 1s linear infinite` : 'none')};
+  `;
+
   export const MainBox = styled(Box)`
     flex-grow: 1;
   `;

--- a/demos/react-supabase-todolist/src/components/providers/SystemProvider.tsx
+++ b/demos/react-supabase-todolist/src/components/providers/SystemProvider.tsx
@@ -8,8 +8,8 @@ import {
   LogLevels,
   DifferentialWatchedQuery,
   PowerSyncDatabase,
-  WASQLiteOpenFactory,
-  WASQLiteVFS
+  WASQLiteVFS,
+  SyncOptions
 } from '@powersync/web';
 import React, { Suspense } from 'react';
 import { NavigationPanelContextProvider } from '../navigation/NavigationPanelContext';
@@ -26,7 +26,7 @@ export const db = new PowerSyncDatabase({
     dbFilename: 'example.db',
     vfs: WASQLiteVFS.OPFSCoopSyncVFS,
     databaseWorkerLogLevel: LogLevels.debug,
-    enableMultiTabs: typeof SharedWorker !== 'undefined',
+    enableMultiTabs: typeof SharedWorker !== 'undefined'
   },
   logger
 });
@@ -35,6 +35,19 @@ export type EnhancedListRecord = ListRecord & { total_tasks: number; completed_t
 
 export type QueryStore = {
   lists: DifferentialWatchedQuery<EnhancedListRecord>;
+};
+
+/**
+ * Whether to use [checkpoint requests](https://docs.powersync.com/client-sdks/advanced/checkpoint-requests) to add an
+ * explicit sync button to this demo.
+ */
+export const useCheckpointRequests = import.meta.env.VITE_USE_POWERSYNC_CHECKPOINT_REQUESTS;
+
+export const syncOptions: SyncOptions = {
+  appMetadata: {
+    app_version: APP_VERSION
+  },
+  checkpointMode: useCheckpointRequests ? 'requests' : 'legacy'
 };
 
 const QueryStore = React.createContext<QueryStore | null>(null);
@@ -77,13 +90,9 @@ export const SystemProvider = ({ children }: { children: React.ReactNode }) => {
 
     powerSync.init();
     const l = connector.registerListener({
-      initialized: () => { },
+      initialized: () => {},
       sessionStarted: () => {
-        powerSync.connect(connector, {
-          appMetadata: {
-            app_version: APP_VERSION
-          }
-        });
+        powerSync.connect(connector, syncOptions);
       }
     });
 

--- a/demos/react-supabase-todolist/src/components/providers/SystemProvider.tsx
+++ b/demos/react-supabase-todolist/src/components/providers/SystemProvider.tsx
@@ -41,7 +41,7 @@ export type QueryStore = {
  * Whether to use [checkpoint requests](https://docs.powersync.com/client-sdks/advanced/checkpoint-requests) to add an
  * explicit sync button to this demo.
  */
-export const useCheckpointRequests = import.meta.env.VITE_USE_POWERSYNC_CHECKPOINT_REQUESTS;
+export const useCheckpointRequests = import.meta.env.VITE_USE_POWERSYNC_CHECKPOINT_REQUESTS == 'true';
 
 export const syncOptions: SyncOptions = {
   appMetadata: {

--- a/demos/react-supabase-todolist/src/library/powersync/vite-env.d.ts
+++ b/demos/react-supabase-todolist/src/library/powersync/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   readonly VITE_SUPABASE_URL: string;
   readonly VITE_SUPABASE_ANON_KEY: string;
   readonly VITE_POWERSYNC_URL: string;
+  readonly VITE_USE_POWERSYNC_CHECKPOINT_REQUESTS: 'true' | 'false';
 }
 
 interface ImportMeta {

--- a/packages/common/etc/common.api.md
+++ b/packages/common/etc/common.api.md
@@ -259,6 +259,14 @@ export type CheckpointMode = 'legacy' | 'requests' | {
     requests: CheckpointRequestsOptions;
 };
 
+// @alpha
+export interface CheckpointRequest {
+    readonly hasSyned: boolean;
+    waitForSync(options?: {
+        signal?: AbortSignal;
+    }): Promise<void>;
+}
+
 // @public
 export interface CheckpointRequestsOptions {
     retryDelay: number;
@@ -340,6 +348,8 @@ export interface CommonPowerSyncDatabase extends BaseObserverInterface<PowerSync
     readTransaction<T>(callback: (tx: Transaction) => Promise<T>, lockTimeout?: number): Promise<T>;
     // (undocumented)
     readonly ready: boolean;
+    // @alpha
+    requestCheckpoint(): Promise<CheckpointRequest>;
     resolveTables(sql: string, parameters?: any[], options?: SQLWatchOptions): Promise<string[]>;
     readonly schema: Schema;
     // (undocumented)

--- a/packages/common/etc/common.api.md
+++ b/packages/common/etc/common.api.md
@@ -261,7 +261,7 @@ export type CheckpointMode = 'legacy' | 'requests' | {
 
 // @alpha
 export interface CheckpointRequest {
-    readonly hasSyned: boolean;
+    readonly hasSynced: boolean;
     waitForSync(options?: {
         signal?: AbortSignal;
     }): Promise<void>;

--- a/packages/common/src/client/CommonPowerSyncDatabase.ts
+++ b/packages/common/src/client/CommonPowerSyncDatabase.ts
@@ -235,7 +235,7 @@ export interface CommonPowerSyncDatabase extends BaseObserverInterface<PowerSync
   syncStream(name: string, params?: Record<string, any>): SyncStream;
 
   /**
-   * Requests a checkpoint from thte PowerSync service.
+   * Requests a checkpoint from the PowerSync service.
    *
    * The returned request can be awaited (using {@link CheckpointRequest#waitForSync}) to confirm that the local
    * database has applied server-side changes up to the checkpoint. This method requires an active or connecting sync

--- a/packages/common/src/client/CommonPowerSyncDatabase.ts
+++ b/packages/common/src/client/CommonPowerSyncDatabase.ts
@@ -16,6 +16,7 @@ import { ArrayQueryDefinition, Query } from './Query.js';
 import { WatchCompatibleQuery } from './watched/WatchedQuery.js';
 import { Mutex } from '../utils/mutex.js';
 import { QueryResult } from '../db/QueryResult.js';
+import { CheckpointRequest } from './sync/CheckpointRequest.js';
 
 /**
  * @public
@@ -232,6 +233,19 @@ export interface CommonPowerSyncDatabase extends BaseObserverInterface<PowerSync
    * @returns A {@link SyncStream} instance that can be subscribed to.
    */
   syncStream(name: string, params?: Record<string, any>): SyncStream;
+
+  /**
+   * Requests a checkpoint from thte PowerSync service.
+   *
+   * The returned request can be awaited (using {@link CheckpointRequest#waitForSync}) to confirm that the local
+   * database has applied server-side changes up to the checkpoint. This method requires an active or connecting sync
+   * client connected with a {@link CheckpointMode} set to `requests` and PowerSync service version 1.24.0 or later.
+   *
+   * It can throw for connection, mode, authentication, or service request failures.
+   *
+   * @alpha
+   */
+  requestCheckpoint(): Promise<CheckpointRequest>;
 
   /**
    * Close the database, releasing resources.

--- a/packages/common/src/client/sync/CheckpointRequest.ts
+++ b/packages/common/src/client/sync/CheckpointRequest.ts
@@ -9,8 +9,8 @@
  * and reconnect cycles. A wait interrupted by a disconnect throws an error, but the same request can be awaited again
  * once a new connection is established.
  *
- * Requests do to surive {@link CommonPowerSyncDatabase#disconnectAndClear}, instances created before a clear should be
- * discarded and requested again.
+ * Requests do not survive {@link CommonPowerSyncDatabase#disconnectAndClear}, instances created before a clear should
+ * be discarded and requested again.
  *
  * @alpha
  */

--- a/packages/common/src/client/sync/CheckpointRequest.ts
+++ b/packages/common/src/client/sync/CheckpointRequest.ts
@@ -18,7 +18,7 @@ export interface CheckpointRequest {
   /**
    * Whether this checkpoint request has synced before.
    */
-  readonly hasSyned: boolean;
+  readonly hasSynced: boolean;
 
   /**
    * Waits until this checkpoint has been synced locally.

--- a/packages/common/src/client/sync/CheckpointRequest.ts
+++ b/packages/common/src/client/sync/CheckpointRequest.ts
@@ -1,0 +1,31 @@
+/**
+ * A checkpoint request created by {@link CommonPowerSyncDatabase#requestCheckpoint}.
+ *
+ * Use this value to wait until the local database has applied server-side changes up to the requested checkpoint. This
+ * is useful for explicit refresh flows where the caller wants confirmation that the local view has caught up to the
+ * service.
+ *
+ * Checkpoint requests are backed by request ids tracked in the local database, so they are reusable across disconnect
+ * and reconnect cycles. A wait interrupted by a disconnect throws an error, but the same request can be awaited again
+ * once a new connection is established.
+ *
+ * Requests do to surive {@link CommonPowerSyncDatabase#disconnectAndClear}, instances created before a clear should be
+ * discarded and requested again.
+ *
+ * @alpha
+ */
+export interface CheckpointRequest {
+  /**
+   * Whether this checkpoint request has synced before.
+   */
+  readonly hasSyned: boolean;
+
+  /**
+   * Waits until this checkpoint has been synced locally.
+   *
+   * This method fails on sync errors: If a download or upload error occurs before this checkpoint request has synced,
+   * that error is rethrown here. This makes it easier to observe sync errors when relying on checkpoints. Once sync has
+   * recovered, it is valid to call this method again to await the checkpoint.
+   */
+  waitForSync(options: { signal?: AbortSignal }): Promise<void>;
+}

--- a/packages/common/src/client/sync/CheckpointRequest.ts
+++ b/packages/common/src/client/sync/CheckpointRequest.ts
@@ -27,5 +27,5 @@ export interface CheckpointRequest {
    * that error is rethrown here. This makes it easier to observe sync errors when relying on checkpoints. Once sync has
    * recovered, it is valid to call this method again to await the checkpoint.
    */
-  waitForSync(options: { signal?: AbortSignal }): Promise<void>;
+  waitForSync(options?: { signal?: AbortSignal }): Promise<void>;
 }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -15,6 +15,7 @@ export * from './client/SQLOpenFactory.js';
 export * from './client/sync/bucket/CrudBatch.js';
 export { CrudEntry, OpId, UpdateType } from './client/sync/bucket/CrudEntry.js';
 export * from './client/sync/bucket/CrudTransaction.js';
+export * from './client/sync/CheckpointRequest.js';
 export * from './client/sync/stream/JsonValue.js';
 export * from './client/sync/sync-streams.js';
 export {

--- a/packages/node/tests/sync.test.ts
+++ b/packages/node/tests/sync.test.ts
@@ -214,6 +214,69 @@ describe('Sync', () => {
       await db.waitForStatus((s) => s.downloading);
       completeInitialRequest.resolve();
     });
+
+    describe('requestCheckpoint', () => {
+      mockSyncServiceTest('fails when disconnected', async ({ syncService }) => {
+        const db = await syncService.createDatabase();
+        expect(db.requestCheckpoint()).rejects.toThrow(/sync client is disconnected/);
+      });
+
+      mockSyncServiceTest('fails when connected with legacy mode', async ({ syncService }) => {
+        const db = await syncService.createDatabase();
+        await db.connect(new TestConnector());
+        expect(db.requestCheckpoint()).rejects.toThrow(/with legacy checkpoint mode, cannot request/);
+      });
+
+      mockSyncServiceTest('waits until data is applied', async ({ syncService }) => {
+        const db = await syncService.createDatabase();
+        await db.connect(new TestConnector(), { checkpointMode: 'requests' });
+
+        const checkpoint = await db.requestCheckpoint();
+        syncService.pushLine({ checkpoint: { last_op_id: '0', buckets: [], write_checkpoint: '2' } });
+        expect(checkpoint.hasSyned).toBeFalsy();
+        syncService.pushLine({ checkpoint_complete: { last_op_id: '0' } });
+
+        await checkpoint.waitForSync();
+        expect(checkpoint.hasSyned).toBeTruthy();
+      });
+
+      mockSyncServiceTest('throws on disconnect but can request again', async ({ syncService }) => {
+        const db = await syncService.createDatabase();
+        await db.connect(new TestConnector(), { checkpointMode: 'requests' });
+        const checkpoint = await db.requestCheckpoint();
+
+        const failureExpectation = expect(checkpoint.waitForSync()).rejects.toThrow(/sync client is disconnected/);
+        await db.disconnect();
+        await failureExpectation;
+
+        await db.connect(new TestConnector(), { checkpointMode: 'requests' });
+        syncService.pushLine({ checkpoint: { last_op_id: '0', buckets: [], write_checkpoint: '2' } });
+        syncService.pushLine({ checkpoint_complete: { last_op_id: '0' } });
+        await checkpoint.waitForSync();
+      });
+
+      mockSyncServiceTest('fails when reconnecting with legacy mode', async ({ syncService }) => {
+        const db = await syncService.createDatabase();
+        await db.connect(new TestConnector(), { checkpointMode: 'requests' });
+        const checkpoint = await db.requestCheckpoint();
+
+        await db.disconnect();
+        await db.connect(new TestConnector(), { checkpointMode: 'legacy' });
+        expect(checkpoint.waitForSync()).rejects.toThrow(/Connected with legacy checkpoint mode/);
+      });
+
+      mockSyncServiceTest('fails on sync errors', async ({ syncService }) => {
+        const db = await syncService.createDatabase();
+        await db.connect(new TestConnector(), { checkpointMode: 'requests' });
+        const checkpoint = await db.requestCheckpoint();
+
+        const failureExpectation = expect(checkpoint.waitForSync()).rejects.toThrow(
+          /Sync error while waiting for checkpoint request/
+        );
+        syncService.pushLine({ checkpoint: { buckets: [], last_op_id: 'invalid line' } });
+        await failureExpectation;
+      });
+    });
   });
 
   mockSyncServiceTest('can migrate between sync implementations', async ({ syncService }) => {

--- a/packages/node/tests/sync.test.ts
+++ b/packages/node/tests/sync.test.ts
@@ -233,11 +233,11 @@ describe('Sync', () => {
 
         const checkpoint = await db.requestCheckpoint();
         syncService.pushLine({ checkpoint: { last_op_id: '0', buckets: [], write_checkpoint: '2' } });
-        expect(checkpoint.hasSyned).toBeFalsy();
+        expect(checkpoint.hasSynced).toBeFalsy();
         syncService.pushLine({ checkpoint_complete: { last_op_id: '0' } });
 
         await checkpoint.waitForSync();
-        expect(checkpoint.hasSyned).toBeTruthy();
+        expect(checkpoint.hasSynced).toBeTruthy();
       });
 
       mockSyncServiceTest('throws on disconnect but can request again', async ({ syncService }) => {

--- a/packages/node/tests/sync.test.ts
+++ b/packages/node/tests/sync.test.ts
@@ -276,6 +276,20 @@ describe('Sync', () => {
         syncService.pushLine({ checkpoint: { buckets: [], last_op_id: 'invalid line' } });
         await failureExpectation;
       });
+
+      mockSyncServiceTest('can abort waiting for requests', async ({ syncService }) => {
+        const db = await syncService.createDatabase();
+        await db.connect(new TestConnector(), { checkpointMode: 'requests' });
+        const checkpoint = await db.requestCheckpoint();
+
+        const controller = new AbortController();
+        const failureExpectation = expect(checkpoint.waitForSync({ signal: controller.signal })).rejects.toThrow(
+          /custom abort reason/
+        );
+
+        controller.abort('custom abort reason');
+        await failureExpectation;
+      });
     });
   });
 

--- a/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
+++ b/packages/shared-internals/src/client/BasePowerSyncDatabase.ts
@@ -32,7 +32,8 @@ import {
   WatchOnChangeHandler,
   BaseObserver,
   SqliteRecord,
-  SyncStreamConnectionMethod
+  SyncStreamConnectionMethod,
+  CheckpointRequest
 } from '@powersync/common';
 import { BucketStorageAdapter, PSInternalTable } from './sync/bucket/BucketStorageAdapter.js';
 import { SyncStatusSnapshot } from '../db/crud/SyncStatus.js';
@@ -58,6 +59,11 @@ import { MEMORY_TRIGGER_CLAIM_MANAGER } from './triggers/MemoryTriggerClaimManag
 import { symbolAsyncIterator } from '../utils/compatibility.js';
 import { MAX_OP_ID } from '../constants.js';
 import { SqliteBucketStorage } from './sync/bucket/SqliteBucketStorage.js';
+import {
+  cannotRequestDueToDisconnectedError,
+  checkpointRequestsNotEnabledError
+} from './sync/stream/CheckpointState.js';
+import { CheckpointRequestImpl } from './sync/CheckpointRequestImpl.js';
 
 const POWERSYNC_TABLE_MATCH = /(^ps_data__|^ps_data_local__)/;
 
@@ -96,7 +102,7 @@ export abstract class BasePowerSyncDatabase<Options extends BasePowerSyncDatabas
 
   protected bucketStorageAdapter: BucketStorageAdapter;
   protected _isReadyPromise: Promise<void>;
-  protected connectionManager: ConnectionManager;
+  connectionManager: ConnectionManager;
   private subscriptions: InternalSubscriptionAdapter;
 
   get syncStreamImplementation() {
@@ -306,10 +312,18 @@ export abstract class BasePowerSyncDatabase<Options extends BasePowerSyncDatabas
       return;
     }
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       const dispose = this.registerListener({
         statusChanged: (status) => {
-          if (predicate(status)) {
+          let isComplete = false;
+          try {
+            isComplete = predicate(status);
+          } catch (e) {
+            reject(e);
+            isComplete = true;
+          }
+
+          if (isComplete) {
             abort();
           }
         }
@@ -318,6 +332,7 @@ export abstract class BasePowerSyncDatabase<Options extends BasePowerSyncDatabas
       function abort() {
         dispose();
         resolve();
+        signal?.removeEventListener('abort', abort);
       }
 
       if (signal?.aborted) {
@@ -449,6 +464,21 @@ export abstract class BasePowerSyncDatabase<Options extends BasePowerSyncDatabas
 
   syncStream(name: string, params?: Record<string, any>): SyncStream {
     return this.connectionManager.stream(this.subscriptions, name, params ?? null);
+  }
+
+  async requestCheckpoint(): Promise<CheckpointRequest> {
+    await this.waitForReady();
+
+    const impl = this.connectionManager.syncStreamImplementation;
+    if (impl == null) {
+      throw cannotRequestDueToDisconnectedError();
+    }
+    if (this.connectionManager.connectionOptions?.checkpointMode == 'legacy') {
+      throw checkpointRequestsNotEnabledError();
+    }
+
+    const checkpoint = await impl.requestCheckpoint();
+    return new CheckpointRequestImpl(checkpoint, this);
   }
 
   async close(options: PowerSyncCloseOptions = DEFAULT_POWERSYNC_CLOSE_OPTIONS) {

--- a/packages/shared-internals/src/client/ConnectionManager.ts
+++ b/packages/shared-internals/src/client/ConnectionManager.ts
@@ -100,7 +100,7 @@ export class ConnectionManager extends BaseObserver<ConnectionManagerListener> {
    */
   protected pendingConnectionOptions: StoredConnectionOptions | null;
 
-  protected currentOptions: ResolvedSyncOptions | null;
+  private currentOptions: ResolvedSyncOptions | null;
 
   syncStreamImplementation: StreamingSyncImplementation | null;
 

--- a/packages/shared-internals/src/client/ConnectionManager.ts
+++ b/packages/shared-internals/src/client/ConnectionManager.ts
@@ -100,7 +100,7 @@ export class ConnectionManager extends BaseObserver<ConnectionManagerListener> {
    */
   protected pendingConnectionOptions: StoredConnectionOptions | null;
 
-  private currentOptions: ResolvedSyncOptions | null;
+  protected currentOptions: ResolvedSyncOptions | null;
 
   syncStreamImplementation: StreamingSyncImplementation | null;
 

--- a/packages/shared-internals/src/client/sync/CheckpointRequestImpl.ts
+++ b/packages/shared-internals/src/client/sync/CheckpointRequestImpl.ts
@@ -18,9 +18,10 @@ export class CheckpointRequestImpl implements CheckpointRequest {
     return isCheckpointRequestApplied(status, this.requestId);
   }
 
-  async waitForSync({ signal }: { signal?: AbortSignal }): Promise<void> {
+  async waitForSync(options?: { signal?: AbortSignal }): Promise<void> {
     if (this.hasSyned) return;
 
+    const signal = options?.signal;
     const manager = this.database.connectionManager;
     if (manager.syncStreamImplementation == null) {
       throw cannotRequestDueToDisconnectedError();

--- a/packages/shared-internals/src/client/sync/CheckpointRequestImpl.ts
+++ b/packages/shared-internals/src/client/sync/CheckpointRequestImpl.ts
@@ -18,7 +18,7 @@ export class CheckpointRequestImpl implements CheckpointRequest {
     return isCheckpointRequestApplied(status, this.requestId);
   }
 
-  async waitForSync(options: { signal?: AbortSignal }): Promise<void> {
+  async waitForSync(options?: { signal?: AbortSignal }): Promise<void> {
     if (this.hasSyned) return;
 
     const manager = this.database.connectionManager;
@@ -31,7 +31,7 @@ export class CheckpointRequestImpl implements CheckpointRequest {
 
     await this.database.waitForStatus((status) => {
       if (isCheckpointRequestApplied((status as SyncStatusSnapshot).core, this.requestId)) {
-        return;
+        return true;
       }
 
       const anyError = status.downloadError ?? status.uploadError;
@@ -42,6 +42,8 @@ export class CheckpointRequestImpl implements CheckpointRequest {
       if (!status.connected && !status.connecting) {
         throw cannotRequestDueToDisconnectedError();
       }
-    }, options.signal);
+
+      return false;
+    }, options?.signal);
   }
 }

--- a/packages/shared-internals/src/client/sync/CheckpointRequestImpl.ts
+++ b/packages/shared-internals/src/client/sync/CheckpointRequestImpl.ts
@@ -13,13 +13,13 @@ export class CheckpointRequestImpl implements CheckpointRequest {
     private readonly database: BasePowerSyncDatabase
   ) {}
 
-  get hasSyned(): boolean {
+  get hasSynced(): boolean {
     const status = this.database.currentStatus.core;
     return isCheckpointRequestApplied(status, this.requestId);
   }
 
   async waitForSync(options?: { signal?: AbortSignal }): Promise<void> {
-    if (this.hasSyned) return;
+    if (this.hasSynced) return;
 
     const signal = options?.signal;
     const manager = this.database.connectionManager;

--- a/packages/shared-internals/src/client/sync/CheckpointRequestImpl.ts
+++ b/packages/shared-internals/src/client/sync/CheckpointRequestImpl.ts
@@ -1,0 +1,47 @@
+import { CheckpointRequest } from '@powersync/common';
+import { BasePowerSyncDatabase } from '../BasePowerSyncDatabase.js';
+import {
+  cannotRequestDueToDisconnectedError,
+  checkpointRequestsNotEnabledError,
+  isCheckpointRequestApplied
+} from './stream/CheckpointState.js';
+import { SyncStatusSnapshot } from '../../db/crud/SyncStatus.js';
+
+export class CheckpointRequestImpl implements CheckpointRequest {
+  constructor(
+    private readonly requestId: bigint,
+    private readonly database: BasePowerSyncDatabase
+  ) {}
+
+  get hasSyned(): boolean {
+    const status = this.database.currentStatus.core;
+    return isCheckpointRequestApplied(status, this.requestId);
+  }
+
+  async waitForSync(options: { signal?: AbortSignal }): Promise<void> {
+    if (this.hasSyned) return;
+
+    const manager = this.database.connectionManager;
+    if (manager.syncStreamImplementation == null) {
+      throw cannotRequestDueToDisconnectedError();
+    }
+    if (manager.connectionOptions?.checkpointMode == 'legacy') {
+      throw checkpointRequestsNotEnabledError();
+    }
+
+    await this.database.waitForStatus((status) => {
+      if (isCheckpointRequestApplied((status as SyncStatusSnapshot).core, this.requestId)) {
+        return;
+      }
+
+      const anyError = status.downloadError ?? status.uploadError;
+      if (anyError) {
+        throw new Error('Sync error while waiting for checkpoint request', { cause: anyError });
+      }
+
+      if (!status.connected && !status.connecting) {
+        throw cannotRequestDueToDisconnectedError();
+      }
+    }, options.signal);
+  }
+}

--- a/packages/shared-internals/src/client/sync/CheckpointRequestImpl.ts
+++ b/packages/shared-internals/src/client/sync/CheckpointRequestImpl.ts
@@ -18,7 +18,7 @@ export class CheckpointRequestImpl implements CheckpointRequest {
     return isCheckpointRequestApplied(status, this.requestId);
   }
 
-  async waitForSync(options?: { signal?: AbortSignal }): Promise<void> {
+  async waitForSync({ signal }: { signal?: AbortSignal }): Promise<void> {
     if (this.hasSyned) return;
 
     const manager = this.database.connectionManager;
@@ -44,6 +44,10 @@ export class CheckpointRequestImpl implements CheckpointRequest {
       }
 
       return false;
-    }, options?.signal);
+    }, signal);
+
+    if (signal?.aborted) {
+      throw signal.reason;
+    }
   }
 }

--- a/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -105,6 +105,8 @@ export interface StreamingSyncImplementation
   waitUntilStatusMatches(predicate: (status: SyncStatus) => boolean): Promise<void>;
   updateSubscriptions(subscriptions: SubscribedStream[]): void;
   markConnectionMayHaveChanged(): void;
+
+  requestCheckpoint(): Promise<bigint>;
 }
 
 /**
@@ -357,6 +359,11 @@ The next upload iteration will be delayed.`
         }
       });
     });
+  }
+
+  async requestCheckpoint(): Promise<bigint> {
+    const neverAbort = new AbortController().signal;
+    return BigInt(await this.requestNextCheckpointFromService(neverAbort));
   }
 
   async disconnect(): Promise<void> {
@@ -631,7 +638,7 @@ The next upload iteration will be delayed.`
         }
 
         // If the request was applied, we don't need to retry.
-        if (isCheckpointRequestApplied(this.syncStatus?.core, requestId)) {
+        if (isCheckpointRequestApplied(this.syncStatus?.core, BigInt(requestId))) {
           continue;
         }
 

--- a/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
+++ b/packages/shared-internals/src/client/sync/stream/AbstractStreamingSyncImplementation.ts
@@ -213,7 +213,6 @@ export abstract class AbstractStreamingSyncImplementation
     const status = await this.options.remote.fetchAndDecodeJson({
       method: 'POST',
       path: '/sync/checkpoint-request',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(request),
       signal
     });

--- a/packages/shared-internals/src/client/sync/stream/CheckpointState.ts
+++ b/packages/shared-internals/src/client/sync/stream/CheckpointState.ts
@@ -126,7 +126,11 @@ export function cannotRequestDueToDisconnectedError(): Error {
   return new Error('Cannot request checkpoints, sync client is disconnected.');
 }
 
-export function isCheckpointRequestApplied(status: CoreSyncStatus | null, requestId: string): boolean {
+export function checkpointRequestsNotEnabledError(): Error {
+  return new Error('Connected with legacy checkpoint mode, cannot request checkpoints.');
+}
+
+export function isCheckpointRequestApplied(status: CoreSyncStatus | null, requestId: bigint): boolean {
   const applied = status?.internal_last_applied_checkpoint_request_id;
-  return applied != null && BigInt(applied) >= BigInt(requestId);
+  return applied != null && BigInt(applied) >= requestId;
 }

--- a/packages/web/src/db/sync/SSRWebStreamingSyncImplementation.ts
+++ b/packages/web/src/db/sync/SSRWebStreamingSyncImplementation.ts
@@ -58,4 +58,8 @@ export class SSRStreamingSyncImplementation extends BaseObserver implements Stre
    * No-op in SSR mode.
    */
   markConnectionMayHaveChanged(): void {}
+
+  requestCheckpoint(): Promise<bigint> {
+    throw new Error('Sub sync implementation does not support request checkpoints');
+  }
 }

--- a/packages/web/src/db/sync/SharedWebStreamingSyncImplementation.ts
+++ b/packages/web/src/db/sync/SharedWebStreamingSyncImplementation.ts
@@ -227,6 +227,10 @@ export class SharedWebStreamingSyncImplementation extends WebStreamingSyncImplem
     return this.isInitialized;
   }
 
+  requestCheckpoint(): Promise<bigint> {
+    return this.syncManager.requestCheckpoint();
+  }
+
   updateSubscriptions(subscriptions: SubscribedStream[]): void {
     this.syncManager.updateSubscriptions(subscriptions);
   }

--- a/packages/web/src/worker/sync/SharedSyncImplementation.ts
+++ b/packages/web/src/worker/sync/SharedSyncImplementation.ts
@@ -340,6 +340,10 @@ export class SharedSyncImplementation extends BaseObserver<SharedSyncImplementat
     });
   }
 
+  requestCheckpoint() {
+    return this.withSyncImplementation((sync) => sync.requestCheckpoint());
+  }
+
   protected async withSyncImplementation<T>(callback: (sync: StreamingSyncImplementation) => Promise<T>): Promise<T> {
     await this.waitForReady();
 

--- a/packages/web/src/worker/sync/WorkerClient.ts
+++ b/packages/web/src/worker/sync/WorkerClient.ts
@@ -88,6 +88,10 @@ export class WorkerClient {
     }
   }
 
+  requestCheckpoint(): Promise<bigint> {
+    return this.sync.requestCheckpoint();
+  }
+
   disconnect() {
     return this.sync.disconnect();
   }


### PR DESCRIPTION
As a follow-up to #1072 which implements [request checkpoint protocol changes](https://github.com/orgs/powersync-ja/discussions/317), this adds the [explicit sync API](https://github.com/orgs/powersync-ja/discussions/324).

Added methods closely match the ones in the Swift SDK: `PowerSyncDatabase.requestCheckpoint()` requests a checkpoint (throwing if we're not connected). On checkpoints, `hasSynced` reports whether a checkpoint has synced and `waitForSync` can be used to wait for it. There's no `waitForSync(timeout:)` equivalent, passing an `AbortSignal.timeout()` instead is too obvious.

A notable difference is that the Swift SDK adds typed errors for different checkpoint failure modes, where this currently uses a plain `Error` class. This isn't great, but matches what we do in most other parts of the SDK too. We can revisit better/typed error reports in a future update.

This is adopted in two demos, using an opt-in environment flag in both cases:

1. In the React Supabase todolist demo, there's a refresh button next to the connectivity indicator when connecting. It spins while we're waiting for a checkpoint, a snackbar displays results.
2. In the React Native Supabase todolist demo, a swipe-to-refresh pattern is used to request checkpoints.

AI use: Changes in demos are mostly generated with Claude Code, I also used it to review these changes and made minor improvements in response.