### PR TITLE
fix(react): forward throttleMs from useQuery to the watched query

### DIFF
--- a/.changeset/olive-moons-tickle.md
+++ b/.changeset/olive-moons-tickle.md
@@ -1,0 +1,5 @@
+---
+'@powersync/react': patch
+---
+
+Forward `throttleMs` from `useQuery` to the underlying watched query. It was accepted by the options type but never passed on, so the default 30ms throttle always applied.

--- a/packages/react/src/hooks/watched/useQuery.ts
+++ b/packages/react/src/hooks/watched/useQuery.ts
@@ -80,6 +80,7 @@ export function useQuery<RowType = any>(
     queryChanged,
     options: {
       reportFetching: options.reportFetching,
+      throttleMs: options.throttleMs,
       // Maintains backwards compatibility with previous versions
       // Differentiation is opt-in by default
       // We emit new data for each table change by default.

--- a/packages/react/tests/useQuery.test.tsx
+++ b/packages/react/tests/useQuery.test.tsx
@@ -933,6 +933,80 @@ describe('useQuery', () => {
         expect(finalState.isFetching).toEqual(false);
         expect(finalState.isLoading).toEqual(false);
       });
+
+      it('should forward throttleMs to the watched query', async () => {
+        const db = openPowerSync();
+        const throttleMs = 1234;
+
+        // Spy on the watched query construction to assert the option reaches it.
+        // Asserting on the received option avoids depending on wall clock throttle windows.
+        const baseCustomQuery = db.customQuery;
+        let watchOptions: commonSdk.WatchedQueryOptions | undefined;
+
+        vi.spyOn(db, 'customQuery').mockImplementation((query) => {
+          const builder = baseCustomQuery.call(db, query);
+          const baseWatch = builder.watch;
+
+          // The hooks use the `watch` method if no rowComparator is set
+          vi.spyOn(builder, 'watch').mockImplementation((buildOptions) => {
+            watchOptions = buildOptions;
+            return baseWatch.call(builder, buildOptions);
+          });
+
+          return builder;
+        });
+
+        renderHook(() => useQuery('SELECT * from lists', [], { throttleMs }), {
+          wrapper: ({ children }) => testWrapper({ children, db })
+        });
+
+        await waitFor(
+          async () => {
+            expect(watchOptions?.throttleMs).toEqual(throttleMs);
+          },
+          { timeout: 500, interval: 100 }
+        );
+      });
+
+      it('should forward throttleMs to the differential watched query', async () => {
+        const db = openPowerSync();
+        const throttleMs = 1234;
+
+        const baseCustomQuery = db.customQuery;
+        let watchOptions: commonSdk.WatchedQueryOptions | undefined;
+
+        vi.spyOn(db, 'customQuery').mockImplementation((query) => {
+          const builder = baseCustomQuery.call(db, query);
+          const baseDifferentialWatch = builder.differentialWatch;
+
+          // The hooks use the `differentialWatch` method if a rowComparator is set
+          vi.spyOn(builder, 'differentialWatch').mockImplementation((buildOptions) => {
+            watchOptions = buildOptions;
+            return baseDifferentialWatch.call(builder, buildOptions);
+          });
+
+          return builder;
+        });
+
+        renderHook(
+          () =>
+            useQuery('SELECT * from lists', [], {
+              throttleMs,
+              rowComparator: {
+                keyBy: (item) => item.id,
+                compareBy: (item) => JSON.stringify(item)
+              }
+            }),
+          { wrapper: ({ children }) => testWrapper({ children, db }) }
+        );
+
+        await waitFor(
+          async () => {
+            expect(watchOptions?.throttleMs).toEqual(throttleMs);
+          },
+          { timeout: 500, interval: 100 }
+        );
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #1082.

`useQuery` accepts `throttleMs` in its options type, but the object it builds for `useWatchedQuery` only carries `reportFetching` and `rowComparator`, so the value never arrives and you always get the 30ms default.

`useWatchedQuery` already reads `hookOptions.throttleMs` in three places, so it's just the one missing property.

The other thing I mentioned in the issue is left alone here: `tables` and `triggerImmediate` also type-check on the hook and are also dropped, and `triggerOnTables` isn't reachable through it at all. That's the options type inheriting from the callback API rather than the watched-query one, and untangling it is a breaking change, so it seemed like your call rather than something to fold in.
