### PR TITLE
fix(attachments-storage-react-native): await File.move before reading size in moveFile

### DIFF
--- a/.changeset/fix-move-file-race.md
+++ b/.changeset/fix-move-file-race.md
@@ -1,0 +1,5 @@
+---
+'@powersync/attachments-storage-react-native': patch
+---
+
+Fix `ExpoFileSystemStorageAdapter.moveFile` returning a stale size.

--- a/packages/attachments-storage-react-native/src/ExpoFileSystemStorageAdapter.ts
+++ b/packages/attachments-storage-react-native/src/ExpoFileSystemStorageAdapter.ts
@@ -101,7 +101,7 @@ To use the Expo File System attachment adapter please install expo-file-system (
       if (target.exists) {
         target.delete();
       }
-      new this.File(sourceUri).move(target);
+      await new this.File(sourceUri).move(target);
     }
     return new this.File(targetUri).size ?? 0;
   }


### PR DESCRIPTION
`ExpoFileSystemStorageAdapter.moveFile` fires off `File.prototype.move()` without awaiting it, then reads `.size` on the very next line. `move` is an async native call dispatched off the JS thread, while `.size` is a synchronous property read, so the read happens before the relocation has completed. `size` resolves to `null` for a file it can't read yet, and `moveFile`'s own `?? 0` turns that into a `0` returned for a file that goes on to move correctly.

It's reachable through the public API: `AttachmentQueue.saveFileFromUri` calls straight into this for any `StreamingLocalStorageAdapter`. The two sibling adapters (`ReactNativeFileSystemStorageAdapter`, `NodeFileSystemAdapter`) already await their move/rename before stat'ing, so this brings the Expo adapter in line with them.

The fix is one line: add the missing `await`. A changeset is included.
