### PR TITLE
Remove optimizeDeps.exclude from vite.config.ts

### DIFF
--- a/demos/example-vite/vite.config.ts
+++ b/demos/example-vite/vite.config.ts
@@ -12,11 +12,6 @@ export default defineConfig({
     emptyOutDir: true
   },
   envDir: '..', // Use this dir for env vars, not 'src'.
-  optimizeDeps: {
-    // Don't optimize these packages as they contain web workers and WASM files.
-    // https://github.com/vitejs/vite/issues/11672#issuecomment-1415820673
-    exclude: ['@powersync/web']
-  },
   worker: {
     format: 'es'
   },


### PR DESCRIPTION
I'm on Vite v8.8.2, and apparently the issues with web workers were fixed, because it just works for me without the `optimizeDeps: {exclude: ['@powersync/web']}`. Perhaps the requirement can now be removed from the example? (And the docs, but I didn't find any.)