### PR TITLE
Update core extension to 0.5.3

### DIFF
--- a/.changeset/flat-buttons-suffer.md
+++ b/.changeset/flat-buttons-suffer.md
@@ -1,0 +1,9 @@
+---
+'@powersync/adapter-sql-js': patch
+'@powersync/react-native': patch
+'@powersync/capacitor': patch
+'@powersync/node': patch
+'@powersync/web': patch
+---
+
+Update PowerSync SQLite core extension to version 0.5.3.

--- a/packages/adapter-sql-js/package.json
+++ b/packages/adapter-sql-js/package.json
@@ -36,7 +36,7 @@
     "@powersync/shared-internals": "workspace:*"
   },
   "devDependencies": {
-    "@powersync/sql-js": "0.0.11",
+    "@powersync/sql-js": "0.0.12",
     "@powersync/web": "workspace:*",
     "@rollup/plugin-alias": "catalog:",
     "@rollup/plugin-commonjs": "catalog:",

--- a/packages/capacitor/Package.swift
+++ b/packages/capacitor/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
         .package(url: "https://github.com/sqlcipher/SQLCipher.swift.git", from: "4.0.0"),
-        .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", from: "0.4.12")
+        .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", from: "0.5.3")
     ],
     targets: [
         .target(

--- a/packages/capacitor/PowersyncCapacitor.podspec
+++ b/packages/capacitor/PowersyncCapacitor.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '15.0'
   s.dependency 'Capacitor'
   s.swift_version = '5.1'
-  s.dependency "powersync-sqlite-core", "~> 0.5.2"
+  s.dependency "powersync-sqlite-core", "~> 0.5.3"
    s.xcconfig = {
     'OTHER_CFLAGS' => '$(inherited) -DSQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION=1',
     'HEADER_SEARCH_PATHS' => '$(inherited) "$(PODS_ROOT)/SQLCipher"'

--- a/packages/capacitor/android/build.gradle
+++ b/packages/capacitor/android/build.gradle
@@ -3,7 +3,7 @@ ext {
     androidxAppCompatVersion = project.hasProperty('androidxAppCompatVersion') ? rootProject.ext.androidxAppCompatVersion : '1.7.1'
     androidxJunitVersion = project.hasProperty('androidxJunitVersion') ? rootProject.ext.androidxJunitVersion : '1.3.0'
     androidxEspressoCoreVersion = project.hasProperty('androidxEspressoCoreVersion') ? rootProject.ext.androidxEspressoCoreVersion : '3.7.0'
-    powerSyncCoreVersion = project.hasProperty('powerSyncCoreVersion') ? rootProject.ext.powerSyncCoreVersion : '0.5.2'
+    powerSyncCoreVersion = project.hasProperty('powerSyncCoreVersion') ? rootProject.ext.powerSyncCoreVersion : '0.5.3'
 }
 
 buildscript {

--- a/packages/node/download_core.js
+++ b/packages/node/download_core.js
@@ -5,18 +5,18 @@ import { Readable } from 'node:stream';
 import { finished } from 'node:stream/promises';
 
 // When changing this version, run node download_core.js update_hashes
-const version = '0.5.2';
+const version = '0.5.3';
 const versionHashes = {
-  'powersync_x64.dll': '95b1aa81b5307793fcf5ef4d0982f38076e14cdd7b97ea1a84faa545af0b74db',
-  'powersync_x86.dll': '215d4aa2a08972dea7cbc91c316c111c2968ec47bd40865a78237b649d8d2e9a',
-  'powersync_aarch64.dll': '42a66fff06b2c927c60c78941ff8c069ad878761a46802a13dc33b9d503f6589',
-  'libpowersync_x86.linux.so': '3be78268b546796c5e8983d37b3c4b28e2c6d2a5c4ec21757164c0d6b7bc11f8',
-  'libpowersync_x64.linux.so': 'e3288d3e1e2bfc5ccee4fb66d5afb9c691e7da7010b3a561892857a922659819',
-  'libpowersync_aarch64.linux.so': '50817891679aa5598009119aa6cf00561e28c04078c6045c109281cf32bcf747',
-  'libpowersync_armv7.linux.so': 'c0028d3536fdd8684c6be20988d7edf91eb290da0b53a6f3b6752c3f0462daa7',
-  'libpowersync_riscv64gc.linux.so': 'c636d46f0e591953e37e306efd8c055b44216fb019733cbdae718d70387b6042',
-  'libpowersync_x64.macos.dylib': '53359ad66f31160795cf2728b1125567593bb00bd62197372fca8e461040abce',
-  'libpowersync_aarch64.macos.dylib': 'a3a37b9f346a7d12717149209f01c5f580a2ee3471b37bcdfa59a324834fd698'
+  'powersync_x64.dll': 'b3f62293f26d3ee309880d30e1e54819ac21b4d0b1ba9b9177f92e1dcbfdb0c7',
+  'powersync_x86.dll': 'd2403446c5b2d0550eb99cb195db01798ef78a740ba4f462cd0b887e0ce4bd8a',
+  'powersync_aarch64.dll': '19afce715bf63b4f590fb2c00d18c3681b818cd6eee5a35284bd3a804f090b20',
+  'libpowersync_x86.linux.so': 'dc9be35f8a5b5511be8f6b28f8c9d1e00e6ecdb72074ea8e67b826474810276f',
+  'libpowersync_x64.linux.so': 'a6de0c79151ad6243ca18633f0df10bed32b692095fdf0f01ebdac6eb01d2edf',
+  'libpowersync_aarch64.linux.so': 'f27b1cadce2210541903ba2f4e9652782c9e14c913cde4f67c463cec00d46d14',
+  'libpowersync_armv7.linux.so': '3f6ddf0838fbd34e0986e21de0db89b5a0462cdc1eaee95e42c9dcdc1f0c4cc5',
+  'libpowersync_riscv64gc.linux.so': '5eaa1458153ab562ca0047aa2af4aa3303ee7291eabd92baeb2e9ab2f07935ba',
+  'libpowersync_x64.macos.dylib': '1209f802bcd886a112bd0de9ca5d7497a62af045fc64b78e703bdd465ee40979',
+  'libpowersync_aarch64.macos.dylib': '4fa96a98d7edb64a188493beb277bddcb7e85b286e2533d685ecf49ff51c6807'
 };
 
 const assets = Object.keys(versionHashes);

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -81,7 +81,7 @@ repositories {
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
-  implementation 'com.powersync:powersync-sqlite-core:0.5.2'
+  implementation 'com.powersync:powersync-sqlite-core:0.5.3'
   // For < 0.71, this will be from the local maven repo
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion

--- a/packages/react-native/ios/Package.swift
+++ b/packages/react-native/ios/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 // When updating this, also update the version in powersync-react-native.podspec and android/build.gradle
-let coreExtensionVersion: Version = "0.5.2"
+let coreExtensionVersion: Version = "0.5.3"
 
 let packageName = "PowerSyncReactNative"
 

--- a/packages/react-native/powersync-react-native.podspec
+++ b/packages/react-native/powersync-react-native.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.dependency "React-callinvoker"
   s.dependency "React"
   # When updating this, also update the version in Package.swift and android/build.gradle
-  s.dependency "powersync-sqlite-core", "~> 0.5.2"
+  s.dependency "powersync-sqlite-core", "~> 0.5.3"
   if defined?(install_modules_dependencies())
     install_modules_dependencies(s)
   else

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@journeyapps/wa-sqlite':
-      specifier: 2.0.3
-      version: 2.0.3
+      specifier: 2.0.4
+      version: 2.0.4
     '@microsoft/api-extractor':
       specifier: ^7.59.0
       version: 7.59.0
@@ -251,8 +251,8 @@ importers:
         version: link:../shared-internals
     devDependencies:
       '@powersync/sql-js':
-        specifier: 0.0.11
-        version: 0.0.11
+        specifier: 0.0.12
+        version: 0.0.12
       '@powersync/web':
         specifier: workspace:*
         version: link:../web
@@ -411,7 +411,7 @@ importers:
     devDependencies:
       '@journeyapps/wa-sqlite':
         specifier: 'catalog:'
-        version: 2.0.3
+        version: 2.0.4
       '@powersync/web':
         specifier: workspace:*
         version: link:../web
@@ -436,7 +436,7 @@ importers:
     devDependencies:
       '@journeyapps/wa-sqlite':
         specifier: 'catalog:'
-        version: 2.0.3
+        version: 2.0.4
       '@powersync/web':
         specifier: workspace:*
         version: link:../web
@@ -543,7 +543,7 @@ importers:
     devDependencies:
       '@journeyapps/wa-sqlite':
         specifier: 'catalog:'
-        version: 2.0.3
+        version: 2.0.4
       '@nuxt/module-builder':
         specifier: ^1.0.2
         version: 1.0.2(@nuxt/cli@3.34.0(@nuxt/schema@4.3.1)(cac@6.7.14)(commander@12.1.0)(magicast@0.5.2)(supports-color@10.2.2))(@vue/compiler-core@3.5.35)(esbuild@0.27.3)(typescript@6.0.3)(vue-tsc@3.2.5(typescript@6.0.3))(vue@3.5.30(typescript@6.0.3))
@@ -789,7 +789,7 @@ importers:
     dependencies:
       '@journeyapps/wa-sqlite':
         specifier: 'catalog:'
-        version: 2.0.3
+        version: 2.0.4
       '@powersync/common':
         specifier: workspace:*
         version: link:../common
@@ -844,7 +844,7 @@ importers:
     dependencies:
       '@journeyapps/wa-sqlite':
         specifier: 'catalog:'
-        version: 2.0.3
+        version: 2.0.4
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3991,8 +3991,8 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  '@journeyapps/wa-sqlite@2.0.3':
-    resolution: {integrity: sha512-LEnzLL/+6z9AAOJQ1nZD5/lo5xE6ZWpkH/M6S3RAGiM047jDqKvGjx8SkGkG1bRcFbbGApf3RWlHGfrmButXcg==}
+  '@journeyapps/wa-sqlite@2.0.4':
+    resolution: {integrity: sha512-c5WE1UPOgDVy8+v63NRRhWsQqvWgkhS1TZKBxEYW/MS7bJE4ndbOfofz9covF7N2KElQVVRZ0qd+XjiS4zt63g==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -5521,8 +5521,8 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
-  '@powersync/sql-js@0.0.11':
-    resolution: {integrity: sha512-m3wlVMgYlmyaBD9Aii5x91OBFtxi2/YKS56fEP8MTEKW41leClO1pbGC6Dj88pGU9cj05EB3pbBeXgrTAFfqLg==}
+  '@powersync/sql-js@0.0.12':
+    resolution: {integrity: sha512-OO4gKWtIXxtcAuRhq5+RDWjHkA2zgeaSL26skku35DkCwrU+oFr2IItN1Tcb+/Rj2fJASYl7K++KJGrKuVrEPg==}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -22569,7 +22569,7 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
-  '@journeyapps/wa-sqlite@2.0.3': {}
+  '@journeyapps/wa-sqlite@2.0.4': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -24936,7 +24936,7 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@powersync/sql-js@0.0.11': {}
+  '@powersync/sql-js@0.0.12': {}
 
   '@quansync/fs@1.0.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ overrides:
 catalog:
   # We must depend on an exact version of wa-sqlite, as we want to update the core extension
   # (which can be breaking for SDKs) without a major revision.
-  '@journeyapps/wa-sqlite': 2.0.3
+  '@journeyapps/wa-sqlite': 2.0.4
   '@microsoft/api-extractor': ^7.59.0
   '@nuxt/devtools-kit': ^3.2.3
   '@nuxt/devtools-ui-kit': ^3.2.3


### PR DESCRIPTION
This updates the core extension to version 0.5.3 ([release notes](https://github.com/powersync-ja/powersync-sqlite-core/releases/tag/v0.5.3)).