### PR TITLE
fix(shared-internals): clear disconnectingPromise after a failed disconnect

### DIFF
--- a/.changeset/fix-disconnect-promise-poison.md
+++ b/.changeset/fix-disconnect-promise-poison.md
@@ -1,0 +1,5 @@
+---
+'@powersync/shared-internals': patch
+---
+
+Fix a rejected `disconnect()` permanently poisoning later `disconnect()` and `connect()` calls on the same instance.

--- a/packages/shared-internals/src/client/ConnectionManager.ts
+++ b/packages/shared-internals/src/client/ConnectionManager.ts
@@ -290,8 +290,11 @@ export class ConnectionManager extends BaseObserver<ConnectionManagerListener> {
 
     this.disconnectingPromise = this.performDisconnect();
 
-    await this.disconnectingPromise;
-    this.disconnectingPromise = null;
+    try {
+      await this.disconnectingPromise;
+    } finally {
+      this.disconnectingPromise = null;
+    }
   }
 
   protected async performDisconnect() {

--- a/packages/shared-internals/tests/client/ConnectionManager.test.ts
+++ b/packages/shared-internals/tests/client/ConnectionManager.test.ts
@@ -23,6 +23,8 @@ class MockStreamingSyncImplementation
 {
   isConnected = false;
   isReady = false;
+  disconnectCalls = 0;
+  disconnectError: Error | null = null;
   readonly receivedUpdates: SubscribedStream[][] = [];
 
   constructor(
@@ -43,7 +45,11 @@ class MockStreamingSyncImplementation
   }
 
   async disconnect() {
+    this.disconnectCalls++;
     this.isConnected = false;
+    if (this.disconnectError) {
+      throw this.disconnectError;
+    }
   }
 
   async getWriteCheckpoint() {
@@ -197,6 +203,41 @@ describe('ConnectionManager', () => {
       expect(names(harness.sync.effectiveSubscriptions)).toEqual([]);
 
       await harness.manager.disconnect();
+    });
+  });
+
+  describe('failed disconnect', () => {
+    test('does not reuse a rejected disconnect for later disconnect and connect', async () => {
+      const harness = managerWithCreateHook();
+      await harness.manager.connect(connector, {}, {});
+      const error = new Error('transient teardown failure');
+      harness.sync.disconnectError = error;
+
+      await expect(harness.manager.disconnect()).rejects.toBe(error);
+      // performDisconnect already nulled the sync implementation, so a retry has nothing to tear down.
+      await expect(harness.manager.disconnect()).resolves.toBeUndefined();
+      expect(harness.syncs[0].disconnectCalls).toBe(1);
+
+      await harness.manager.connect(connector, {}, {});
+      expect(harness.syncs).toHaveLength(2);
+
+      await harness.manager.disconnect();
+    });
+
+    test('concurrent disconnects share the in-flight rejection, then a later call retries', async () => {
+      const harness = managerWithCreateHook();
+      await harness.manager.connect(connector, {}, {});
+      const error = new Error('transient teardown failure');
+      harness.sync.disconnectError = error;
+
+      const first = harness.manager.disconnect();
+      const second = harness.manager.disconnect();
+
+      await expect(first).rejects.toBe(error);
+      await expect(second).rejects.toBe(error);
+
+      await expect(harness.manager.disconnect()).resolves.toBeUndefined();
+      expect(harness.syncs[0].disconnectCalls).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

`disconnectInternal()` clears `disconnectingPromise` in a `finally` so a rejected `disconnect()` no longer leaves `ConnectionManager` unable to disconnect or connect again. The next call starts a new teardown instead of returning the same cached rejection (#1097). Concurrent in-flight `disconnect()` calls still share one promise and the same rejection; only a later call retries.

`disconnectInternal()` is also on the `connect()` path, and `disconnectAndClear()` disconnects first, so one teardown failure previously blocked reconnect and clear for the life of the instance.

`try`/`finally` wraps the existing `await` of `disconnectingPromise`, matching `ControlledExecutor.execute()` in this package (clear the in-flight field in `finally` whether the task fulfills or rejects). The `try`/`finally` form is the patch specified and verified in #1097. An alternative is `this.disconnectingPromise = this.performDisconnect().finally(() => { this.disconnectingPromise = null })`.

`performDisconnect()` is unchanged: it still does not `dispose()` after `disconnect()` throws. Members are already nulled before those awaits, so a retry is a no-op rather than a double-dispose.

## Test plan

- [x] `pnpm exec vitest run tests/client/ConnectionManager.test.ts` in `packages/shared-internals`. New tests fail without the `finally`, pass with it
- [x] `pnpm exec vitest run` in `packages/shared-internals` (59 tests)
- [x] Changeset included for `@powersync/shared-internals` (patch)

Closes #1097
